### PR TITLE
test(regression): extend UI/parser/DTO guard coverage

### DIFF
--- a/e2e/workspace-smoke.spec.ts
+++ b/e2e/workspace-smoke.spec.ts
@@ -87,6 +87,22 @@ test("keeps review detail pane readable on narrow viewport", async ({ page }) =>
   expect(hasHorizontalOverflow).toBe(false);
 });
 
+test("shows unified recovery guidance for workspace retry errors", async ({ page }) => {
+  await openSeedWorkspace(page);
+  await page.goto("/reviews/demo-review?workspaceError=source_unavailable");
+
+  await expect(
+    page.getByText(
+      /Reanalysis source is unavailable\. Reconnect GitHub OAuth and retry\.|再解析元が利用できません。GitHub OAuth を再接続して再試行してください。/,
+    ),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      /If the issue continues, check connection status and review logs\.|継続する場合は接続状態とログを確認してください。/,
+    ),
+  ).toBeVisible();
+});
+
 test("persists connection state transitions in settings workspace", async ({ page }) => {
   await openSeedWorkspace(page);
   await page.goto("/settings/connections");

--- a/src/server/infrastructure/parser/typescript-parser-adapter.real-pr-fixtures.test.ts
+++ b/src/server/infrastructure/parser/typescript-parser-adapter.real-pr-fixtures.test.ts
@@ -140,6 +140,19 @@ describe("TypeScriptParserAdapter real PR fixtures", () => {
     );
   });
 
+  it("keeps stable symbol keys for security-sensitive fixture callables", async () => {
+    const adapter = new TypeScriptParserAdapter();
+    const [, pair] = createRealPrFixturePairs("real-pr-fixture-review");
+    const before = await adapter.parse(pair.before!);
+    const after = await adapter.parse(pair.after!);
+    const diff = await adapter.diff({ before, after });
+    const symbolKeys = new Set(diff.items.map((item) => item.symbolKey));
+
+    expect(symbolKeys.has("function::<root>::startGitHubDemoSessionAction")).toBe(true);
+    expect(symbolKeys.has("function::<root>::parsePullRequestNumber")).toBe(true);
+    expect(symbolKeys.has("function::<root>::readRequiredValue")).toBe(true);
+  });
+
   it("runs end-to-end analysis pipeline on real PR fixtures without unsupported files", async () => {
     const reviewId = "real-pr-fixture-review";
     const startedAt = Date.now();

--- a/src/server/presentation/mappers/to-review-workspace-dto.test.ts
+++ b/src/server/presentation/mappers/to-review-workspace-dto.test.ts
@@ -489,6 +489,66 @@ describe("toReviewWorkspaceDto", () => {
     expect(dto.unsupportedFiles[99]?.filePath).toBe("generated/file-100.bin");
   });
 
+  it("keeps unsupported reason buckets deterministic regardless of input order", () => {
+    const reviewSession = ReviewSession.create({
+      reviewId: "review-6",
+      title: "Unsupported ordering",
+      repositoryName: "duck8823/locus",
+      branchLabel: "main",
+      viewerName: "Duck",
+      lastOpenedAt: "2026-03-08T00:00:00.000Z",
+      groups: [
+        {
+          groupId: "group-1",
+          title: "Group 1",
+          summary: "Primary",
+          filePath: "src/a.ts",
+          status: "unread",
+          upstream: [],
+          downstream: [],
+        },
+      ],
+      unsupportedFileAnalyses: [
+        {
+          reviewId: "review-6",
+          fileId: "u-1",
+          filePath: "src/unknown.vue",
+          language: "vue",
+          reason: "unsupported_language",
+        },
+        {
+          reviewId: "review-6",
+          fileId: "u-2",
+          filePath: "assets/logo.png",
+          language: null,
+          reason: "binary_file",
+        },
+        {
+          reviewId: "review-6",
+          fileId: "u-3",
+          filePath: "src/broken.ts",
+          language: "typescript",
+          reason: "parser_failed",
+        },
+        {
+          reviewId: "review-6",
+          fileId: "u-4",
+          filePath: "src/second.vue",
+          language: "vue",
+          reason: "unsupported_language",
+        },
+      ],
+    });
+
+    const dto = toReviewWorkspaceDto(reviewSession);
+
+    expect(dto.unsupportedSummary.byReason).toEqual([
+      { reason: "binary_file", count: 1 },
+      { reason: "parser_failed", count: 1 },
+      { reason: "unsupported_language", count: 2 },
+    ]);
+  });
+
   it("caps partial coverage below 100 percent", () => {
     const unsupportedFileAnalyses = [
       {


### PR DESCRIPTION
## Motivation / 目的
Feature velocity requires denser regression coverage to keep failures diagnosable.

機能追加速度に対して、失敗時の原因特定まで含めた回帰テスト密度を上げる必要があります。

## What this PR changes / 変更内容
- Add e2e regression for workspace retry-guidance rendering.
- Add parser fixture key-stability regression assertion.
- Add DTO unsupported-summary determinism regression test.

## Validation / 検証
- npm test -- src/server/infrastructure/parser/typescript-parser-adapter.real-pr-fixtures.test.ts src/server/presentation/mappers/to-review-workspace-dto.test.ts
- npm run test:e2e -- e2e/workspace-smoke.spec.ts --grep workspace retry errors

## Issue
Closes #59