### PR TITLE
Stabilize e2e seed-workspace bootstrap retries

### DIFF
--- a/e2e/workspace-smoke.spec.ts
+++ b/e2e/workspace-smoke.spec.ts
@@ -2,6 +2,8 @@ import { execSync } from "node:child_process";
 import { test, expect, type Page } from "@playwright/test";
 
 const workspacePathPattern = /\/reviews\/demo-review$/;
+const openSeedDemoTestId = "open-seed-demo";
+const homeBootstrapMaxAttempts = 3;
 
 function reseedDemoData() {
   execSync("npm run demo:data:reseed", {
@@ -11,11 +13,29 @@ function reseedDemoData() {
 }
 
 async function openSeedWorkspace(page: Page) {
-  await page.goto("/");
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= homeBootstrapMaxAttempts; attempt += 1) {
+    try {
+      await page.goto("/", { waitUntil: "domcontentloaded" });
+      await expect(page.getByTestId(openSeedDemoTestId)).toBeVisible({ timeout: 15_000 });
+      lastError = null;
+      break;
+    } catch (error) {
+      lastError = error;
+      if (attempt < homeBootstrapMaxAttempts) {
+        await page.waitForTimeout(300 * attempt);
+      }
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+
   await page.evaluate(() => {
     window.localStorage.clear();
   });
-  await page.getByTestId("open-seed-demo").click();
+  await page.getByTestId(openSeedDemoTestId).click();
   await expect(page).toHaveURL(workspacePathPattern);
 }
 


### PR DESCRIPTION
## Summary
Closes #116

This PR hardens the Playwright seed-workspace bootstrap helper by adding bounded retries around the initial home-page navigation and CTA readiness check.

## Motivation
We occasionally observed transient timeouts at `page.goto("/")` in smoke tests. These failures are race-like and noisy, and they reduce CI signal quality.

The goal is to make the bootstrap deterministic without weakening product assertions.

## Changes
- Added bounded retry logic in `openSeedWorkspace` for home-page bootstrap
- Waits for seed CTA visibility before proceeding
- Keeps existing deterministic setup (`localStorage.clear()` + reseed flow)

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `PLAYWRIGHT_PORT=3000 npm run test:e2e`

---

## 日本語
### 概要
Issue #116 対応として、Playwright の `openSeedWorkspace` ヘルパーに初期画面遷移のリトライを追加し、seed CTA の表示確認後に遷移処理を進めるようにしました。

### Motivation
`page.goto("/")` で稀にタイムアウトが発生し、CIのノイズになっていました。

テストの本質的なアサーションを弱めずに、起動直後のレースに強くするのが目的です。

### 変更内容
- `openSeedWorkspace` に bounded retry を追加
- seed ボタン表示を確認してからクリック
- `localStorage.clear()` と reseed による決定的セットアップは維持
