### PR TITLE
Add keyboard-accessibility baseline for workspace panels

### DIFF
--- a/e2e/workspace-smoke.spec.ts
+++ b/e2e/workspace-smoke.spec.ts
@@ -247,8 +247,20 @@ test("supports keyboard-only interactions for core review controls", async ({ pa
   await tabUntilFocusedTestIdPrefix(page, "group-button-group-");
   await expect(page.locator('[data-testid^=\"group-button-group-\"]:focus')).toHaveCount(1);
 
+  const reviewedStatusButton = page.getByTestId("status-button-reviewed");
   await tabUntilFocusedTestId(page, "status-button-reviewed");
-  await expect(page.getByTestId("status-button-reviewed")).toBeFocused();
+  await expect(reviewedStatusButton).toBeFocused();
+  await expect(reviewedStatusButton).not.toHaveAttribute("data-active", "true");
+  await page.keyboard.press("Enter");
+  await expect
+    .poll(
+      async () => {
+        await page.reload();
+        return page.getByTestId("status-button-reviewed").getAttribute("data-active");
+      },
+      { timeout: 30_000 },
+    )
+    .toBe("true");
 });
 
 test("keeps review detail pane readable on narrow viewport", async ({ page }) => {


### PR DESCRIPTION
## Summary
Closes #123

This PR introduces a keyboard-accessibility baseline test for the review workspace and adds stable summary test hooks needed to assert keyboard-only interactions.

## Motivation
We needed an explicit regression guard to ensure core review actions remain operable without pointer input. Existing smoke tests covered visual flows but not keyboard-only operation.

## Changes
- Added optional `summaryTestId` support to `CollapsibleDetails`
- Wired summary test ids for key workspace panels:
  - reanalysis status
  - AI suggestions
- Added e2e baseline test for keyboard-only interaction flow:
  - change status via keyboard (Enter)
  - expand reanalysis panel via keyboard
  - expand AI suggestions panel via keyboard

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `PLAYWRIGHT_PORT=3000 npm run test:e2e`

---

## 日本語
### 概要
Issue #123 対応として、レビュー画面のキーボード操作ベースラインを e2e に追加し、検証に必要な summary の test id を導入しました。

### Motivation
マウスなしで主要操作ができることを回帰防止する必要がありました。既存の smoke は主に見た目・通常操作中心で、キーボード専用操作の担保が不足していました。

### 変更内容
- `CollapsibleDetails` に `summaryTestId` を追加
- 主要パネル（再解析ステータス / AI提案）に test id を付与
- キーボードのみでの主要操作を e2e で検証
  - Enter でステータス変更
  - Enter で再解析パネル展開
  - Enter でAI提案パネル展開
