### PR TITLE
feat: add workspace locale preference switcher

### DIFF
--- a/src/app/(workspace)/reviews/[reviewId]/page.module.css
+++ b/src/app/(workspace)/reviews/[reviewId]/page.module.css
@@ -40,6 +40,32 @@
   gap: 12px;
 }
 
+.localeSwitcher {
+  display: inline-flex;
+  gap: 6px;
+  padding: 4px;
+  border: 1px solid rgba(154, 167, 209, 0.2);
+  border-radius: 14px;
+  background: rgba(18, 25, 51, 0.88);
+}
+
+.localeButton {
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid rgba(154, 167, 209, 0.22);
+  border-radius: 10px;
+  background: rgba(11, 16, 32, 0.65);
+  color: var(--foreground);
+  font-size: 12px;
+  line-height: 1.2;
+  transition: border-color 0.16s ease, background 0.16s ease;
+}
+
+.localeButton[data-active="true"] {
+  border-color: rgba(124, 156, 255, 0.6);
+  background: rgba(94, 123, 255, 0.16);
+}
+
 .actionButton,
 .statusButton,
 .groupButton {

--- a/src/app/(workspace)/reviews/[reviewId]/page.tsx
+++ b/src/app/(workspace)/reviews/[reviewId]/page.tsx
@@ -27,6 +27,7 @@ import {
 import { requestInitialAnalysisRetryAction } from "@/server/presentation/actions/request-initial-analysis-retry-action";
 import { requestReanalysisAction } from "@/server/presentation/actions/request-reanalysis-action";
 import { selectReviewGroupAction } from "@/server/presentation/actions/select-review-group-action";
+import { setWorkspaceLocaleAction } from "@/server/presentation/actions/set-workspace-locale-action";
 import { setReviewGroupStatusAction } from "@/server/presentation/actions/set-review-group-status-action";
 import {
   groupArchitectureNodes,
@@ -229,6 +230,30 @@ export default async function ReviewWorkspacePage({
           </div>
         </div>
         <div className={styles.actions}>
+          <div className={styles.localeSwitcher} aria-label={copy.actions.languageLabel}>
+            <form action={setWorkspaceLocaleAction}>
+              <input name="reviewId" type="hidden" value={workspace.reviewId} />
+              <input name="locale" type="hidden" value="ja" />
+              <button
+                className={styles.localeButton}
+                data-active={workspaceLocale === "ja"}
+                type="submit"
+              >
+                {copy.actions.switchToJapanese}
+              </button>
+            </form>
+            <form action={setWorkspaceLocaleAction}>
+              <input name="reviewId" type="hidden" value={workspace.reviewId} />
+              <input name="locale" type="hidden" value="en" />
+              <button
+                className={styles.localeButton}
+                data-active={workspaceLocale === "en"}
+                type="submit"
+              >
+                {copy.actions.switchToEnglish}
+              </button>
+            </form>
+          </div>
           <Link className={styles.actionButton} href="/settings/connections">
             {copy.links.connections}
           </Link>

--- a/src/app/(workspace)/reviews/[reviewId]/workspace-copy.ts
+++ b/src/app/(workspace)/reviews/[reviewId]/workspace-copy.ts
@@ -87,6 +87,9 @@ export const workspaceCopyByLocale = {
     },
     actions: {
       markStatusPrefix: "Mark",
+      languageLabel: "Language",
+      switchToEnglish: "English",
+      switchToJapanese: "日本語",
       queueReanalysis: "Queue reanalysis",
       queueingReanalysis: "Queueing...",
       reloadNow: "Reload now",
@@ -214,6 +217,9 @@ export const workspaceCopyByLocale = {
     },
     actions: {
       markStatusPrefix: "状態を",
+      languageLabel: "表示言語",
+      switchToEnglish: "English",
+      switchToJapanese: "日本語",
       queueReanalysis: "再解析をキュー投入",
       queueingReanalysis: "キュー投入中...",
       reloadNow: "今すぐ再読み込み",

--- a/src/server/presentation/actions/set-workspace-locale-action.test.ts
+++ b/src/server/presentation/actions/set-workspace-locale-action.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  setCookieMock,
+  cookiesMock,
+  revalidatePathMock,
+  redirectMock,
+} = vi.hoisted(() => {
+  const setCookieMock = vi.fn();
+  return {
+    setCookieMock,
+    cookiesMock: vi.fn(async () => ({ set: setCookieMock })),
+    revalidatePathMock: vi.fn(),
+    redirectMock: vi.fn(),
+  };
+});
+
+vi.mock("next/headers", () => ({
+  cookies: cookiesMock,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+import { setWorkspaceLocaleAction } from "@/server/presentation/actions/set-workspace-locale-action";
+
+describe("setWorkspaceLocaleAction", () => {
+  beforeEach(() => {
+    setCookieMock.mockClear();
+    cookiesMock.mockClear();
+    revalidatePathMock.mockClear();
+    redirectMock.mockClear();
+  });
+
+  it("persists locale cookie and redirects to current review", async () => {
+    const formData = new FormData();
+    formData.set("reviewId", "review-1");
+    formData.set("locale", "ja");
+
+    await setWorkspaceLocaleAction(formData);
+
+    expect(cookiesMock).toHaveBeenCalledTimes(1);
+    expect(setCookieMock).toHaveBeenCalledWith("locus-ui-locale", "ja", {
+      path: "/",
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 365,
+    });
+    expect(revalidatePathMock).toHaveBeenCalledWith("/reviews/review-1");
+    expect(redirectMock).toHaveBeenCalledWith("/reviews/review-1");
+  });
+
+  it("rejects unsupported locale values", async () => {
+    const formData = new FormData();
+    formData.set("reviewId", "review-2");
+    formData.set("locale", "de");
+
+    await expect(setWorkspaceLocaleAction(formData)).rejects.toThrow(
+      "Unsupported workspace locale: de",
+    );
+    expect(setCookieMock).not.toHaveBeenCalled();
+    expect(revalidatePathMock).not.toHaveBeenCalled();
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/presentation/actions/set-workspace-locale-action.ts
+++ b/src/server/presentation/actions/set-workspace-locale-action.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { readRequiredString } from "@/server/presentation/actions/read-required-string";
+
+const supportedLocales = new Set(["ja", "en"]);
+
+function assertWorkspaceLocale(value: string): "ja" | "en" {
+  if (!supportedLocales.has(value)) {
+    throw new Error(`Unsupported workspace locale: ${value}`);
+  }
+
+  return value as "ja" | "en";
+}
+
+export async function setWorkspaceLocaleAction(formData: FormData): Promise<void> {
+  const reviewId = readRequiredString(formData, "reviewId");
+  const locale = assertWorkspaceLocale(readRequiredString(formData, "locale"));
+  const cookieStore = await cookies();
+
+  cookieStore.set("locus-ui-locale", locale, {
+    path: "/",
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24 * 365,
+  });
+
+  revalidatePath(`/reviews/${reviewId}`);
+  redirect(`/reviews/${reviewId}`);
+}


### PR DESCRIPTION
## Motivation / 背景
- Workspace copy is now localized (`ja` / `en`), but users had no explicit in-product control to override browser language.
- For bilingual demos and reviews, switching language quickly from the workspace itself improves usability and verification speed.

- workspace 文言は `ja` / `en` 対応済みですが、ブラウザ言語を上書きする UI がありませんでした。
- 日英を行き来するデモ/レビューでは、workspace 上で即座に言語を切り替えられる方が使いやすく検証もしやすくなります。

## Changes / 変更内容
1. Added `setWorkspaceLocaleAction`
   - Validates locale (`ja` / `en`)
   - Persists `locus-ui-locale` cookie
   - Revalidates and redirects back to the same review page

2. Added locale switcher UI in workspace header
   - Two explicit buttons: `日本語` / `English`
   - Active locale is visually highlighted

3. Extended workspace copy dictionary
   - Added labels needed by locale switch controls

4. Styling
   - Added compact segmented-style locale switcher styles for header actions area

5. Tests
   - Added unit tests for `setWorkspaceLocaleAction`
     - successful cookie persistence + redirect
     - unsupported locale rejection

## Validation / 確認
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅
