### PR TITLE
feat: add semantic analysis coverage KPI to workspace

### DIFF
--- a/src/app/(workspace)/reviews/[reviewId]/page.tsx
+++ b/src/app/(workspace)/reviews/[reviewId]/page.tsx
@@ -445,6 +445,12 @@ export default async function ReviewWorkspacePage({
 
           <div className={styles.detailBlock}>
             <span className={styles.muted}>Analysis coverage</span>
+            {totalFileCount !== null && supportedFileCount !== null ? (
+              <p className={styles.muted}>
+                Coverage: {supportedFileCount}/{totalFileCount} (
+                {formatCoveragePercent(supportedFileCount, totalFileCount)})
+              </p>
+            ) : null}
             {workspace.unsupportedSummary.totalCount === 0 ? (
               <p>All changed files were covered by active parser adapters.</p>
             ) : (
@@ -453,12 +459,6 @@ export default async function ReviewWorkspacePage({
                   {workspace.unsupportedSummary.totalCount} file(s) were excluded from semantic
                   analysis.
                 </p>
-                {totalFileCount !== null && supportedFileCount !== null ? (
-                  <p className={styles.muted}>
-                    Coverage: {supportedFileCount}/{totalFileCount} (
-                    {formatCoveragePercent(supportedFileCount, totalFileCount)})
-                  </p>
-                ) : null}
                 <ul className={styles.unsupportedList}>
                   {workspace.unsupportedSummary.byReason.map((entry) => (
                     <li key={entry.reason}>


### PR DESCRIPTION
## Motivation / 背景
- The analysis coverage panel showed only unsupported counts, which made it harder to estimate parser coverage quality at a glance.
- Reviewers need a quick KPI to judge whether semantic analysis is broadly covering changed files before trusting grouped results.

- これまでの coverage 表示は「除外ファイル件数」中心で、解析カバレッジの全体感を即座に把握しづらい状態でした。
- semantic group を信頼してレビューを進める前に、変更ファイル全体に対するカバレッジ指標を一目で確認できる必要があります。

## Changes / 変更内容
- Added a workspace-level coverage KPI in the "Analysis coverage" panel:
  - `Coverage: supported/total (percent)`
- Coverage is calculated from existing data:
  - `total = analysisTotalFiles`
  - `supported = total - unsupportedSummary.totalCount`
- Keeps existing unsupported breakdown/details intact.

## Validation / 確認
- `npm run lint`
- `npm run typecheck`
- `npm test`

All passed locally.
