### PR TITLE
feat(workspace): unify retry error routing and guidance

### DIFF
--- a/docs/operations/review-retry-error-matrix.ja.md
+++ b/docs/operations/review-retry-error-matrix.ja.md
@@ -1,0 +1,39 @@
+# レビュー再試行エラーマトリクス (H1-3)
+
+> English: [review-retry-error-matrix.md](review-retry-error-matrix.md)
+
+## 目的
+
+再試行系エラーコードと、ユーザーに提示する復帰導線を一箇所で定義する。
+
+## ワークスペース action リダイレクトコード
+
+| Query code | 発生条件 | ユーザー案内 |
+|---|---|---|
+| `workspace_not_found` | レビューセッションが存在しない | ホームから開き直す |
+| `source_unavailable` | 再解析ソースを解決できない | GitHub OAuth再接続後に再試行 |
+| `action_failed` | 想定外の action 失敗 | ページ再読み込み後に再試行 |
+
+## Review API レスポンスコード
+
+| API endpoint | Error code | 意味 | 想定UI挙動 |
+|---|---|---|---|
+| `POST /api/reviews/[reviewId]/reanalyze` | `REVIEW_SESSION_NOT_FOUND` | レビュー不存在 | not-found 案内表示 |
+| `POST /api/reviews/[reviewId]/reanalyze` | `INVALID_REANALYZE_REQUEST` | payload不正 or ソース状態不正 | 再試行導線 + 診断情報 |
+| `POST /api/reviews/[reviewId]/progress` | `REVIEW_GROUP_NOT_FOUND` | グループ不存在 | 最新状態を再読込 |
+| `GET /api/reviews/[reviewId]/analysis-status` | `REVIEW_SESSION_NOT_FOUND` | poll対象不存在 | poll停止して開き直し |
+
+## OAuth callback/start コード（接続設定画面）
+
+| Query code | 意味 | ユーザー操作 |
+|---|---|---|
+| `oauth_provider_rejected` | provider 側で認可拒否 | OAuth を再実行して再同意 |
+| `oauth_callback_invalid` | callback パラメータ不正 | 設定画面から OAuth 再開始 |
+| `oauth_callback_retryable` | 一時的交換失敗 | 少し待って再試行 |
+| `oauth_callback_failed` | 交換失敗（終端） | ログ/認証情報を確認 |
+| `oauth_start_failed` | 開始処理失敗 | 環境変数確認後に再試行 |
+
+## 運用メモ
+
+- マッピングは加法的に拡張する。
+- 未知コードは汎用再試行メッセージにフォールバックし、診断ログを残す。

--- a/docs/operations/review-retry-error-matrix.md
+++ b/docs/operations/review-retry-error-matrix.md
@@ -1,0 +1,39 @@
+# Review Retry Error Matrix (H1-3)
+
+> 日本語: [review-retry-error-matrix.ja.md](review-retry-error-matrix.ja.md)
+
+## Purpose
+
+Define a single mapping between retry-related error codes and user-facing recovery guidance.
+
+## Workspace action redirect codes
+
+| Query code | Trigger | User guidance |
+|---|---|---|
+| `workspace_not_found` | Review session does not exist | Reopen workspace from home |
+| `source_unavailable` | Reanalysis source cannot be resolved | Reconnect GitHub OAuth and retry |
+| `action_failed` | Unexpected action failure | Reload page and retry |
+
+## Review API response codes
+
+| API endpoint | Error code | Meaning | Expected UI action |
+|---|---|---|---|
+| `POST /api/reviews/[reviewId]/reanalyze` | `REVIEW_SESSION_NOT_FOUND` | review missing | show not-found guidance |
+| `POST /api/reviews/[reviewId]/reanalyze` | `INVALID_REANALYZE_REQUEST` | malformed payload or invalid source state | show retry + diagnostics |
+| `POST /api/reviews/[reviewId]/progress` | `REVIEW_GROUP_NOT_FOUND` | selected group missing | reload latest state |
+| `GET /api/reviews/[reviewId]/analysis-status` | `REVIEW_SESSION_NOT_FOUND` | polling target missing | stop polling and reopen |
+
+## OAuth callback/start codes (connections workspace)
+
+| Query code | Meaning | User action |
+|---|---|---|
+| `oauth_provider_rejected` | provider denied authorization | retry OAuth and re-consent |
+| `oauth_callback_invalid` | callback params invalid | restart OAuth from settings |
+| `oauth_callback_retryable` | temporary exchange failure | retry shortly |
+| `oauth_callback_failed` | terminal exchange failure | inspect logs / credentials |
+| `oauth_start_failed` | start flow failed | verify env + retry |
+
+## Operational note
+
+- Keep these mappings additive.
+- Unknown codes should fall back to a generic retry message and diagnostics logging.

