### PR TITLE
docs(adr): pivot to Rust/Slint native (ADR 0005) and supersede 0002/0003

### DIFF
--- a/docs/adr/0002-web-first-nextjs-typescript.ja.md
+++ b/docs/adr/0002-web-first-nextjs-typescript.ja.md
@@ -2,8 +2,11 @@
 
 > English: [0002-web-first-nextjs-typescript.md](0002-web-first-nextjs-typescript.md)
 
-- Status: Accepted
+- Status: Superseded by [ADR 0005](0005-rust-slint-native-rewrite.ja.md)
 - Date: 2026-03-07
+- Superseded: 2026-04-15
+
+> **Superseded.** 本 ADR は当初プロトタイプの Next.js + TypeScript web-first 方針を記録したものです。ADR 0005 により Rust + Slint ネイティブアプリへ転換しました。以下の決定は歴史参照として残していますが、新規の作業を拘束しません。
 
 ## Context
 

--- a/docs/adr/0002-web-first-nextjs-typescript.md
+++ b/docs/adr/0002-web-first-nextjs-typescript.md
@@ -2,8 +2,11 @@
 
 > 日本語: [0002-web-first-nextjs-typescript.ja.md](0002-web-first-nextjs-typescript.ja.md)
 
-- Status: Accepted
+- Status: Superseded by [ADR 0005](0005-rust-slint-native-rewrite.md)
 - Date: 2026-03-07
+- Superseded: 2026-04-15
+
+> **Superseded.** This ADR records the Next.js + TypeScript web-first direction that governed the original prototype. ADR 0005 pivots the product to a Rust + Slint native application. The decisions below are retained for historical context only; they no longer constrain new work.
 
 ## Context
 

--- a/docs/adr/0003-layered-server-architecture.ja.md
+++ b/docs/adr/0003-layered-server-architecture.ja.md
@@ -2,8 +2,11 @@
 
 > English: [0003-layered-server-architecture.md](0003-layered-server-architecture.md)
 
-- Status: Accepted
+- Status: Superseded by [ADR 0005](0005-rust-slint-native-rewrite.ja.md)
 - Date: 2026-03-07
+- Superseded: 2026-04-15
+
+> **Superseded.** 本 ADR は Next.js web プロトタイプのサーバー側レイヤリングを記述したものです。Rust + Slint ネイティブ版は Web サーバーを持たない別の実行モデルであり、ADR 0005 に従います。以下のレイヤ責務の原則は Rust 版のモジュール構成を考える際の参考にはなり得ますが、新規作業を規範的には拘束しません。
 
 ## Context
 

--- a/docs/adr/0003-layered-server-architecture.md
+++ b/docs/adr/0003-layered-server-architecture.md
@@ -2,8 +2,11 @@
 
 > 日本語: [0003-layered-server-architecture.ja.md](0003-layered-server-architecture.ja.md)
 
-- Status: Accepted
+- Status: Superseded by [ADR 0005](0005-rust-slint-native-rewrite.md)
 - Date: 2026-03-07
+- Superseded: 2026-04-15
+
+> **Superseded.** This ADR describes the server-side layering inside the Next.js web prototype. The Rust + Slint native application has a different execution model (no web server) and is governed by ADR 0005. The layer-ownership principles below may still inform the Rust module layout, but this ADR no longer normatively constrains new work.
 
 ## Context
 

