### PR TITLE
feat: improve architecture pane signal in review workspace

### DIFF
--- a/src/app/(workspace)/reviews/[reviewId]/page.module.css
+++ b/src/app/(workspace)/reviews/[reviewId]/page.module.css
@@ -154,7 +154,7 @@
   padding: 12px 14px;
 }
 
-.archColumn h3 {
+.archColumnHeading {
   margin-bottom: 10px;
   font-size: 14px;
   letter-spacing: 0.04em;
@@ -167,7 +167,7 @@
   gap: 10px;
 }
 
-.archSection h4 {
+.archSectionHeading {
   margin-bottom: 6px;
   font-size: 13px;
   color: var(--foreground);

--- a/src/app/(workspace)/reviews/[reviewId]/page.tsx
+++ b/src/app/(workspace)/reviews/[reviewId]/page.tsx
@@ -194,12 +194,16 @@ export default async function ReviewWorkspacePage({
             <div className={styles.archColumns}>
               {architectureColumns.map((column) => {
                 const groupedNodes = groupArchitectureNodes(column.nodes);
-                const categories = ARCHITECTURE_CATEGORY_ORDER.map((category) => [category, groupedNodes[category]] as const)
+                const categories = ARCHITECTURE_CATEGORY_ORDER
+                  .map((category) => [
+                    category,
+                    groupedNodes[category],
+                  ] as const)
                   .filter(([, nodes]) => nodes.length > 0);
 
                 return (
                   <div key={column.label} className={styles.archColumn}>
-                    <h3>{column.label}</h3>
+                    <h3 className={styles.archColumnHeading}>{column.label}</h3>
                     {categories.length === 0 ? (
                       <p className={styles.muted}>No related nodes.</p>
                     ) : (
@@ -210,7 +214,12 @@ export default async function ReviewWorkspacePage({
                             aria-labelledby={`arch-${column.label.toLowerCase()}-${category}`}
                             className={styles.archSection}
                           >
-                            <h4 id={`arch-${column.label.toLowerCase()}-${category}`}>{ARCHITECTURE_CATEGORY_LABELS[category]}</h4>
+                            <h4
+                              id={`arch-${column.label.toLowerCase()}-${category}`}
+                              className={styles.archSectionHeading}
+                            >
+                              {ARCHITECTURE_CATEGORY_LABELS[category]}
+                            </h4>
                             <ul className={styles.archNodeList}>
                               {nodes.map((node) => (
                                 <li key={`${column.label}-${node.raw}`}>

--- a/src/server/presentation/formatters/architecture-node.test.ts
+++ b/src/server/presentation/formatters/architecture-node.test.ts
@@ -41,10 +41,34 @@ describe("architecture-node formatter", () => {
       "unknown:raw",
     ]);
 
-    expect(grouped.layer).toHaveLength(1);
-    expect(grouped.file).toHaveLength(1);
-    expect(grouped.symbol).toHaveLength(1);
-    expect(grouped.unknown).toHaveLength(1);
+    expect(grouped.layer).toEqual([
+      {
+        raw: "layer:domain",
+        kind: "layer",
+        label: "domain",
+      },
+    ]);
+    expect(grouped.file).toEqual([
+      {
+        raw: "file:src/domain/user-service.ts",
+        kind: "file",
+        label: "src/domain/user-service.ts",
+      },
+    ]);
+    expect(grouped.symbol).toEqual([
+      {
+        raw: "symbol:function::<root>::createUser",
+        kind: "symbol",
+        label: "createUser (function)",
+      },
+    ]);
+    expect(grouped.unknown).toEqual([
+      {
+        raw: "unknown:raw",
+        kind: "unknown",
+        label: "unknown:raw",
+      },
+    ]);
   });
 
   it("handles empty and unknown node payloads safely", () => {

--- a/src/server/presentation/formatters/architecture-node.ts
+++ b/src/server/presentation/formatters/architecture-node.ts
@@ -60,15 +60,18 @@ function parseSymbolNode(raw: string): ArchitectureNodeView {
   const normalizedKind = kind.trim().length > 0 ? kind.trim() : "symbol";
   const remainingSegments = segments.slice(1);
   const hasExplicitSymbolName = remainingSegments.length > 0;
-  const symbolName = (remainingSegments.at(-1) ?? primarySegment).trim() || "unknown";
   const containerSegments = [
     ...primaryContainerParts,
     ...remainingSegments.slice(0, Math.max(remainingSegments.length - 1, 0)),
   ].filter((part) => part !== SYMBOL_ROOT_SEGMENT && part.length > 0);
   const container = containerSegments.join(".");
-  const displayName = container.length > 0 ? `${container}.${symbolName}` : symbolName;
+  let label = `${normalizedKind} symbol`;
 
-  const label = hasExplicitSymbolName ? `${displayName} (${normalizedKind})` : `${normalizedKind} symbol`;
+  if (hasExplicitSymbolName) {
+    const symbolName = remainingSegments.at(-1)?.trim() || "unknown";
+    const displayName = container.length > 0 ? `${container}.${symbolName}` : symbolName;
+    label = `${displayName} (${normalizedKind})`;
+  }
 
   return {
     raw,
@@ -98,7 +101,9 @@ export function toArchitectureNodeView(raw: string): ArchitectureNodeView {
 }
 
 export function groupArchitectureNodes(rawNodes: string[]): ArchitectureNodeGroups {
-  const trimmed = rawNodes.map((rawNode) => rawNode.trim()).filter((rawNode) => rawNode.length > 0);
+  const trimmed = rawNodes
+    .map((rawNode) => rawNode.trim())
+    .filter((rawNode) => rawNode.length > 0);
   const deduplicated = [...new Set(trimmed)];
   const groups: ArchitectureNodeGroups = {
     layer: [],


### PR DESCRIPTION
## Motivation / 背景
- **EN:** The architecture pane currently renders raw node strings (`layer:*`, `file:*`, `symbol:*`) in a flat list, which makes large review groups noisy and hard to scan.
- **JA:** 現在のアーキテクチャペインは `layer:*` / `file:*` / `symbol:*` を生文字列のままフラット表示しており、変更量が多いと読み取りづらくなります。
- **EN:** We need a structured, readable view so reviewers can quickly understand upstream/downstream context.
- **JA:** レビュアーが上流/下流の文脈を素早く把握できるよう、構造化された見せ方に改善します。

## What changed / 変更内容
- Add `architecture-node` formatter in presentation layer:
  - classify nodes into `layer` / `file` / `symbol` / `unknown`
  - normalize labels for display (e.g. symbol keys to readable labels)
  - deduplicate and sort nodes per category
- Update review workspace architecture pane:
  - split into `Upstream` / `Downstream` columns
  - group nodes by category with section headers
  - render compact, readable labels with wrapping support

## Validation / 検証
- `npm run lint`
- `npm run typecheck`
- `npm test`

## Scope note / スコープ補足
- This PR is display-quality focused and does not change domain persistence schema.
- 本PRは表示品質の改善に限定し、ドメイン永続化スキーマは変更していません。