--- a/src/app/(workspace)/reviews/[reviewId]/page.module.css
+++ b/src/app/(workspace)/reviews/[reviewId]/page.module.css
@@ -335,6 +335,17 @@
   overflow-wrap: break-word;
 }
 
+.workspaceAlert {
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  border-radius: 14px;
+  background: rgba(127, 29, 29, 0.2);
+  color: #fecaca;
+  padding: 10px 12px;
+  margin-bottom: 16px;
+  display: grid;
+  gap: 6px;
+}
+
 .analysisProgressTrack {
   height: 8px;
   width: 100%;

--- a/src/app/(workspace)/reviews/[reviewId]/page.tsx
+++ b/src/app/(workspace)/reviews/[reviewId]/page.tsx
@@ -37,6 +37,7 @@ import { selectReviewGroupAction } from "@/server/presentation/actions/select-re
 import { setWorkspaceLocaleAction } from "@/server/presentation/actions/set-workspace-locale-action";
 import { setReviewGroupStatusAction } from "@/server/presentation/actions/set-review-group-status-action";
 import { DEMO_VIEWER_COOKIE_NAME } from "@/server/presentation/actions/demo-viewer-cookie-name";
+import { parseWorkspaceErrorCode } from "@/server/presentation/actions/workspace-error-code";
 import {
   groupArchitectureNodes,
   type ArchitectureNodeGroups,
@@ -110,10 +111,13 @@ interface ArchitectureColumn {
 
 export default async function ReviewWorkspacePage({
   params,
+  searchParams,
 }: {
   params: Promise<{ reviewId: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { reviewId } = await params;
+  const resolvedSearchParams = await searchParams;
   const headerStore = await headers();
   const cookieStore = await cookies();
   const viewerName = cookieStore.get(DEMO_VIEWER_COOKIE_NAME)?.value;
@@ -122,6 +126,19 @@ export default async function ReviewWorkspacePage({
     acceptLanguage: headerStore.get("accept-language"),
   });
   const copy = workspaceCopyByLocale[workspaceLocale];
+  const workspaceErrorCode = parseWorkspaceErrorCode(
+    typeof resolvedSearchParams.workspaceError === "string"
+      ? resolvedSearchParams.workspaceError
+      : null,
+  );
+  const workspaceErrorMessage =
+    workspaceErrorCode === "workspace_not_found"
+      ? copy.text.workspaceErrorWorkspaceNotFound
+      : workspaceErrorCode === "source_unavailable"
+        ? copy.text.workspaceErrorSourceUnavailable
+        : workspaceErrorCode === "action_failed"
+          ? copy.text.workspaceErrorActionFailed
+          : null;
 
   if (!viewerName) {
     redirect("/");
@@ -284,6 +301,13 @@ export default async function ReviewWorkspacePage({
           </form>
         </div>
       </div>
+
+      {workspaceErrorMessage ? (
+        <section className={styles.workspaceAlert} role="status" aria-live="polite">
+          <p>{workspaceErrorMessage}</p>
+          <p className={styles.muted}>{copy.text.workspaceErrorNextAction}</p>
+        </section>
+      ) : null}
 
       <div className={styles.layout}>
         <section className={styles.panel}>

--- a/src/app/(workspace)/reviews/[reviewId]/workspace-copy.ts
+++ b/src/app/(workspace)/reviews/[reviewId]/workspace-copy.ts
@@ -110,6 +110,14 @@ export const workspaceCopyByLocale = {
       semanticFocus: "focus",
       semanticSpanDelta: "span delta",
       semanticLocationDetails: "location details",
+      workspaceErrorWorkspaceNotFound:
+        "The review workspace could not be found. Please reopen it from the home screen.",
+      workspaceErrorSourceUnavailable:
+        "Reanalysis source is unavailable. Reconnect GitHub OAuth and retry.",
+      workspaceErrorActionFailed:
+        "The request failed. Reload this page and try again.",
+      workspaceErrorNextAction:
+        "If the issue continues, check connection status and review logs.",
     },
     actions: {
       markStatusPrefix: "Mark",
@@ -281,6 +289,14 @@ export const workspaceCopyByLocale = {
       semanticFocus: "注目点",
       semanticSpanDelta: "行数差分",
       semanticLocationDetails: "位置情報",
+      workspaceErrorWorkspaceNotFound:
+        "レビュー画面が見つかりません。ホーム画面から開き直してください。",
+      workspaceErrorSourceUnavailable:
+        "再解析元が利用できません。GitHub OAuth を再接続して再試行してください。",
+      workspaceErrorActionFailed:
+        "リクエストに失敗しました。ページを再読み込みして再実行してください。",
+      workspaceErrorNextAction:
+        "継続する場合は接続状態とログを確認してください。",
     },
     actions: {
       markStatusPrefix: "状態を",

--- a/src/server/presentation/actions/request-initial-analysis-retry-action.test.ts
+++ b/src/server/presentation/actions/request-initial-analysis-retry-action.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ReanalyzeSourceUnavailableError } from "@/server/application/errors/reanalyze-source-unavailable-error";
+
+const { executeMock, getDependenciesMock, revalidatePathMock, redirectMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  getDependenciesMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+vi.mock("@/server/composition/dependencies", () => ({
+  getDependencies: getDependenciesMock,
+}));
+
+vi.mock("@/server/application/usecases/request-initial-analysis-retry", () => ({
+  RequestInitialAnalysisRetryUseCase: class {
+    async execute(input: { reviewId: string }) {
+      return executeMock(input);
+    }
+  },
+}));
+
+import { requestInitialAnalysisRetryAction } from "@/server/presentation/actions/request-initial-analysis-retry-action";
+
+describe("requestInitialAnalysisRetryAction", () => {
+  beforeEach(() => {
+    executeMock.mockReset();
+    getDependenciesMock.mockReset();
+    revalidatePathMock.mockReset();
+    redirectMock.mockReset();
+    getDependenciesMock.mockReturnValue({
+      reviewSessionRepository: {},
+      analysisJobScheduler: {},
+    });
+  });
+
+  it("revalidates and redirects on success", async () => {
+    const formData = new FormData();
+    formData.set("reviewId", "review-1");
+
+    await requestInitialAnalysisRetryAction(formData);
+
+    expect(executeMock).toHaveBeenCalledWith({ reviewId: "review-1" });
+    expect(revalidatePathMock).toHaveBeenCalledWith("/reviews/review-1");
+    expect(redirectMock).toHaveBeenCalledWith("/reviews/review-1");
+  });
+
+  it("redirects with normalized workspace error code on failure", async () => {
+    executeMock.mockRejectedValueOnce(new ReanalyzeSourceUnavailableError("review-1"));
+    const formData = new FormData();
+    formData.set("reviewId", "review-1");
+
+    await requestInitialAnalysisRetryAction(formData);
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      "/reviews/review-1?workspaceError=source_unavailable",
+    );
+  });
+});

--- a/src/server/presentation/actions/request-initial-analysis-retry-action.ts
+++ b/src/server/presentation/actions/request-initial-analysis-retry-action.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { RequestInitialAnalysisRetryUseCase } from "@/server/application/usecases/request-initial-analysis-retry";
 import { getDependencies } from "@/server/composition/dependencies";
 import { readRequiredString } from "@/server/presentation/actions/read-required-string";
+import { toWorkspaceErrorCode } from "@/server/presentation/actions/workspace-error-code";
 
 export async function requestInitialAnalysisRetryAction(formData: FormData): Promise<void> {
   const reviewId = readRequiredString(formData, "reviewId");
@@ -14,7 +15,14 @@ export async function requestInitialAnalysisRetryAction(formData: FormData): Pro
     analysisJobScheduler,
   });
 
-  await useCase.execute({ reviewId });
-  revalidatePath(`/reviews/${reviewId}`);
-  redirect(`/reviews/${reviewId}`);
+  try {
+    await useCase.execute({ reviewId });
+    revalidatePath(`/reviews/${reviewId}`);
+    redirect(`/reviews/${reviewId}`);
+  } catch (error) {
+    const query = new URLSearchParams({
+      workspaceError: toWorkspaceErrorCode(error),
+    });
+    redirect(`/reviews/${reviewId}?${query.toString()}`);
+  }
 }

--- a/src/server/presentation/actions/request-reanalysis-action.test.ts
+++ b/src/server/presentation/actions/request-reanalysis-action.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ReviewSessionNotFoundError } from "@/server/application/errors/review-session-not-found-error";
+
+const { executeMock, getDependenciesMock, revalidatePathMock, redirectMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  getDependenciesMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+vi.mock("@/server/composition/dependencies", () => ({
+  getDependencies: getDependenciesMock,
+}));
+
+vi.mock("@/server/application/usecases/request-manual-reanalysis", () => ({
+  RequestManualReanalysisUseCase: class {
+    async execute(input: { reviewId: string }) {
+      return executeMock(input);
+    }
+  },
+}));
+
+import { requestReanalysisAction } from "@/server/presentation/actions/request-reanalysis-action";
+
+describe("requestReanalysisAction", () => {
+  beforeEach(() => {
+    executeMock.mockReset();
+    getDependenciesMock.mockReset();
+    revalidatePathMock.mockReset();
+    redirectMock.mockReset();
+    getDependenciesMock.mockReturnValue({
+      reviewSessionRepository: {},
+      analysisJobScheduler: {},
+    });
+  });
+
+  it("revalidates and redirects on success", async () => {
+    const formData = new FormData();
+    formData.set("reviewId", "review-1");
+
+    await requestReanalysisAction(formData);
+
+    expect(executeMock).toHaveBeenCalledWith({ reviewId: "review-1" });
+    expect(revalidatePathMock).toHaveBeenCalledWith("/reviews/review-1");
+    expect(redirectMock).toHaveBeenCalledWith("/reviews/review-1");
+  });
+
+  it("redirects with workspace_not_found when review is missing", async () => {
+    executeMock.mockRejectedValueOnce(new ReviewSessionNotFoundError("review-1"));
+    const formData = new FormData();
+    formData.set("reviewId", "review-1");
+
+    await requestReanalysisAction(formData);
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      "/reviews/review-1?workspaceError=workspace_not_found",
+    );
+  });
+});

--- a/src/server/presentation/actions/request-reanalysis-action.ts
+++ b/src/server/presentation/actions/request-reanalysis-action.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { RequestManualReanalysisUseCase } from "@/server/application/usecases/request-manual-reanalysis";
 import { getDependencies } from "@/server/composition/dependencies";
 import { readRequiredString } from "@/server/presentation/actions/read-required-string";
+import { toWorkspaceErrorCode } from "@/server/presentation/actions/workspace-error-code";
 
 export async function requestReanalysisAction(formData: FormData): Promise<void> {
   const reviewId = readRequiredString(formData, "reviewId");
@@ -14,7 +15,14 @@ export async function requestReanalysisAction(formData: FormData): Promise<void>
     analysisJobScheduler,
   });
 
-  await useCase.execute({ reviewId });
-  revalidatePath(`/reviews/${reviewId}`);
-  redirect(`/reviews/${reviewId}`);
+  try {
+    await useCase.execute({ reviewId });
+    revalidatePath(`/reviews/${reviewId}`);
+    redirect(`/reviews/${reviewId}`);
+  } catch (error) {
+    const query = new URLSearchParams({
+      workspaceError: toWorkspaceErrorCode(error),
+    });
+    redirect(`/reviews/${reviewId}?${query.toString()}`);
+  }
 }

--- a/src/server/presentation/actions/workspace-error-code.test.ts
+++ b/src/server/presentation/actions/workspace-error-code.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { ReanalyzeSourceUnavailableError } from "@/server/application/errors/reanalyze-source-unavailable-error";
+import { ReviewSessionNotFoundError } from "@/server/application/errors/review-session-not-found-error";
+import {
+  parseWorkspaceErrorCode,
+  toWorkspaceErrorCode,
+} from "@/server/presentation/actions/workspace-error-code";
+
+describe("workspace-error-code", () => {
+  it("parses known codes only", () => {
+    expect(parseWorkspaceErrorCode("source_unavailable")).toBe("source_unavailable");
+    expect(parseWorkspaceErrorCode("WORKSPACE_NOT_FOUND")).toBe("workspace_not_found");
+    expect(parseWorkspaceErrorCode("unknown")).toBeNull();
+  });
+
+  it("maps action errors to stable workspace codes", () => {
+    expect(toWorkspaceErrorCode(new ReviewSessionNotFoundError("review-1"))).toBe("workspace_not_found");
+    expect(toWorkspaceErrorCode(new ReanalyzeSourceUnavailableError("review-1"))).toBe("source_unavailable");
+    expect(toWorkspaceErrorCode(new Error("random"))).toBe("action_failed");
+  });
+});

--- a/src/server/presentation/actions/workspace-error-code.ts
+++ b/src/server/presentation/actions/workspace-error-code.ts
@@ -1,0 +1,36 @@
+import { ReanalyzeSourceUnavailableError } from "@/server/application/errors/reanalyze-source-unavailable-error";
+import { ReviewSessionNotFoundError } from "@/server/application/errors/review-session-not-found-error";
+
+export const workspaceErrorCodeValues = [
+  "workspace_not_found",
+  "source_unavailable",
+  "action_failed",
+] as const;
+
+export type WorkspaceErrorCode = (typeof workspaceErrorCodeValues)[number];
+
+const workspaceErrorCodeSet = new Set<string>(workspaceErrorCodeValues);
+
+export function parseWorkspaceErrorCode(
+  value: string | null | undefined,
+): WorkspaceErrorCode | null {
+  const normalized = value?.trim().toLowerCase();
+
+  if (!normalized || !workspaceErrorCodeSet.has(normalized)) {
+    return null;
+  }
+
+  return normalized as WorkspaceErrorCode;
+}
+
+export function toWorkspaceErrorCode(error: unknown): WorkspaceErrorCode {
+  if (error instanceof ReviewSessionNotFoundError) {
+    return "workspace_not_found";
+  }
+
+  if (error instanceof ReanalyzeSourceUnavailableError) {
+    return "source_unavailable";
+  }
+
+  return "action_failed";
+}


### PR DESCRIPTION
## Motivation / 目的
Retry failure paths were inconsistent across actions; users need deterministic next steps.

再試行失敗時の導線が action ごとに揺れていたため、ユーザーに一貫した次アクションを提示する必要があります。

## What this PR changes / 変更内容
- Introduce stable workspaceError codes and action-level redirects.
- Add unified workspace alert copy (EN/JA).
- Document retry/error matrix in docs/operations (EN/JA).

## Validation / 検証
- npm test -- src/server/presentation/actions/workspace-error-code.test.ts src/server/presentation/actions/request-reanalysis-action.test.ts src/server/presentation/actions/request-initial-analysis-retry-action.test.ts
- npm run typecheck

## Issue
Closes #58