### PR TITLE
test(workspace): guard detail pane readability on narrow viewport

### DIFF
--- a/e2e/workspace-smoke.spec.ts
+++ b/e2e/workspace-smoke.spec.ts
@@ -71,6 +71,22 @@ test("keeps review status changes after reload", async ({ page }) => {
   );
 });
 
+test("keeps review detail pane readable on narrow viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await openSeedWorkspace(page);
+
+  await expect(
+    page.getByRole("heading", { level: 2, name: /Detail pane|詳細/ }),
+  ).toBeVisible();
+  await expect(page.getByTestId("status-button-reviewed")).toBeVisible();
+  await expect(page.getByText(/location details|位置情報/).first()).toBeVisible();
+
+  const hasHorizontalOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > window.innerWidth + 1,
+  );
+  expect(hasHorizontalOverflow).toBe(false);
+});
+
 test("persists connection state transitions in settings workspace", async ({ page }) => {
   await openSeedWorkspace(page);
   await page.goto("/settings/connections");


### PR DESCRIPTION
## Motivation / 目的
Detail pane readability can regress silently on 390px layouts; we need a stable e2e guard to catch overflow and broken controls early.

390px 幅の詳細ペイン可読性は回帰しやすいため、overflow と操作崩れを早期検知する e2e ガードが必要です。

## What this PR changes / 変更内容
- Add narrow-viewport e2e coverage for detail pane readability and primary controls.

## Validation / 検証
- npm run test:e2e -- e2e/workspace-smoke.spec.ts --grep detail pane readable

## Issue
Closes #56