--- a/docs/adr/0005-rust-slint-native-rewrite.ja.md
+++ b/docs/adr/0005-rust-slint-native-rewrite.ja.md
@@ -1,0 +1,102 @@
+# ADR 0005: Locus を Rust + Slint ネイティブアプリに作り直し、AI 連携は内蔵 Terminal ペインに委譲する
+
+> English: [0005-rust-slint-native-rewrite.md](0005-rust-slint-native-rewrite.md)
+
+- Status: Accepted
+- Date: 2026-04-15
+
+## Context
+
+当初の Locus プロトタイプ（ADR 0002、ADR 0003）は Web SaaS 形態を前提に、Next.js + TypeScript の上に layered server を同居させる構成でした。その形態のために以下の装備が必要でした。
+
+- guardrail / prompt version / コスト見積もり付きの LLM provider adapter
+- OAuth トークン暗号化と接続遷移監査
+- リトライと stale-running 検知付きの耐久分析ジョブキュー
+- capability policy 付きの Plugin SDK
+- マルチコードホスト adapter（GitHub / GitLab / 将来の Bitbucket）
+
+しかし実際の使われ方は **「AI Agent CLI と同居する個人用ローカル Viewer」** に収束しました。ユーザーの手元ではすでに Claude Code / Codex / Gemini がターミナルで動いています。Locus 側で LLM provider に認証し、プロンプトテンプレートを管理し、コスト上限を設けて監査ログを永続化する必要はありません。選んだ Agent CLI 側がすべて持っていますし、Locus 内部の adapter 層よりも速く進化します。
+
+SaaS 向けの重装備は、得られる価値に見合わないコストに変わってしまいました。
+
+加えて、プロトタイプでのセマンティック diff 実装経験から技術面での 2 つの嗜好が明確になりました。
+
+1. **`tree-sitter` が多言語セマンティック diff の正解**。TypeScript 側の `tree-sitter` バインディングは動いたものの、Rust ネイティブの `tree-sitter` エコシステムの方が直接的で、対象言語（Go、TypeScript、Rust、Python、Dart、GDScript 等）を広くカバーしています。
+2. **AI Agent との受け渡しは HTTP ではなく PTY が本質**。Locus の価値は「整形済みプロンプト（ファイル・行・diff 断片・コメント）を組み立て、ユーザーが使っている Agent に渡すこと」にあります。Web アプリ内部でネットワーク境界を介して仲介するのは、レイテンシと設定項目が増えるだけで得るものがありません。
+
+## Decision
+
+Locus を **Rust + Slint ネイティブアプリ**として作り直し、初期は **macOS** を対象とします。以下の設計コミットメントに従います。
+
+### 1. 形態
+
+- Rust + Slint バイナリをデスクトップアプリとして配布
+- macOS 優先。Linux / Windows は最初のリリースでは明示的に対象外
+- アプリ内 Web サーバーなし、HTTP 認証なし、既定で永続化 DB なし
+
+### 2. AI 連携を Terminal ペインに委譲する
+
+- Locus は **LLM を自前で呼ばない**
+- Slint 内蔵の Terminal ペイン（`alacritty_terminal` + `portable-pty`）で Agent CLI を子プロセスとして起動する（Claude Code / Codex / Gemini をユーザーが選択）
+- Viewer は PR・diff・コメント選択から整形済みプロンプトを組み立て、**PTY に書き込む**だけ
+- 認証・プロバイダ選択・コスト管理・レート制限・会話履歴・レビュー記憶はすべて Agent CLI 側にある
+- 本方針を支える PoC は [#197](https://github.com/duck8823/locus/pull/197) で合流し、[#198](https://github.com/duck8823/locus/pull/198) でリポジトリ root に昇格した
+
+### 3. セマンティック diff は `tree-sitter` で
+
+- 最初の対象言語: **Go**（`tree-sitter-go` は公式・高品質）
+- [ADR 0004](0004-semantic-change-ir.ja.md) の parser-adapter + 共通 Semantic Change IR 境界は維持する。移動するのは具体 adapter 実装のみ（TypeScript → Rust）
+- 新しい言語は同じ IR 境界の裏側に `tree-sitter-*` crate を差し替えるだけで追加できる
+
+### 4. 明示的に捨てるもの
+
+- LLM provider adapter 層（heuristic / `openai_compat` / guardrail / prompt template）
+- AI suggestion の監査・redaction policy・永続化
+- 耐久分析ジョブキューとリトライポリシー
+- OAuth トークン暗号化、接続遷移監査、OAuth start / callback フロー
+- Plugin SDK と capability policy
+- GitLab / Bitbucket コードホスト adapter
+- マーケティングページ、サインインフロー、SaaS オンボーディング導線
+
+いずれも SaaS 形態では本当に意味のあった装備ですが、「Agent CLI と同居するローカル Viewer」という現実には合わず、保守予算を消費するだけになっていました。
+
+### 5. 明示的に残すもの
+
+- **プロダクトの芯**: アーキテクチャマップ + セマンティック diff + ビジネスロジックコンテキスト + 「確認」ではなく「理解」
+- [ADR 0001](0001-prototype-first-mvp.ja.md) prototype-first な進め方
+- [ADR 0004](0004-semantic-change-ir.ja.md) parser-adapter + Semantic Change IR 境界（実装は移るが抽象は動かない）
+- `docs/architecture/semantic-analysis-pipeline.*` にまとめた思想
+
+## Consequences
+
+### ポジティブ
+
+- SaaS インフラの大半が消え、長期保守コストが大幅に下がる
+- Rust の `tree-sitter` はセマンティック diff と直接的に噛み合う
+- PTY 経由の Agent 委譲により、Claude Code / Codex / Gemini の改善をそのまま享受できる
+- ローカル完結なので OAuth トークンストレージ・暗号鍵・監査保存期間・プロバイダレート制限の政治から完全に解放される
+- `tree-sitter-go` に絞ることで、実在する Go プロジェクト（ユーザー自身のもの）でセマンティック diff UX を検証してから言語を広げられる
+
+### ネガティブ
+
+- ホスト型マルチユーザーレビューの可能性は、もう一度作り直さない限り放棄する
+- コントリビューターは Rust + Slint の知識が必要になる。TypeScript + Next.js 時代の貢献者がそのまま移行できるわけではない
+- macOS 優先のため、Linux / Windows ユーザーは最初のリリースでは一切使えない
+- ターミナルエミュレータ（`alacritty_terminal`）の埋め込みは難度が高く、ANSI / キーボード / リサイズ / フォーカスなど継続的な保守源になる
+- アプリ内 LLM 体験を *好む* ユーザー層は他ツールに譲ることになる
+
+### 可逆性
+
+- この作り直しは形態の hard fork であってプロダクトアイデアの hard fork ではない。判断が誤りだった場合、Next.js プロトタイプは `legacy/nextjs` ブランチ（force push / 削除保護済み）から再開できる
+- `tree-sitter` + Semantic Change IR 境界はホスト言語非依存なので、将来再度ホスト言語を変える場合でも parser 戦略を考え直す必要はない
+
+## 他 ADR との関係
+
+- [ADR 0001 — Prototype-first MVP](0001-prototype-first-mvp.ja.md): 有効。本 ADR 自体が prototype-first な動きである（「PTY 経由の Agent 委譲が正しい受け渡しか」を SaaS より安くローカルバイナリで検証する）
+- [ADR 0002 — Web-first + Next.js](0002-web-first-nextjs-typescript.ja.md): 本 ADR により **superseded**
+- [ADR 0003 — Layered server architecture](0003-layered-server-architecture.ja.md): 本 ADR により **superseded**。レイヤ責務の原則は Rust 版のモジュール構成を考える際の参考にはなり得るが、新規作業を規範的には拘束しない
+- [ADR 0004 — Parser-adapter + Semantic Change IR](0004-semantic-change-ir.ja.md): 有効。変わるのは具体 adapter 実装のみ
+
+## 備考
+
+本 ADR は、PoC (#197) と Next.js 資産削除 (#198) がすでに `main` に合流した後に遡及的に記述しました。それらの PR を規範的にゲートするためではなく、その PR 群が従った決定を記録するためのものです。

--- a/docs/adr/0005-rust-slint-native-rewrite.md
+++ b/docs/adr/0005-rust-slint-native-rewrite.md
@@ -1,0 +1,102 @@
+# ADR 0005: Rewrite Locus as a Rust + Slint native application, with AI delegated to an embedded terminal pane
+
+> 日本語: [0005-rust-slint-native-rewrite.ja.md](0005-rust-slint-native-rewrite.ja.md)
+
+- Status: Accepted
+- Date: 2026-04-15
+
+## Context
+
+The original Locus prototype (ADR 0002, ADR 0003) pursued a Web SaaS form factor built on Next.js + TypeScript with a layered server inside the web app. That form factor pulled in considerable infrastructure:
+
+- LLM provider adapters with guardrails, prompt versioning, and cost estimation
+- OAuth token encryption and connection transition audit trails
+- A durable analysis job queue with retries and stale-running detection
+- A plugin SDK with capability policy enforcement
+- Multi-code-host adapters (GitHub, GitLab, eventual Bitbucket)
+
+In practice, the realistic usage pattern has collapsed to **"a personal, local reviewer that sits next to an AI agent CLI"**. Users already have Claude Code / Codex / Gemini running in their terminal. They do not need Locus to authenticate to LLM providers, manage prompt templates, enforce cost caps, or persist audit logs — the agent CLI of their choice already does all of that, and will continue to evolve faster than a Locus-internal adapter layer can keep up.
+
+The SaaS-grade machinery has become cost without benefit.
+
+Separately, prototype experience with semantic diff made two technical preferences clear:
+
+1. **`tree-sitter` is the right parser ecosystem** for multi-language semantic diff. The TypeScript-side `tree-sitter` bindings worked, but the Rust-native `tree-sitter` ecosystem is more direct and broadly covers our target languages (Go, TypeScript, Rust, Python, Dart, GDScript, …).
+2. **The AI agent handoff is fundamentally a PTY handoff**, not an HTTP handoff. The value of Locus is composing structured prompts (file, line, diff slice, comment) and handing them to whichever agent the user is running; trying to mediate that over a network boundary inside a web app adds latency and configuration surface for no gain.
+
+## Decision
+
+Rewrite Locus as a **Rust + Slint native application** targeting **macOS** initially, with the following design commitments:
+
+### 1. Form factor
+
+- Rust + Slint binary, distributed as a desktop application
+- macOS-first; Linux/Windows are explicit non-goals for the first release
+- No in-application web server, no HTTP authentication, no persistent database by default
+
+### 2. AI delegation via an embedded terminal pane
+
+- Locus **does not call LLMs itself**
+- A Slint-hosted Terminal pane (`alacritty_terminal` + `portable-pty`) runs an agent CLI as a child process — Claude Code, Codex, or Gemini, user-selectable
+- The Viewer composes structured prompts from the PR / diff / comment selection and **writes them into the PTY**
+- Authentication, provider choice, cost control, rate limiting, conversation history, and review memory all live in the agent CLI, not in Locus
+- The PoC validating this design shipped in [#197](https://github.com/duck8823/locus/pull/197) and was promoted to the repository root in [#198](https://github.com/duck8823/locus/pull/198)
+
+### 3. Semantic diff via `tree-sitter`
+
+- First target language: **Go** (`tree-sitter-go` is official and high-quality)
+- The parser-adapter + common Semantic Change IR boundary from [ADR 0004](0004-semantic-change-ir.md) is carried over intact; only the concrete adapter implementations move from TypeScript to Rust
+- New languages are added by swapping in additional `tree-sitter-*` crates behind the same IR boundary
+
+### 4. What is explicitly dropped
+
+- LLM provider adapter layer (heuristic, `openai_compat`, guardrailed, prompt templates)
+- AI suggestion audit / redaction policy and persistence
+- Durable analysis job queue and retry policy
+- OAuth token encryption, connection transition audit, OAuth start/callback flows
+- Plugin SDK and capability policy
+- GitLab / Bitbucket code-host adapters
+- Web marketing page, sign-in flow, and SaaS onboarding surfaces
+
+These capabilities were genuinely useful to the SaaS form factor, but each one cost maintenance budget without serving the "local reviewer next to an agent CLI" reality.
+
+### 5. What is explicitly kept
+
+- The **core product idea**: architecture map + semantic diff + business-logic context + "understanding over checking"
+- [ADR 0001](0001-prototype-first-mvp.md) prototype-first delivery posture
+- [ADR 0004](0004-semantic-change-ir.md) parser-adapter + Semantic Change IR boundary (implementation moves, abstraction does not)
+- The thinking captured in `docs/architecture/semantic-analysis-pipeline.*`
+
+## Consequences
+
+### Positive
+
+- The bulk of the SaaS infrastructure disappears, cutting long-term maintenance cost dramatically
+- `tree-sitter` in Rust is a more direct fit for semantic diff than wrestling with TypeScript parser bindings
+- Agent delegation via PTY means Locus inherits every improvement in Claude Code / Codex / Gemini automatically, for free
+- Local-first removes the need to ever touch OAuth token storage, encryption keys, audit retention, or provider rate-limit politics
+- A `tree-sitter-go` first focus lets us validate the semantic-diff UX on real code (the user's own Go projects) before spending time on parser breadth
+
+### Negative
+
+- We give up the possibility of a hosted, multi-user review surface without a second rewrite
+- Contributors need Rust + Slint familiarity; the prior contributor base (TypeScript + Next.js) cannot transfer trivially
+- macOS-first means Linux/Windows users cannot use Locus at all in the first release
+- Embedding a terminal emulator (`alacritty_terminal`) is non-trivial and a real source of ongoing maintenance (ANSI, keyboard handling, resize, focus)
+- Some users may *prefer* an in-app LLM experience; we're explicitly ceding that segment to other tools
+
+### Reversibility
+
+- The rewrite is a hard fork of the form factor, not of the product idea. If the decision proves wrong, the Next.js prototype is preserved on the `legacy/nextjs` branch (force-push / delete protected) and can be resumed
+- The `tree-sitter` + Semantic Change IR boundary is implementation-language-agnostic; switching host language again later would not require re-thinking the parser strategy
+
+## Relationship to other ADRs
+
+- [ADR 0001 — Prototype-first MVP](0001-prototype-first-mvp.md): still in force. This ADR is itself a prototype-first move — it is cheaper to validate "PTY-hosted agent is the correct handoff" in a local binary than in a SaaS
+- [ADR 0002 — Web-first + Next.js](0002-web-first-nextjs-typescript.md): **superseded** by this ADR
+- [ADR 0003 — Layered server architecture](0003-layered-server-architecture.md): **superseded** by this ADR. The layered-ownership principles may still inform Rust module layout but are no longer normative
+- [ADR 0004 — Parser-adapter + Semantic Change IR](0004-semantic-change-ir.md): still in force. Only the concrete adapter implementations change
+
+## Notes
+
+This ADR was retroactively written after the PoC (#197) and the Next.js asset removal (#198) had already landed on `main`. It records the decision that those PRs executed against, rather than gating them.


### PR DESCRIPTION
## Summary / 概要

- ADR 0005: Locus を Rust + Slint ネイティブアプリに作り直し、AI 連携を内蔵 Terminal ペインに委譲する方針を明文化
- ADR 0002 (web-first + Next.js) と ADR 0003 (layered server architecture) を superseded としてマーク

Closes #195

## Motivation / モチベーション

PoC (#197) と Next.js 資産削除 (#198) はすでに merge 済みで \`main\` は Rust + Slint 化している。方針転換の背景と決定内容を ADR として遡及的に残し、過去の ADR 0002 / 0003 との関係を整理しておく。

## Scope / スコープ

**In scope:**
- \`docs/adr/0005-rust-slint-native-rewrite.{md,ja.md}\` の新規追加
- \`docs/adr/0002-*.{md,ja.md}\` の Status を Superseded by ADR 0005 に変更
- \`docs/adr/0003-*.{md,ja.md}\` の Status を Superseded by ADR 0005 に変更

**Out of scope:**
- コードの変更は一切なし
- ADR 0001 (prototype-first) / 0004 (semantic-change-ir) は有効。触らない
- 残存 docs/architecture, docs/operations 等の書き直し

## ADR 0005 の骨子

- 形態: Rust + Slint バイナリ、macOS 優先
- AI 連携: 内蔵しない。\`alacritty_terminal\` + \`portable-pty\` の Terminal ペインで Claude Code / Codex / Gemini を同居させ、Viewer は整形済みプロンプトを PTY に書き込むだけ
- セマンティック diff: tree-sitter。最初の対象言語は Go
- 捨てるもの: LLM provider adapter / OAuth / 耐久ジョブキュー / Plugin SDK / GitLab/Bitbucket adapter 等
- 残すもの: ADR 0001, 0004、プロダクトの芯（architecture map + semantic diff + business context）

## Validation / 検証

- [x] 壊れリンクなし（ADR 内の相互リンクはすべて実在ファイル指す）
- [x] ADR 0001 / 0004 へのリンクが生きていることを確認
- [x] Status 変更が英日両方で揃っている

## AI Review Loop / AI レビューループ

- [ ] Gemini scout (next)
- [ ] Codex verifier (next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)