### PR TITLE
feat: add terminal-job retention policy to analysis queue

### DIFF
--- a/src/server/infrastructure/queue/file-analysis-job-scheduler.test.ts
+++ b/src/server/infrastructure/queue/file-analysis-job-scheduler.test.ts
@@ -185,4 +185,111 @@ describe("FileAnalysisJobScheduler", () => {
     expect(persisted.jobs[0]?.status).toBe("succeeded");
     expect(persisted.jobs[0]?.attempts).toBe(2);
   });
+
+  it("retains only the latest terminal jobs while keeping queued/running jobs", async () => {
+    const dataDirectory = await createTempDataDirectory();
+    const filePath = path.join(dataDirectory, "jobs.json");
+    await writeFile(
+      filePath,
+      JSON.stringify(
+        {
+          jobs: [
+            {
+              jobId: "job-queued-existing",
+              reviewId: "review-q",
+              requestedAt: "2026-03-10T00:00:00.000Z",
+              reason: "manual_reanalysis",
+              status: "queued",
+              queuedAt: "2026-03-10T00:00:00.000Z",
+              startedAt: null,
+              completedAt: null,
+              durationMs: null,
+              attempts: 0,
+              lastError: null,
+            },
+            {
+              jobId: "job-running-existing",
+              reviewId: "review-r",
+              requestedAt: "2026-03-10T00:00:00.000Z",
+              reason: "code_host_webhook",
+              status: "running",
+              queuedAt: "2026-03-10T00:00:00.000Z",
+              startedAt: "2026-03-10T00:01:00.000Z",
+              completedAt: null,
+              durationMs: null,
+              attempts: 1,
+              lastError: null,
+            },
+            {
+              jobId: "job-succeeded-oldest",
+              reviewId: "review-1",
+              requestedAt: "2026-03-10T00:00:00.000Z",
+              reason: "initial_ingestion",
+              status: "succeeded",
+              queuedAt: "2026-03-10T00:00:00.000Z",
+              startedAt: "2026-03-10T00:00:00.000Z",
+              completedAt: "2026-03-10T00:00:10.000Z",
+              durationMs: 10000,
+              attempts: 1,
+              lastError: null,
+            },
+            {
+              jobId: "job-succeeded-middle",
+              reviewId: "review-2",
+              requestedAt: "2026-03-10T00:00:00.000Z",
+              reason: "initial_ingestion",
+              status: "succeeded",
+              queuedAt: "2026-03-10T00:00:00.000Z",
+              startedAt: "2026-03-10T00:00:00.000Z",
+              completedAt: "2026-03-10T00:00:20.000Z",
+              durationMs: 20000,
+              attempts: 1,
+              lastError: null,
+            },
+            {
+              jobId: "job-failed-latest",
+              reviewId: "review-3",
+              requestedAt: "2026-03-10T00:00:00.000Z",
+              reason: "initial_ingestion",
+              status: "failed",
+              queuedAt: "2026-03-10T00:00:00.000Z",
+              startedAt: "2026-03-10T00:00:00.000Z",
+              completedAt: "2026-03-10T00:00:30.000Z",
+              durationMs: 30000,
+              attempts: 3,
+              lastError: "failure",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const scheduler = new FileAnalysisJobScheduler({
+      dataDirectory: filePath,
+      autoRun: false,
+      maxRetainedTerminalJobs: 2,
+      onJob: async () => {},
+    });
+
+    await scheduler.scheduleReviewAnalysis({
+      reviewId: "review-new",
+      requestedAt: "2026-03-10T00:05:00.000Z",
+      reason: "initial_ingestion",
+    });
+
+    const persisted = (await readJobsFile(filePath)) as {
+      jobs: Array<{ jobId: string; status: string }>;
+    };
+    const persistedIds = persisted.jobs.map((job) => job.jobId);
+
+    expect(persistedIds).toContain("job-queued-existing");
+    expect(persistedIds).toContain("job-running-existing");
+    expect(persistedIds).toContain("job-succeeded-middle");
+    expect(persistedIds).toContain("job-failed-latest");
+    expect(persistedIds).not.toContain("job-succeeded-oldest");
+    expect(persisted.jobs.filter((job) => job.status === "queued")).toHaveLength(2);
+  });
 });

--- a/src/server/infrastructure/queue/file-analysis-job-scheduler.ts
+++ b/src/server/infrastructure/queue/file-analysis-job-scheduler.ts
@@ -37,12 +37,14 @@ export interface QueuedAnalysisJob {
 export interface FileAnalysisJobSchedulerOptions {
   dataDirectory?: string;
   maxAttempts?: number;
+  maxRetainedTerminalJobs?: number;
   staleRunningMs?: number;
   autoRun?: boolean;
   onJob: (job: QueuedAnalysisJob) => Promise<void>;
 }
 
 const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_MAX_RETAINED_TERMINAL_JOBS = 500;
 const DEFAULT_STALE_RUNNING_MS = 10 * 60 * 1000;
 
 function toErrorMessage(error: unknown): string {
@@ -60,6 +62,7 @@ function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
 export class FileAnalysisJobScheduler implements AnalysisJobScheduler {
   private readonly filePath: string;
   private readonly maxAttempts: number;
+  private readonly maxRetainedTerminalJobs: number;
   private readonly staleRunningMs: number;
   private readonly autoRun: boolean;
   private readonly onJob: (job: QueuedAnalysisJob) => Promise<void>;
@@ -71,6 +74,8 @@ export class FileAnalysisJobScheduler implements AnalysisJobScheduler {
       options.dataDirectory ??
       path.join(process.cwd(), ".locus-data", "analysis-jobs", "jobs.json");
     this.maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    this.maxRetainedTerminalJobs =
+      options.maxRetainedTerminalJobs ?? DEFAULT_MAX_RETAINED_TERMINAL_JOBS;
     this.staleRunningMs = options.staleRunningMs ?? DEFAULT_STALE_RUNNING_MS;
     this.autoRun = options.autoRun ?? true;
     this.onJob = options.onJob;
@@ -263,12 +268,47 @@ export class FileAnalysisJobScheduler implements AnalysisJobScheduler {
     return Math.max(0, completedAtEpochMs - startedAtEpochMs);
   }
 
+  private pruneTerminalJobs(store: QueueStore): void {
+    if (this.maxRetainedTerminalJobs < 0) {
+      return;
+    }
+
+    const terminalJobs = store.jobs.filter(
+      (job) => job.status === "succeeded" || job.status === "failed",
+    );
+
+    if (terminalJobs.length <= this.maxRetainedTerminalJobs) {
+      return;
+    }
+
+    const retainedTerminalJobs = [...terminalJobs]
+      .sort((left, right) => {
+        const leftEpochMs = Date.parse(left.completedAt ?? left.queuedAt);
+        const rightEpochMs = Date.parse(right.completedAt ?? right.queuedAt);
+        const normalizedLeftEpochMs = Number.isNaN(leftEpochMs) ? 0 : leftEpochMs;
+        const normalizedRightEpochMs = Number.isNaN(rightEpochMs) ? 0 : rightEpochMs;
+
+        return normalizedRightEpochMs - normalizedLeftEpochMs;
+      })
+      .slice(0, this.maxRetainedTerminalJobs);
+    const retainedTerminalJobIds = new Set(retainedTerminalJobs.map((job) => job.jobId));
+
+    store.jobs = store.jobs.filter((job) => {
+      if (job.status !== "succeeded" && job.status !== "failed") {
+        return true;
+      }
+
+      return retainedTerminalJobIds.has(job.jobId);
+    });
+  }
+
   private async mutateStore<T>(fn: (store: QueueStore) => T | Promise<T>): Promise<T> {
     const task = this.writeQueue
       .catch(() => undefined)
       .then(async () => {
         const store = await this.loadStore();
         const result = await fn(store);
+        this.pruneTerminalJobs(store);
         await this.persistStore(store);
         return result;
       });


### PR DESCRIPTION
## Motivation / 背景
- `jobs.json` in the durable analysis queue grows indefinitely as succeeded/failed jobs accumulate.
- Unbounded queue history increases disk usage and JSON parse/write cost on every enqueue/drain operation.

- 耐久キューの `jobs.json` は完了ジョブ（succeeded/failed）が蓄積し続け、無制限に肥大化します。
- 履歴が無制限だと、enqueue/drain のたびに JSON の読み書きコストとディスク使用量が増加します。

## Changes / 変更内容
- Added terminal-job retention policy to `FileAnalysisJobScheduler`:
  - new option: `maxRetainedTerminalJobs` (default: 500)
  - keeps all `queued` / `running` jobs
  - keeps only latest N terminal jobs (`succeeded` / `failed`) by completion timestamp
- Pruning is applied inside store mutation before persistence.
- Added regression test to verify:
  - active jobs are never pruned
  - old terminal jobs are dropped
  - latest terminal jobs are retained

## Validation / 確認
- `npm run lint`
- `npm run typecheck`
- `npm test`

All passed locally.
