### PR TITLE
Sync README feature/roadmap status with current prototype capabilities

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -65,12 +65,12 @@ UserService.updateProfile()         UserService.updateProfile()
 | 機能 | 概要 | 状態 |
 |---|---|---|
 | アーキテクチャミニマップ v0 | 直近 upstream/downstream と change group 遷移を表示 | 🟡 Prototype |
-| セマンティックDiff | ASTベースの関数・メソッド単位の変更可視化 | 🔴 計画中 |
-| ビジネスロジックコンテキスト | Confluence・GitHub Issues/Projects連携 | 🔴 計画中 |
-| AIレビュー補助 | コンテキストを持ったLLMによるレビュー | 🔴 計画中 |
+| セマンティックDiff | ASTベースの関数・メソッド単位の変更可視化（TS/JS先行） | 🟡 Prototype |
+| ビジネスロジックコンテキスト | GitHub Issueコンテキストのブリッジ + fallback diagnostics（Confluenceは計画中） | 🟡 Prototype |
+| AIレビュー補助 | ワークスペース内提案パネル + ヒューリスティックProvider（LLM provider adapter は計画中） | 🟡 Prototype |
 | Web review workspace v0 | Next.js 製レビューシェルとレイヤ境界、stub ナビゲーション | 🟡 Prototype |
 | レビュー進捗トラッキング | 大きなPRで迷子にならない | 🟡 Prototype |
-| プラガブル接続 | GitHub（初期実装）、GitLab・Bitbucket（プラグイン） | 🔴 計画中 |
+| プラガブル接続 | GitHub先行の契約境界 + Plugin SDK/runtime プロトタイプ | 🟡 Prototype |
 
 ## プラガブル設計
 
@@ -85,13 +85,17 @@ Locusは最初から拡張可能な設計で作られています：
 
 ## プロジェクトの現状
 
-現在のリポジトリには **実行可能な Web シェルのプロトタイプ** があります。より深い解析スライスは、引き続き設計ドキュメント主導で進めます。
+現在のリポジトリには **コアレビュー導線を通しで実行できるプロトタイプ** があります。一方で、製品化と外部統合の強化はこれから進めます。
 
 すでに動くもの:
 - Next.js App Router の Web シェル
 - `src/server/**` 配下のレイヤードサーバースケルトン
 - 選択中の change group と進捗状態を保持できる file-backed demo review session
 - 実際の PR ファイルを semantic analysis に流し込める GitHub pull request snapshot adapter
+- parser adapter 経由のセマンティック差分グルーピング（TS/JS先行）
+- live GitHub Issue context + fallback diagnostics を持つ business-context bridge
+- ヒューリスティック provider を使う AI提案パネルと採否保持
+- 将来拡張向けの Plugin SDK/runtime プロトタイプ境界
 - presentation / application 境界を通る route handler / server action
 
 すでに決まっていること:
@@ -102,7 +106,8 @@ Locusは最初から拡張可能な設計で作られています：
 
 意図的にまだ固定していないこと:
 - 解析言語ごとの長期的な parser family
-- Web シェルの後に載せる最初の semantic-diff スパイク対象言語
+- 本番品質での外部統合（Confluence/Jira、追加コードホスト）
+- 本番運用向けの LLM provider 接続とガードレール
 - MVP 検証に不要な本番インフラ詳細
 
 ### ローカル開発
@@ -192,26 +197,25 @@ npm run demo:data:reseed   # 基本ディレクトリと空のジョブキュー
 
 ## ロードマップ
 
-### MVP
-- GitHub連携
-- Web review workspace v0
-- AI自動生成アーキテクチャマップ
-- セマンティックDiff（関数・メソッド単位）
-- レビュー進捗トラッキング
+### MVP（プロトタイプトラック）
+- ✅ GitHub ingestion + review workspace フロー
+- ✅ セマンティック差分グルーピング（TS/JS先行）
+- ✅ アーキテクチャミニマップ v0
+- ✅ レビュー進捗の永続化
 
-### Phase 2
-- Confluence・GitHub Issues/Projects連携
-- ビジネスロジックコンテキストオーバーレイ
-- AIレビュー補助（全システムコンテキスト付き）
+### Phase 2（製品化・統合）
+- ⏳ Confluence など要件コンテキスト統合の拡張
+- ⏳ LLM provider adapter を使った AIレビュー補助の接続
+- ⏳ live context / analysis 運用の信頼性強化
 
-### Phase 3
-- コミュニティ拡張向けプラグインSDK
-- 追加コードホスト対応
-- UI/UXの洗練
+### Phase 3（エコシステム・運用スケール）
+- ⏳ 追加コードホストアダプタ（GitLab / Bitbucket）
+- ⏳ Plugin エコシステムのハードニング
+- ⏳ 本番移行ハードニング（migration、SLO、セキュリティ運用）
 
 ## コントリビュート
 
