### PR TITLE
PoC: Slint + alacritty_terminal で PTY 同居 Terminal ペイン

### DIFF
--- a/poc/terminal-pane/.gitignore
+++ b/poc/terminal-pane/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/poc/terminal-pane/Cargo.toml
+++ b/poc/terminal-pane/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "locus-poc-terminal"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+alacritty_terminal = "=0.26.0"
+portable-pty = "0.9.0"
+slint = "1.15.1"
+
+[build-dependencies]
+slint-build = "1.15.1"

--- a/poc/terminal-pane/README.md
+++ b/poc/terminal-pane/README.md
@@ -1,0 +1,18 @@
+# locus PoC — Terminal Pane
+
+Slint + alacritty_terminal + portable-pty で AI Agent CLI を同居させる Terminal ペインの実現性検証。
+
+詳細: https://github.com/duck8823/locus/issues/194
+
+## 実行
+
+```bash
+cargo run -- claude
+# 任意のコマンドを試す
+cargo run -- bash
+```
+
+## スコープ
+
+含む: PTY 起動 / セルグリッド描画 / キー入力 / リサイズ追従
+含まない: 色解決 / スクロールバック / マウス選択 / GitHub 連携

--- a/poc/terminal-pane/build.rs
+++ b/poc/terminal-pane/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    slint_build::compile("ui/app.slint").unwrap();
+}

--- a/poc/terminal-pane/src/main.rs
+++ b/poc/terminal-pane/src/main.rs
@@ -5,7 +5,7 @@
 
 use std::io::{Read, Write};
 use std::rc::Rc;
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -63,8 +63,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     cmd.env("TERM", "xterm-256color");
 
-    let _child = pair.slave.spawn_command(cmd)?;
+    let mut child = pair.slave.spawn_command(cmd)?;
     drop(pair.slave);
+
+    // 子プロセスが終了したらイベントループを抜ける
+    thread::spawn(move || {
+        let _ = child.wait();
+        let _ = slint::quit_event_loop();
+    });
 
     let mut reader = pair.master.try_clone_reader()?;
     let writer = Arc::new(Mutex::new(pair.master.take_writer()?));
@@ -75,7 +81,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let term = Arc::new(Mutex::new(Term::new(Config::default(), &size, EventProxy)));
 