-Locusは現在、企画フェーズにあります。フィードバック・アイデア・議論を歓迎します。
+Locusは現在、プロトタイプフェーズにあります。フィードバック・アイデア・議論を歓迎します。
 
 - [Issue](https://github.com/duck8823/locus/issues) を開いてアイデアや問題を共有してください
 - コントリビューションガイドは [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) を参照（英語版: [CONTRIBUTING.md](CONTRIBUTING.md)）

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ With full knowledge of your system's architecture and the linked specifications,
 | Feature | Description | Status |
 |---|---|---|
 | Architecture Minimap v0 | Immediate upstream/downstream mini-map with change-group navigation | 🟡 Prototype |
-| Semantic Diff | AST-based, function-level change visualization | 🔴 Planned |
-| Business Logic Context | Confluence & GitHub Issues/Projects integration | 🔴 Planned |
-| AI Review Assistant | Context-aware review powered by LLMs | 🔴 Planned |
+| Semantic Diff | AST-based, function-level change visualization (TS/JS-first) | 🟡 Prototype |
+| Business Logic Context | GitHub issue-context bridge with fallback diagnostics (Confluence planned) | 🟡 Prototype |
+| AI Review Assistant | In-workspace suggestion panel with heuristic provider (LLM adapters planned) | 🟡 Prototype |
 | Web Review Workspace v0 | Next.js review shell with layered server boundaries and stub navigation | 🟡 Prototype |
 | Review Progress Tracking | Never lose your place in a large PR | 🟡 Prototype |
-| Pluggable Connections | GitHub (first), GitLab, Bitbucket (via plugins) | 🔴 Planned |
+| Pluggable Connections | Plugin SDK/runtime boundary with GitHub-first contracts | 🟡 Prototype |
 
 ## Pluggable by Design
 
@@ -80,13 +80,17 @@ All external integrations use OAuth, so Locus works with your existing authentic
 
 ## Project Status
 
-This repository now has a **runnable web-shell prototype**, while the deeper analysis slices remain documentation-led.
+This repository now has a **runnable end-to-end prototype** across the core review flow, while productization and external integrations remain in progress.
 
 Already runnable today:
 - a Next.js App Router web shell
 - a layered `src/server/**` backend skeleton
 - a file-backed demo review session that preserves selected change group and status
 - a GitHub pull-request snapshot adapter that can ingest real PR files into semantic analysis
+- parser-adapter based semantic grouping (TS/JS-first)
+- business-context bridge with live GitHub issue-context fetch + fallback diagnostics
+- AI suggestion panel with heuristic provider and decision persistence
+- plugin SDK/runtime prototype boundary for future code-host/context extensions
 - route handlers and server actions that exercise the presentation/application boundary
 
 What is already decided:
@@ -97,7 +101,8 @@ What is already decided:
 
 What is intentionally still open:
 - the long-term parser family per analysis language
-- which languages ship in the first semantic-diff spike after the web shell exists
+- production-ready external integrations (Confluence/Jira, additional code hosts)
+- LLM-backed suggestion providers with production safeguards
 - production infrastructure details that are unnecessary for MVP validation
 
 ### Local development
@@ -187,26 +192,25 @@ npm run demo:data:reseed   # recreate baseline directories + empty job queue
 
 ## Roadmap
 
-### MVP
-- GitHub integration
-- Web review workspace v0
-- AI-generated architecture map
-- Semantic diff (function-level)
-- Review progress tracking
+### MVP (prototype track)
+- ✅ GitHub ingestion + review workspace flow
+- ✅ Semantic change grouping (TS/JS-first)
+- ✅ Architecture minimap v0
+- ✅ Review progress persistence
 
-### Phase 2
-- Confluence & GitHub Issues/Projects integration
-- Business logic context overlay
-- AI review assistant (with full system context)
+### Phase 2 (productization & integration)
+- ⏳ Confluence / richer requirement-context integration
+- ⏳ LLM-backed AI review assistant providers
+- ⏳ Reliability hardening for live context + analysis operations
 
-### Phase 3
-- Plugin SDK for community extensions
-- Additional code host support
-- Refined UI/UX
+### Phase 3 (ecosystem & scale)
+- ⏳ Additional code host adapters (GitLab / Bitbucket)
+- ⏳ Plugin ecosystem hardening
+- ⏳ Production rollout hardening (migration, SLO, security operations)
 
 ## Contributing
 
-Locus is in the planning phase. Feedback, ideas, and discussion are very welcome.
+Locus is in the prototype phase. Feedback, ideas, and discussion are very welcome.
 
 - Open an [Issue](https://github.com/duck8823/locus/issues) to share thoughts or report problems
 - See [CONTRIBUTING.md](CONTRIBUTING.md) or [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) for contribution guidelines


### PR DESCRIPTION
## Summary
Closes #105

This docs-only PR updates `README.md` / `README.ja.md` so feature status and roadmap wording match what is already implemented in the runnable prototype.

## Motivation
The previous README tables still marked several capabilities as `Planned` even though prototype implementations are already present. This mismatch makes prioritization and onboarding harder.

By syncing documentation with current behavior, we reduce planning friction and keep contributor expectations accurate.

## Changes
- Feature status table updated in EN/JA:
  - Semantic Diff: Planned -> Prototype (TS/JS-first)
  - Business Logic Context: Planned -> Prototype (GitHub issue-context bridge + fallback)
  - AI Review Assistant: Planned -> Prototype (heuristic provider + panel)
  - Pluggable Connections: Planned -> Prototype (SDK/runtime boundary)
- Project Status section updated to reflect currently runnable prototype slices.
- Roadmap wording updated to distinguish:
  - MVP prototype track (done)
  - productization/integration work (next)
  - ecosystem/scale hardening (later)
- Contributing phase wording updated from `planning` to `prototype`.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`

---

## 日本語
### 概要
`README.md` / `README.ja.md` の機能ステータスとロードマップ表現を、現在の実装実態に合わせて更新しました（docs-only）。

### Motivation
従来のREADMEでは、すでにプロトタイプ実装済みの機能が `Planned` のまま残っており、優先順位判断やオンボーディング時に認識齟齬が起きやすい状態でした。

実装状況に合わせて文言を同期し、計画の前提を揃えることが目的です。

### 変更内容
- EN/JA両方の機能ステータステーブルを更新
- 「プロジェクトの現状」を実装済みプロトタイプに合わせて更新
- ロードマップを
  - MVP（プロトタイプ完了）
  - Phase 2（製品化・統合）
  - Phase 3（エコシステム・運用スケール）
  に再整理
- Contributing のフェーズ表記を `planning` から `prototype` に更新