-    let (byte_tx, byte_rx): (Sender<Vec<u8>>, Receiver<Vec<u8>>) = channel();
+    // bounded channel で PTY → UI のバックプレッシャを確保する
+    let (byte_tx, byte_rx): (SyncSender<Vec<u8>>, Receiver<Vec<u8>>) = sync_channel(1024);
     thread::spawn(move || {
         let mut buf = [0u8; 4096];
         loop {
@@ -104,7 +111,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let writer = writer.clone();
         ui.on_key_pressed(move |text: SharedString| {
-            let bytes = text.as_str().as_bytes().to_vec();
+            let bytes = translate_key(text.as_str());
+            if bytes.is_empty() {
+                return;
+            }
             if let Ok(mut w) = writer.lock() {
                 let _ = w.write_all(&bytes);
                 let _ = w.flush();
@@ -174,6 +184,31 @@ fn build_row(term: &Term<EventProxy>, row: usize) -> TerminalRow {
     }
     TerminalRow {
         cells: ModelRc::from(Rc::new(cells) as Rc<dyn Model<Data = TerminalCell>>),
+    }
+}
+
+/// Slint の KeyEvent.text を VT 互換のバイト列に翻訳する。
+/// Slint は矢印等の特殊キーを Private Use Area の文字で表現するため、
+/// それらを ANSI エスケープシーケンスに変換してから PTY に流す。
+fn translate_key(text: &str) -> Vec<u8> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+    match text {
+        // Arrow keys (Slint private use area → CSI sequences)
+        "\u{F700}" => b"\x1b[A".to_vec(), // Up
+        "\u{F701}" => b"\x1b[B".to_vec(), // Down
+        "\u{F702}" => b"\x1b[D".to_vec(), // Left
+        "\u{F703}" => b"\x1b[C".to_vec(), // Right
+        // Backspace / Delete → TTY erase (DEL, 0x7f)
+        "\u{8}" | "\u{7f}" => vec![0x7f],
+        // Enter → CR
+        "\n" | "\r" => b"\r".to_vec(),
+        // Tab / Escape はそのまま
+        "\t" => b"\t".to_vec(),
+        "\u{1b}" => b"\x1b".to_vec(),
+        // 通常文字は UTF-8 をそのまま流す
+        other => other.as_bytes().to_vec(),
     }
 }
 

--- a/poc/terminal-pane/src/main.rs
+++ b/poc/terminal-pane/src/main.rs
@@ -1,0 +1,188 @@
+// locus PoC: Slint + alacritty_terminal + portable-pty で AI Agent CLI を同居させる Terminal ペイン。
+//
+// 成功判定: 引数で与えたコマンド（既定 `claude`）がペイン内で起動・対話でき、
+// 出力が描画され、キー入力が PTY に流れること。
+
+use std::io::{Read, Write};
+use std::rc::Rc;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use alacritty_terminal::event::{Event, EventListener};
+use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::index::{Column, Line, Point};
+use alacritty_terminal::term::{cell::Cell, Config, Term};
+use alacritty_terminal::vte::ansi::{Processor, StdSyncHandler};
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
+
+slint::include_modules!();
+
+const COLS: u16 = 100;
+const ROWS: u16 = 30;
+
+#[derive(Clone)]
+struct EventProxy;
+impl EventListener for EventProxy {
+    fn send_event(&self, _event: Event) {}
+}
+
+#[derive(Clone, Copy)]
+struct TermSize {
+    cols: usize,
+    rows: usize,
+}
+impl Dimensions for TermSize {
+    fn columns(&self) -> usize {
+        self.cols
+    }
+    fn screen_lines(&self) -> usize {
+        self.rows
+    }
+    fn total_lines(&self) -> usize {
+        self.rows
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cmd_name = std::env::args().nth(1).unwrap_or_else(|| "claude".to_string());
+
+    let pty_system = native_pty_system();
+    let pair = pty_system.openpty(PtySize {
+        rows: ROWS,
+        cols: COLS,
+        pixel_width: 0,
+        pixel_height: 0,
+    })?;
+
+    let mut cmd = CommandBuilder::new(&cmd_name);
+    if let Ok(cwd) = std::env::current_dir() {
+        cmd.cwd(cwd);
+    }
+    cmd.env("TERM", "xterm-256color");
+
+    let _child = pair.slave.spawn_command(cmd)?;
+    drop(pair.slave);
+
+    let mut reader = pair.master.try_clone_reader()?;
+    let writer = Arc::new(Mutex::new(pair.master.take_writer()?));
+
+    let size = TermSize {
+        cols: COLS as usize,
+        rows: ROWS as usize,
+    };
+    let term = Arc::new(Mutex::new(Term::new(Config::default(), &size, EventProxy)));
+
+    let (byte_tx, byte_rx): (Sender<Vec<u8>>, Receiver<Vec<u8>>) = channel();
+    thread::spawn(move || {
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if byte_tx.send(buf[..n].to_vec()).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let ui = AppWindow::new()?;
+    ui.set_cols(COLS as i32);
+    ui.set_visible_rows(ROWS as i32);
+
+    let row_model = Rc::new(VecModel::<TerminalRow>::default());
+    for _ in 0..ROWS {
+        row_model.push(empty_row());
+    }
+    ui.set_rows(ModelRc::from(row_model.clone()));
+
+    {
+        let writer = writer.clone();
+        ui.on_key_pressed(move |text: SharedString| {
+            let bytes = text.as_str().as_bytes().to_vec();
+            if let Ok(mut w) = writer.lock() {
+                let _ = w.write_all(&bytes);
+                let _ = w.flush();
+            }
+        });
+    }
+
+    let processor = Arc::new(Mutex::new(Processor::<StdSyncHandler>::new()));
+    let term_for_timer = term.clone();
+    let processor_for_timer = processor.clone();
+    let row_model_for_timer = row_model.clone();
+    let ui_weak = ui.as_weak();
+    let timer = slint::Timer::default();
+    timer.start(
+        slint::TimerMode::Repeated,
+        Duration::from_millis(16),
+        move || {
+            let mut updated = false;
+            while let Ok(bytes) = byte_rx.try_recv() {
+                let mut term_guard = term_for_timer.lock().unwrap();
+                let mut proc_guard = processor_for_timer.lock().unwrap();
+                proc_guard.advance(&mut *term_guard, &bytes);
+                updated = true;
+            }
+            if !updated {
+                return;
+            }
+            let term_guard = term_for_timer.lock().unwrap();
+            let cursor = term_guard.grid().cursor.point;
+            for r in 0..ROWS as usize {
+                let row = build_row(&term_guard, r);
+                row_model_for_timer.set_row_data(r, row);
+            }
+            if let Some(ui) = ui_weak.upgrade() {
+                ui.set_cursor_col(cursor.column.0 as i32);
+                ui.set_cursor_row(cursor.line.0 as i32);
+            }
+        },
+    );
+
+    ui.run()?;
+    Ok(())
+}
+
+fn empty_row() -> TerminalRow {
+    let cells = VecModel::<TerminalCell>::default();
+    for _ in 0..COLS {
+        cells.push(TerminalCell {
+            ch: SharedString::from(" "),
+            fg: slint::Color::from_rgb_u8(0xee, 0xee, 0xee),
+            bg: slint::Color::from_rgb_u8(0x0b, 0x0b, 0x0b),
+        });
+    }
+    TerminalRow {
+        cells: ModelRc::from(Rc::new(cells) as Rc<dyn Model<Data = TerminalCell>>),
+    }
+}
+
+fn build_row(term: &Term<EventProxy>, row: usize) -> TerminalRow {
+    let cells = VecModel::<TerminalCell>::default();
+    let grid = term.grid();
+    let line = Line(row as i32);
+    for col in 0..COLS as usize {
+        let point = Point::new(line, Column(col));
+        let cell = &grid[point];
+        cells.push(make_cell(cell));
+    }
+    TerminalRow {
+        cells: ModelRc::from(Rc::new(cells) as Rc<dyn Model<Data = TerminalCell>>),
+    }
+}
+
+fn make_cell(cell: &Cell) -> TerminalCell {
+    let mut s = [0u8; 4];
+    let ch: &str = cell.c.encode_utf8(&mut s);
+    TerminalCell {
+        ch: SharedString::from(&*ch),
+        fg: slint::Color::from_rgb_u8(0xee, 0xee, 0xee),
+        bg: slint::Color::from_rgb_u8(0x0b, 0x0b, 0x0b),
+    }
+}

--- a/poc/terminal-pane/ui/app.slint
+++ b/poc/terminal-pane/ui/app.slint
@@ -1,0 +1,78 @@
+import { VerticalBox } from "std-widgets.slint";
+
+export struct TerminalCell {
+    ch: string,
+    fg: color,
+    bg: color,
+}
+
+export struct TerminalRow {
+    cells: [TerminalCell],
+}
+
+export component AppWindow inherits Window {
+    in property <[TerminalRow]> rows;
+    in property <int> cols: 80;
+    in property <int> visible-rows: 24;
+    in property <length> cell-w: 9px;
+    in property <length> cell-h: 18px;
+    in property <int> cursor-col: 0;
+    in property <int> cursor-row: 0;
+
+    callback key-pressed(string);
+    callback resized(length, length);
+
+    title: "locus PoC — Terminal Pane";
+    preferred-width: 900px;
+    preferred-height: 540px;
+    background: #0b0b0b;
+
+    forward-focus: focus-area;
+
+    focus-area := FocusScope {
+        key-pressed(event) => {
+            root.key-pressed(event.text);
+            accept
+        }
+
+        Rectangle {
+            background: #0b0b0b;
+
+            // セルグリッドを行ごとに重ねる
+            for row[ri] in root.rows: Rectangle {
+                x: 0;
+                y: ri * root.cell-h;
+                height: root.cell-h;
+                width: parent.width;
+
+                for cell[ci] in row.cells: Rectangle {
+                    x: ci * root.cell-w;
+                    y: 0;
+                    width: root.cell-w;
+                    height: root.cell-h;
+                    background: cell.bg;
+
+                    Text {
+                        text: cell.ch;
+                        color: cell.fg;
+                        font-family: "Menlo";
+                        font-size: 13px;
+                        horizontal-alignment: left;
+                        vertical-alignment: center;
+                    }
+                }
+            }
+
+            // カーソル
+            Rectangle {
+                x: root.cursor-col * root.cell-w;
+                y: root.cursor-row * root.cell-h;
+                width: root.cell-w;
+                height: root.cell-h;
+                background: #ffffff40;
+                border-width: 1px;
+                border-color: #ffffff;
+            }
+        }
+    }
+}

--- a/poc/terminal-pane/ui/app.slint
+++ b/poc/terminal-pane/ui/app.slint
@@ -55,7 +55,7 @@ export component AppWindow inherits Window {
                     Text {
                         text: cell.ch;
                         color: cell.fg;
-                        font-family: "Menlo";
+                        font-family: "Menlo, Consolas, monospace";
                         font-size: 13px;
                         horizontal-alignment: left;
                         vertical-alignment: center;


### PR DESCRIPTION
## Summary

- Rust + Slint ネイティブへの作り直し (#195, #196) に向けた最大の技術的未知数を PoC で検証
- `poc/terminal-pane/` 配下に独立した Cargo プロジェクトを追加
- Slint の FocusScope + セルグリッド描画 + `portable-pty` + `alacritty_terminal` で、任意のコマンドをペイン内に同居させる構成が成立することを確認

Closes #194（検証完了後）

## 分割

1. chore(poc): cargo プロジェクト骨組み（`alacritty_terminal` はバージョン固定）
2. feat(poc): Slint UI スケルトン（セルグリッド + カーソル + FocusScope）
3. feat(poc): PTY + alacritty_terminal を Slint モデルに繋ぎ込み

## スコープ外（PoC 範囲）

- 色解決・スクロールバック・マウス選択
- リサイズ追従
- Codex / Gemini 対応（まずは動作確認のみ）
- PR 一覧・diff・tree-sitter 連携（本体作り直し #196 で実施）

## Test plan

- [x] `cargo build` が通る
- [x] `cargo run -- bash` でウィンドウが開き、ペイン内でシェルが動く（ローカル確認済み）
- [ ] `cargo run -- claude` で Claude Code TUI が描画される（後続で確認）
- [ ] リサイズ時の winsize 追従（#196 で対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)