### PR TITLE
core(#200): add ReviewTarget / SourceSnapshot / Draft types + split main.rs into modules

### DIFF
--- a/.ai/spec/200.md
+++ b/.ai/spec/200.md
@@ -1,0 +1,167 @@
+# Spec: #200 core contracts + module boundaries
+
+## 目的
+
+`src/main.rs` べた書きの状態から、v0.1 以降の実装に耐える型とモジュール境界を先に用意する。**既存の terminal pane の挙動は一切変えない** 純粋な refactor + 型追加。
+
+## モジュール構成
+
+```
+src/
+  main.rs            — composition root のみ。PTY 起動と UI 起動の配線
+  terminal/
+    mod.rs           — 既存の PTY + alacritty_terminal + キー入力 translate
+  github/
+    mod.rs           — 空モジュール (IssueContextProvider trait の置き場にもなる)
+  review/
+    mod.rs           — サブモジュールの re-export
+    target.rs        — ReviewTarget enum
+    snapshot.rs      — SourceSnapshot struct + UnsupportedFile
+    diff.rs          — FileDiff / Hunk / DiffLine / LineKind
+    selection.rs     — SelectionAnchor / Granularity
+    draft.rs         — PromptDraft / DraftEntry / SendMode
+  ui_state/
+    mod.rs           — Slint モデル (TerminalCell, TerminalRow) ビルダ
+```
+
+## 型の骨子
+
+### review::target
+
+```rust
+pub enum ReviewTarget {
+    GitHubPr { owner: String, repo: String, pr_number: u64 },
+    LocalCompare { repo_path: PathBuf, base_ref: String, head_ref: String },
+    WorkingTree { repo_path: PathBuf, base_ref: String },
+}
+```
+
+### review::snapshot
+
+```rust
+pub struct SourceSnapshot {
+    pub file_id: FileId,      // before/after で stable
+    pub file_path: String,
+    pub language: Option<String>,
+    pub revision: Revision,   // Before / After
+    pub content: String,
+}
+
+pub enum Revision { Before, After }
+
+pub struct FileId(pub String);
+
+pub enum UnsupportedFile {
+    Binary { file_id: FileId, file_path: String },
+    PatchMissing { file_id: FileId, file_path: String, reason: String },
+    ParserFailed { file_id: FileId, file_path: String, detail: String },
+}
+```
+
+### review::diff
+
+```rust
+pub struct FileDiff {
+    pub file_id: FileId,
+    pub file_path: String,
+    pub hunks: Vec<Hunk>,
+}
+
+pub struct Hunk {
+    pub old_start: u32,
+    pub old_len: u32,
+    pub new_start: u32,
+    pub new_len: u32,
+    pub lines: Vec<DiffLine>,
+}
+
+pub struct DiffLine {
+    pub kind: LineKind,
+    pub old_line_no: Option<u32>,
+    pub new_line_no: Option<u32>,
+    pub content: String,
+}
+
+pub enum LineKind { Context, Added, Removed }
+```
+
+### review::selection
+
+```rust
+pub struct SelectionAnchor {
+    pub file_id: FileId,
+    pub file_path: String,
+    pub granularity: Granularity,
+}
+
+pub enum Granularity {
+    File,
+    Hunk { hunk_index: usize },
+    Range { start_line: u32, end_line: u32, side: Side },
+    Line { line: u32, side: Side },
+}
+
+pub enum Side { Before, After }
+```
+
+### review::draft
+
+```rust
+pub struct PromptDraft {
+    pub entries: Vec<DraftEntry>,
+}
+
+pub struct DraftEntry {
+    pub anchor: SelectionAnchor,
+    pub note: Option<String>,
+}
+
+pub enum SendMode { InsertOnly, InsertAndSend, CopyToClipboard }
+
+impl PromptDraft {
+    pub fn new() -> Self { ... }
+    pub fn push(&mut self, entry: DraftEntry) { ... }
+    pub fn remove(&mut self, index: usize) -> Option<DraftEntry> { ... }
+    pub fn is_empty(&self) -> bool { ... }
+    pub fn len(&self) -> usize { ... }
+}
+```
+
+## terminal::mod.rs
+
+現在 `main.rs` にある以下を切り出し:
+- `EventProxy`, `TermSize`, `translate_key`
+- `spawn_pty_and_term` 相当の関数: 子プロセス起動 → PTY → Term → byte channel → Timer 更新クロージャをまとめて組み立てる
+- `main.rs` からは `terminal::launch(&ui, cmd_name)` のように1関数呼び出しで済む形にする
+
+## ui_state::mod.rs
+
+現在 `main.rs` にある以下を切り出し:
+- `empty_row`, `build_row`, `make_cell`
+- `TerminalRow` / `TerminalCell` 詰め替え関数
+
+## main.rs
+
+composition root のみ。argv パース → `terminal::launch(&ui, cmd_name)` → `ui.run()`.
+
+## テスト
+
+- `review::draft` の push/remove/is_empty/len 動作テスト
+- `review::diff::LineKind` の Display or 分類に対する軽いユニットテスト
+- `review::selection::SelectionAnchor` のコンストラクトテスト
+
+これら型は現時点で UI や I/O を持たないので純粋関数テストが書ける。
+
+## 非スコープ
+
+- octocrab 呼び出し実装
+- diff 描画 / 選択 UI
+- PTY への prompt 送信
+- parser adapter 契約（#205）
+
+## 検証
+
+- `cargo build`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test`
+- `cargo run -- bash` が引き続きウィンドウを開く（手動確認、自動化なし）

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -1,0 +1,8 @@
+#![allow(dead_code)]
+
+//! GitHub 連携のための境界モジュール。
+//!
+//! v0.1 (#200) の段階では空。次 Issue (#201) で octocrab ラッパと
+//! `IssueContextProvider` trait を追加する。意図的に先にモジュールだけ
+//! 切っておき、main.rs が依存関係の変更なしに次の変更を受け入れられる
+//! ようにしておく。

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,223 +1,23 @@
-// locus PoC: Slint + alacritty_terminal + portable-pty で AI Agent CLI を同居させる Terminal ペイン。
-//
-// 成功判定: 引数で与えたコマンド（既定 `claude`）がペイン内で起動・対話でき、
-// 出力が描画され、キー入力が PTY に流れること。
+//! locus composition root.
+//!
+//! UI / PTY / ドメイン型はそれぞれ子モジュールに切り出してあり、main はそれを
+//! 配線するだけに徹する。v0.1 では Terminal ペインのみ起動するが、以降の
+//! Issue で diff viewer と PR サイドバーが追加される予定。
 
-use std::io::{Read, Write};
-use std::rc::Rc;
-use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::time::Duration;
-
-use alacritty_terminal::event::{Event, EventListener};
-use alacritty_terminal::grid::Dimensions;
-use alacritty_terminal::index::{Column, Line, Point};
-use alacritty_terminal::term::{cell::Cell, Config, Term};
-use alacritty_terminal::vte::ansi::{Processor, StdSyncHandler};
-use portable_pty::{native_pty_system, CommandBuilder, PtySize};
-use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
+use slint::ComponentHandle;
 
 slint::include_modules!();
 
-const COLS: u16 = 100;
-const ROWS: u16 = 30;
-
-#[derive(Clone)]
-struct EventProxy;
-impl EventListener for EventProxy {
-    fn send_event(&self, _event: Event) {}
-}
-
-#[derive(Clone, Copy)]
-struct TermSize {
-    cols: usize,
-    rows: usize,
-}
-impl Dimensions for TermSize {
-    fn columns(&self) -> usize {
-        self.cols
-    }
-    fn screen_lines(&self) -> usize {
-        self.rows
-    }
-    fn total_lines(&self) -> usize {
-        self.rows
-    }
-}
+mod github;
+mod review;
+mod terminal;
+mod ui_state;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cmd_name = std::env::args().nth(1).unwrap_or_else(|| "claude".to_string());
 
-    let pty_system = native_pty_system();
-    let pair = pty_system.openpty(PtySize {
-        rows: ROWS,
-        cols: COLS,
-        pixel_width: 0,
-        pixel_height: 0,
-    })?;
-
-    let mut cmd = CommandBuilder::new(&cmd_name);
-    if let Ok(cwd) = std::env::current_dir() {
-        cmd.cwd(cwd);
-    }
-    cmd.env("TERM", "xterm-256color");
-
-    let mut child = pair.slave.spawn_command(cmd)?;
-    drop(pair.slave);
-
-    // 子プロセスが終了したらイベントループを抜ける
-    thread::spawn(move || {
-        let _ = child.wait();
-        let _ = slint::quit_event_loop();
-    });
-
-    let mut reader = pair.master.try_clone_reader()?;
-    let writer = Arc::new(Mutex::new(pair.master.take_writer()?));
-
-    let size = TermSize {
-        cols: COLS as usize,
-        rows: ROWS as usize,
-    };
-    let term = Arc::new(Mutex::new(Term::new(Config::default(), &size, EventProxy)));
-
-    // bounded channel で PTY → UI のバックプレッシャを確保する
-    let (byte_tx, byte_rx): (SyncSender<Vec<u8>>, Receiver<Vec<u8>>) = sync_channel(1024);
-    thread::spawn(move || {
-        let mut buf = [0u8; 4096];
-        loop {
-            match reader.read(&mut buf) {
-                Ok(0) => break,
-                Ok(n) => {
-                    if byte_tx.send(buf[..n].to_vec()).is_err() {
-                        break;
-                    }
-                }
-                Err(_) => break,
-            }
-        }
-    });
-
     let ui = AppWindow::new()?;
-    ui.set_cols(COLS as i32);
-    ui.set_visible_rows(ROWS as i32);
-
-    let row_model = Rc::new(VecModel::<TerminalRow>::default());
-    for _ in 0..ROWS {
-        row_model.push(empty_row());
-    }
-    ui.set_rows(ModelRc::from(row_model.clone()));
-
-    {
-        let writer = writer.clone();
-        ui.on_key_pressed(move |text: SharedString| {
-            let bytes = translate_key(text.as_str());
-            if bytes.is_empty() {
-                return;
-            }
-            if let Ok(mut w) = writer.lock() {
-                let _ = w.write_all(&bytes);
-                let _ = w.flush();
-            }
-        });
-    }
-
-    let processor = Arc::new(Mutex::new(Processor::<StdSyncHandler>::new()));
-    let term_for_timer = term.clone();
-    let processor_for_timer = processor.clone();
-    let row_model_for_timer = row_model.clone();
-    let ui_weak = ui.as_weak();
-    let timer = slint::Timer::default();
-    timer.start(
-        slint::TimerMode::Repeated,
-        Duration::from_millis(16),
-        move || {
-            let mut updated = false;
-            while let Ok(bytes) = byte_rx.try_recv() {
-                let mut term_guard = term_for_timer.lock().unwrap();
-                let mut proc_guard = processor_for_timer.lock().unwrap();
-                proc_guard.advance(&mut *term_guard, &bytes);
-                updated = true;
-            }
-            if !updated {
-                return;
-            }
-            let term_guard = term_for_timer.lock().unwrap();
-            let cursor = term_guard.grid().cursor.point;
-            for r in 0..ROWS as usize {
-                let row = build_row(&term_guard, r);
-                row_model_for_timer.set_row_data(r, row);
-            }
-            if let Some(ui) = ui_weak.upgrade() {
-                ui.set_cursor_col(cursor.column.0 as i32);
-                ui.set_cursor_row(cursor.line.0 as i32);
-            }
-        },
-    );
-
+    let _pane = terminal::launch(&ui, &cmd_name)?;
     ui.run()?;
     Ok(())
-}
-
-fn empty_row() -> TerminalRow {
-    let cells = VecModel::<TerminalCell>::default();
-    for _ in 0..COLS {
-        cells.push(TerminalCell {
-            ch: SharedString::from(" "),
-            fg: slint::Color::from_rgb_u8(0xee, 0xee, 0xee),
-            bg: slint::Color::from_rgb_u8(0x0b, 0x0b, 0x0b),
-        });
-    }
-    TerminalRow {
-        cells: ModelRc::from(Rc::new(cells) as Rc<dyn Model<Data = TerminalCell>>),
-    }
-}
-
-fn build_row(term: &Term<EventProxy>, row: usize) -> TerminalRow {
-    let cells = VecModel::<TerminalCell>::default();
-    let grid = term.grid();
-    let line = Line(row as i32);
-    for col in 0..COLS as usize {
-        let point = Point::new(line, Column(col));
-        let cell = &grid[point];
-        cells.push(make_cell(cell));
-    }
-    TerminalRow {
-        cells: ModelRc::from(Rc::new(cells) as Rc<dyn Model<Data = TerminalCell>>),
-    }
-}
-
-/// Slint の KeyEvent.text を VT 互換のバイト列に翻訳する。
-/// Slint は矢印等の特殊キーを Private Use Area の文字で表現するため、
-/// それらを ANSI エスケープシーケンスに変換してから PTY に流す。
-fn translate_key(text: &str) -> Vec<u8> {
-    if text.is_empty() {
-        return Vec::new();
-    }
-    match text {
-        // Arrow keys (Slint private use area → CSI sequences)
-        "\u{F700}" => b"\x1b[A".to_vec(), // Up
-        "\u{F701}" => b"\x1b[B".to_vec(), // Down
-        "\u{F702}" => b"\x1b[D".to_vec(), // Left
-        "\u{F703}" => b"\x1b[C".to_vec(), // Right
-        // Backspace / Delete → TTY erase (DEL, 0x7f)
-        "\u{8}" | "\u{7f}" => vec![0x7f],
-        // Enter → CR
-        "\n" | "\r" => b"\r".to_vec(),
-        // Tab / Escape はそのまま
-        "\t" => b"\t".to_vec(),
-        "\u{1b}" => b"\x1b".to_vec(),
-        // 通常文字は UTF-8 をそのまま流す
-        other => other.as_bytes().to_vec(),
-    }
-}
-
-fn make_cell(cell: &Cell) -> TerminalCell {
-    let mut s = [0u8; 4];
-    let ch: &str = cell.c.encode_utf8(&mut s);
-    TerminalCell {
-        ch: SharedString::from(&*ch),
-        fg: slint::Color::from_rgb_u8(0xee, 0xee, 0xee),
-        bg: slint::Color::from_rgb_u8(0x0b, 0x0b, 0x0b),
-    }
 }

--- a/src/review/diff.rs
+++ b/src/review/diff.rs
@@ -1,0 +1,86 @@
+use super::snapshot::FileId;
+
+/// diff 行の種別。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineKind {
+    Context,
+    Added,
+    Removed,
+}
+
+/// unified diff 1 行分。
+#[derive(Debug, Clone)]
+pub struct DiffLine {
+    pub kind: LineKind,
+    pub old_line_no: Option<u32>,
+    pub new_line_no: Option<u32>,
+    pub content: String,
+}
+
+/// 1 hunk = @@ で区切られた差分ブロック。
+#[derive(Debug, Clone)]
+pub struct Hunk {
+    pub old_start: u32,
+    pub old_len: u32,
+    pub new_start: u32,
+    pub new_len: u32,
+    pub lines: Vec<DiffLine>,
+}
+
+impl Hunk {
+    pub fn header(&self) -> String {
+        format!(
+            "@@ -{},{} +{},{} @@",
+            self.old_start, self.old_len, self.new_start, self.new_len
+        )
+    }
+}
+
+/// 1 ファイルの diff 内部モデル。
+///
+/// UI で描画する単位でもあり、selection anchor の解決単位でもある。
+#[derive(Debug, Clone)]
+pub struct FileDiff {
+    pub file_id: FileId,
+    pub file_path: String,
+    pub hunks: Vec<Hunk>,
+}
+
+impl FileDiff {
+    pub fn is_empty(&self) -> bool {
+        self.hunks.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_kind_equality() {
+        assert_ne!(LineKind::Added, LineKind::Removed);
+        assert_eq!(LineKind::Context, LineKind::Context);
+    }
+
+    #[test]
+    fn hunk_header_format() {
+        let hunk = Hunk {
+            old_start: 10,
+            old_len: 3,
+            new_start: 10,
+            new_len: 5,
+            lines: vec![],
+        };
+        assert_eq!(hunk.header(), "@@ -10,3 +10,5 @@");
+    }
+
+    #[test]
+    fn file_diff_is_empty_when_no_hunks() {
+        let diff = FileDiff {
+            file_id: FileId::new("x"),
+            file_path: "x.rs".into(),
+            hunks: vec![],
+        };
+        assert!(diff.is_empty());
+    }
+}

--- a/src/review/draft.rs
+++ b/src/review/draft.rs
@@ -1,0 +1,128 @@
+use super::selection::SelectionAnchor;
+
+/// PromptDraft の 1 エントリ。選択 + 任意の note。
+#[derive(Debug, Clone)]
+pub struct DraftEntry {
+    pub anchor: SelectionAnchor,
+    pub note: Option<String>,
+}
+
+impl DraftEntry {
+    pub fn new(anchor: SelectionAnchor, note: Option<String>) -> Self {
+        Self { anchor, note }
+    }
+}
+
+/// Terminal ペインに流す前の下書き。
+///
+/// 名前を "Comment" にしないのは、Locus が GitHub に write-back しないため。
+/// このドラフトが届く先は PTY 上の Agent CLI である。
+#[derive(Debug, Clone, Default)]
+pub struct PromptDraft {
+    entries: Vec<DraftEntry>,
+}
+
+impl PromptDraft {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&mut self, entry: DraftEntry) {
+        self.entries.push(entry);
+    }
+
+    pub fn remove(&mut self, index: usize) -> Option<DraftEntry> {
+        if index < self.entries.len() {
+            Some(self.entries.remove(index))
+        } else {
+            None
+        }
+    }
+
+    pub fn entries(&self) -> &[DraftEntry] {
+        &self.entries
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+}
+
+/// PTY / クリップボードへの送り方。
+///
+/// Codex 助言に従い、PTY busy 判定や queue は実装しない。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SendMode {
+    /// 文字列を PTY に流し込むだけ。Enter は送らない。
+    InsertOnly,
+    /// 文字列 + CR を送る。誤爆を避けるため明示的な別操作に割り当てる。
+    InsertAndSend,
+    /// PTY ではなくクリップボードに書く。
+    CopyToClipboard,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::selection::{Granularity, Side};
+    use crate::review::snapshot::FileId;
+
+    fn sample_entry(note: Option<&str>) -> DraftEntry {
+        DraftEntry::new(
+            SelectionAnchor {
+                file_id: FileId::new("a"),
+                file_path: "a.rs".into(),
+                granularity: Granularity::Line {
+                    line: 1,
+                    side: Side::After,
+                },
+            },
+            note.map(str::to_string),
+        )
+    }
+
+    #[test]
+    fn push_and_len() {
+        let mut draft = PromptDraft::new();
+        assert!(draft.is_empty());
+        draft.push(sample_entry(Some("first")));
+        draft.push(sample_entry(None));
+        assert_eq!(draft.len(), 2);
+        assert!(!draft.is_empty());
+    }
+
+    #[test]
+    fn remove_valid_index() {
+        let mut draft = PromptDraft::new();
+        draft.push(sample_entry(Some("a")));
+        draft.push(sample_entry(Some("b")));
+        let removed = draft.remove(0).unwrap();
+        assert_eq!(removed.note.as_deref(), Some("a"));
+        assert_eq!(draft.len(), 1);
+        assert_eq!(draft.entries()[0].note.as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn remove_out_of_range_returns_none() {
+        let mut draft = PromptDraft::new();
+        draft.push(sample_entry(None));
+        assert!(draft.remove(10).is_none());
+        assert_eq!(draft.len(), 1);
+    }
+
+    #[test]
+    fn clear_empties_the_draft() {
+        let mut draft = PromptDraft::new();
+        draft.push(sample_entry(None));
+        draft.clear();
+        assert!(draft.is_empty());
+    }
+}

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -1,0 +1,25 @@
+// v0.1 開始時点では後続 Issue (#201-#206) が消費するまで多くの型・メソッドが
+// dead code として検出される。モジュール単位で許容する。
+#![allow(dead_code, unused_imports)]
+
+//! Locus のコアドメイン型。
+//!
+//! - [`target`] — ReviewTarget: PR や local compare を抽象化
+//! - [`snapshot`] — before/after のファイルスナップショット
+//! - [`diff`] — 内部 diff モデル (FileDiff / Hunk / DiffLine)
+//! - [`selection`] — diff 上の選択アンカー
+//! - [`draft`] — PromptDraft: Terminal に流す前の下書き
+//!
+//! いずれも I/O を持たない純粋な型で、UI / PTY / GitHub から独立している。
+
+pub mod diff;
+pub mod draft;
+pub mod selection;
+pub mod snapshot;
+pub mod target;
+
+pub use diff::{DiffLine, FileDiff, Hunk, LineKind};
+pub use draft::{DraftEntry, PromptDraft, SendMode};
+pub use selection::{Granularity, SelectionAnchor, Side};
+pub use snapshot::{FileId, Revision, SourceSnapshot, UnsupportedFile};
+pub use target::ReviewTarget;

--- a/src/review/selection.rs
+++ b/src/review/selection.rs
@@ -1,0 +1,72 @@
+use super::snapshot::FileId;
+
+/// 選択時にどちら側の行番号を指しているか。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Side {
+    Before,
+    After,
+}
+
+/// 選択の粒度。
+///
+/// line-based な固定を避けるため、line 以上の粒度（range/hunk/file）を
+/// 型レベルで用意する。
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Granularity {
+    File,
+    Hunk { hunk_index: usize },
+    Range { start_line: u32, end_line: u32, side: Side },
+    Line { line: u32, side: Side },
+}
+
+/// diff 上の選択を一意に指し示すアンカー。
+///
+/// PromptDraft はこれを複数束ねて整形する。Comment ではなく Selection と
+/// 呼ぶのは、送り先が GitHub ではなく AI Agent CLI であり、「書き戻し前提の
+/// レビューコメント」という体験を避けるため。
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SelectionAnchor {
+    pub file_id: FileId,
+    pub file_path: String,
+    pub granularity: Granularity,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anchor_equality_on_same_file_and_granularity() {
+        let a = SelectionAnchor {
+            file_id: FileId::new("a"),
+            file_path: "a.rs".into(),
+            granularity: Granularity::Line {
+                line: 10,
+                side: Side::After,
+            },
+        };
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn anchor_inequality_across_sides() {
+        let a = SelectionAnchor {
+            file_id: FileId::new("a"),
+            file_path: "a.rs".into(),
+            granularity: Granularity::Line {
+                line: 10,
+                side: Side::After,
+            },
+        };
+        let b = SelectionAnchor {
+            file_id: FileId::new("a"),
+            file_path: "a.rs".into(),
+            granularity: Granularity::Line {
+                line: 10,
+                side: Side::Before,
+            },
+        };
+        assert_ne!(a, b);
+    }
+}

--- a/src/review/snapshot.rs
+++ b/src/review/snapshot.rs
@@ -1,0 +1,99 @@
+/// Before/after で安定したファイル識別子。
+///
+/// GitHub ではリネームがあっても同じ file として扱いたいので、path ではなく
+/// 別の識別を持たせる余地を残す。v0.1 では単純に path ベースで発行する想定。
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FileId(pub String);
+
+impl FileId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Revision {
+    Before,
+    After,
+}
+
+/// 1ファイルの before/after どちらか一方のスナップショット。
+///
+/// セマンティック解析や diff 再構成はこのスナップショットを正本とする。
+/// patch string は viewer 向けの派生ビューにすぎない。
+#[derive(Debug, Clone)]
+pub struct SourceSnapshot {
+    pub file_id: FileId,
+    pub file_path: String,
+    pub language: Option<String>,
+    pub revision: Revision,
+    pub content: String,
+}
+
+/// 解析・表示対象外となったファイルを明示的に記録するための型。
+///
+/// 「黙って落とす」と信頼を失うため、理由付きで UI まで届ける前提。
+#[derive(Debug, Clone)]
+pub enum UnsupportedFile {
+    Binary {
+        file_id: FileId,
+        file_path: String,
+    },
+    PatchMissing {
+        file_id: FileId,
+        file_path: String,
+        reason: String,
+    },
+    ParserFailed {
+        file_id: FileId,
+        file_path: String,
+        detail: String,
+    },
+}
+
+impl UnsupportedFile {
+    pub fn file_path(&self) -> &str {
+        match self {
+            UnsupportedFile::Binary { file_path, .. }
+            | UnsupportedFile::PatchMissing { file_path, .. }
+            | UnsupportedFile::ParserFailed { file_path, .. } => file_path,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_id_round_trip() {
+        let id = FileId::new("src/main.rs");
+        assert_eq!(id.as_str(), "src/main.rs");
+    }
+
+    #[test]
+    fn unsupported_file_path_accessor() {
+        let cases = [
+            UnsupportedFile::Binary {
+                file_id: FileId::new("a"),
+                file_path: "a.bin".into(),
+            },
+            UnsupportedFile::PatchMissing {
+                file_id: FileId::new("b"),
+                file_path: "b.txt".into(),
+                reason: "too large".into(),
+            },
+            UnsupportedFile::ParserFailed {
+                file_id: FileId::new("c"),
+                file_path: "c.rs".into(),
+                detail: "syntax error".into(),
+            },
+        ];
+        let paths: Vec<&str> = cases.iter().map(UnsupportedFile::file_path).collect();
+        assert_eq!(paths, vec!["a.bin", "b.txt", "c.rs"]);
+    }
+}

--- a/src/review/target.rs
+++ b/src/review/target.rs
@@ -1,0 +1,91 @@
+use std::path::PathBuf;
+
+/// レビュー対象。Locus は「PR viewer」ではなく「ReviewTarget viewer」として
+/// 将来のローカル比較にも同じ UI で対応できるように抽象を先に置く。
+///
+/// v0.1 では UI から開けるのは [`ReviewTarget::GitHubPr`] のみだが、他バリアントも
+/// 型として用意しておく。
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ReviewTarget {
+    /// GitHub の pull request を直接指す。
+    GitHubPr {
+        owner: String,
+        repo: String,
+        pr_number: u64,
+    },
+
+    /// ローカルリポジトリの base..head 比較。将来対応。
+    LocalCompare {
+        repo_path: PathBuf,
+        base_ref: String,
+        head_ref: String,
+    },
+
+    /// 作業ツリー（HEAD と dirty の差分など）。将来対応。
+    WorkingTree {
+        repo_path: PathBuf,
+        base_ref: String,
+    },
+}
+
+impl ReviewTarget {
+    /// UI 上のタイトルとして使える短い表現。
+    pub fn display_label(&self) -> String {
+        match self {
+            ReviewTarget::GitHubPr {
+                owner,
+                repo,
+                pr_number,
+            } => format!("{owner}/{repo}#{pr_number}"),
+            ReviewTarget::LocalCompare {
+                repo_path,
+                base_ref,
+                head_ref,
+            } => format!(
+                "{}: {base_ref}..{head_ref}",
+                repo_path.file_name().and_then(|s| s.to_str()).unwrap_or("?")
+            ),
+            ReviewTarget::WorkingTree {
+                repo_path,
+                base_ref,
+            } => format!(
+                "{}: {base_ref}..worktree",
+                repo_path.file_name().and_then(|s| s.to_str()).unwrap_or("?")
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_label_for_github_pr() {
+        let target = ReviewTarget::GitHubPr {
+            owner: "duck8823".into(),
+            repo: "locus".into(),
+            pr_number: 42,
+        };
+        assert_eq!(target.display_label(), "duck8823/locus#42");
+    }
+
+    #[test]
+    fn display_label_for_local_compare() {
+        let target = ReviewTarget::LocalCompare {
+            repo_path: PathBuf::from("/tmp/sample-repo"),
+            base_ref: "main".into(),
+            head_ref: "topic".into(),
+        };
+        assert_eq!(target.display_label(), "sample-repo: main..topic");
+    }
+
+    #[test]
+    fn display_label_for_working_tree() {
+        let target = ReviewTarget::WorkingTree {
+            repo_path: PathBuf::from("/tmp/sample-repo"),
+            base_ref: "main".into(),
+        };
+        assert_eq!(target.display_label(), "sample-repo: main..worktree");
+    }
+}

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,0 +1,239 @@
+//! Terminal ペインの組み立て。
+//!
+//! `alacritty_terminal` の `Term` + `portable-pty` の子プロセスを Slint の
+//! `AppWindow` に接続する。既存挙動を壊さず `src/main.rs` からの一行呼び出しに
+//! まとめることだけを目的にしている。
+//!
+//! 注: v0.1 では Terminal ペインの COLS / ROWS を固定。リサイズ追従は後続
+//! Issue で扱う。
+
+use std::io::{Read, Write};
+use std::rc::Rc;
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use alacritty_terminal::event::{Event, EventListener};
+use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::term::{Config, Term};
+use alacritty_terminal::vte::ansi::{Processor, StdSyncHandler};
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
+
+use crate::ui_state::{build_row, empty_row};
+use crate::{AppWindow, TerminalRow};
+
+const COLS: u16 = 100;
+const ROWS: u16 = 30;
+
+/// alacritty_terminal に渡すイベントリスナ。PoC 以来何もしていない。
+#[derive(Clone, Default)]
+pub struct EventProxy;
+
+impl EventListener for EventProxy {
+    fn send_event(&self, _event: Event) {}
+}
+
+/// Term に渡すサイズ情報。
+#[derive(Clone, Copy)]
+struct TermSize {
+    cols: usize,
+    rows: usize,
+}
+
+impl Dimensions for TermSize {
+    fn columns(&self) -> usize {
+        self.cols
+    }
+    fn screen_lines(&self) -> usize {
+        self.rows
+    }
+    fn total_lines(&self) -> usize {
+        self.rows
+    }
+}
+
+/// Slint の KeyEvent.text を VT 互換のバイト列に翻訳する。
+///
+/// Slint は矢印等を Private Use Area の文字で表現するため、ANSI CSI に
+/// 変換してから PTY に流す必要がある。
+pub fn translate_key(text: &str) -> Vec<u8> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+    match text {
+        "\u{F700}" => b"\x1b[A".to_vec(), // Up
+        "\u{F701}" => b"\x1b[B".to_vec(), // Down
+        "\u{F702}" => b"\x1b[D".to_vec(), // Left
+        "\u{F703}" => b"\x1b[C".to_vec(), // Right
+        "\u{8}" | "\u{7f}" => vec![0x7f],
+        "\n" | "\r" => b"\r".to_vec(),
+        "\t" => b"\t".to_vec(),
+        "\u{1b}" => b"\x1b".to_vec(),
+        other => other.as_bytes().to_vec(),
+    }
+}
+
+/// PTY を立てて Slint AppWindow に接続する。
+///
+/// 戻り値の [`TerminalPane`] は Timer と PTY 所有権をまとめて保持し、
+/// イベントループが回っている間 drop されないようにする。
+pub fn launch(ui: &AppWindow, command: &str) -> Result<TerminalPane, Box<dyn std::error::Error>> {
+    let pty_system = native_pty_system();
+    let pair = pty_system.openpty(PtySize {
+        rows: ROWS,
+        cols: COLS,
+        pixel_width: 0,
+        pixel_height: 0,
+    })?;
+
+    let mut cmd = CommandBuilder::new(command);
+    if let Ok(cwd) = std::env::current_dir() {
+        cmd.cwd(cwd);
+    }
+    cmd.env("TERM", "xterm-256color");
+
+    let mut child = pair.slave.spawn_command(cmd)?;
+    drop(pair.slave);
+
+    thread::spawn(move || {
+        let _ = child.wait();
+        let _ = slint::quit_event_loop();
+    });
+
+    let mut reader = pair.master.try_clone_reader()?;
+    let writer = Arc::new(Mutex::new(pair.master.take_writer()?));
+
+    let size = TermSize {
+        cols: COLS as usize,
+        rows: ROWS as usize,
+    };
+    let term = Arc::new(Mutex::new(Term::new(Config::default(), &size, EventProxy)));
+
+    let (byte_tx, byte_rx): (SyncSender<Vec<u8>>, Receiver<Vec<u8>>) = sync_channel(1024);
+    thread::spawn(move || {
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if byte_tx.send(buf[..n].to_vec()).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    ui.set_cols(COLS as i32);
+    ui.set_visible_rows(ROWS as i32);
+
+    let row_model = Rc::new(VecModel::<TerminalRow>::default());
+    for _ in 0..ROWS {
+        row_model.push(empty_row(COLS as usize));
+    }
+    ui.set_rows(ModelRc::from(row_model.clone()));
+
+    {
+        let writer = writer.clone();
+        ui.on_key_pressed(move |text: SharedString| {
+            let bytes = translate_key(text.as_str());
+            if bytes.is_empty() {
+                return;
+            }
+            if let Ok(mut w) = writer.lock() {
+                let _ = w.write_all(&bytes);
+                let _ = w.flush();
+            }
+        });
+    }
+
+    let processor = Arc::new(Mutex::new(Processor::<StdSyncHandler>::new()));
+    let term_for_timer = term.clone();
+    let processor_for_timer = processor.clone();
+    let row_model_for_timer = row_model.clone();
+    let ui_weak = ui.as_weak();
+    let timer = slint::Timer::default();
+    timer.start(
+        slint::TimerMode::Repeated,
+        Duration::from_millis(16),
+        move || {
+            let mut updated = false;
+            while let Ok(bytes) = byte_rx.try_recv() {
+                let mut term_guard = term_for_timer.lock().unwrap();
+                let mut proc_guard = processor_for_timer.lock().unwrap();
+                proc_guard.advance(&mut *term_guard, &bytes);
+                updated = true;
+            }
+            if !updated {
+                return;
+            }
+            let term_guard = term_for_timer.lock().unwrap();
+            let cursor = term_guard.grid().cursor.point;
+            for r in 0..ROWS as usize {
+                let row = build_row(&term_guard, r, COLS as usize);
+                row_model_for_timer.set_row_data(r, row);
+            }
+            if let Some(ui) = ui_weak.upgrade() {
+                ui.set_cursor_col(cursor.column.0 as i32);
+                ui.set_cursor_row(cursor.line.0);
+            }
+        },
+    );
+
+    Ok(TerminalPane {
+        _timer: timer,
+        _writer: writer,
+        _term: term,
+        _processor: processor,
+    })
+}
+
+/// Terminal ペインを活きた状態に保つためのオーナーシップ束。
+///
+/// 所有者が drop されると Timer と PTY writer / Term も落ちる。呼び出し側は
+/// イベントループが終わるまでこの値を保持する責任がある。
+pub struct TerminalPane {
+    _timer: slint::Timer,
+    _writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    _term: Arc<Mutex<Term<EventProxy>>>,
+    _processor: Arc<Mutex<Processor<StdSyncHandler>>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::translate_key;
+
+    #[test]
+    fn empty_text_is_dropped() {
+        assert!(translate_key("").is_empty());
+    }
+
+    #[test]
+    fn arrows_map_to_csi() {
+        assert_eq!(translate_key("\u{F700}"), b"\x1b[A");
+        assert_eq!(translate_key("\u{F701}"), b"\x1b[B");
+        assert_eq!(translate_key("\u{F702}"), b"\x1b[D");
+        assert_eq!(translate_key("\u{F703}"), b"\x1b[C");
+    }
+
+    #[test]
+    fn backspace_maps_to_del() {
+        assert_eq!(translate_key("\u{8}"), vec![0x7f]);
+        assert_eq!(translate_key("\u{7f}"), vec![0x7f]);
+    }
+
+    #[test]
+    fn enter_maps_to_cr() {
+        assert_eq!(translate_key("\n"), b"\r");
+        assert_eq!(translate_key("\r"), b"\r");
+    }
+
+    #[test]
+    fn regular_utf8_passes_through() {
+        assert_eq!(translate_key("あ"), "あ".as_bytes());
+        assert_eq!(translate_key("a"), b"a");
+    }
+}

--- a/src/ui_state/mod.rs
+++ b/src/ui_state/mod.rs
@@ -5,12 +5,12 @@
 
 use std::rc::Rc;
 
+use alacritty_terminal::event::EventListener;
 use alacritty_terminal::grid::Dimensions;
 use alacritty_terminal::index::{Column, Line, Point};
 use alacritty_terminal::term::{cell::Cell, Term};
 use slint::{Color, Model, ModelRc, SharedString, VecModel};
 
-use crate::terminal::EventProxy;
 use crate::{TerminalCell, TerminalRow};
 
 const FG: Color = Color::from_rgb_u8(0xee, 0xee, 0xee);
@@ -30,7 +30,7 @@ pub fn empty_row(cols: usize) -> TerminalRow {
     }
 }
 
-pub fn build_row(term: &Term<EventProxy>, row: usize, cols: usize) -> TerminalRow {
+pub fn build_row<T: EventListener>(term: &Term<T>, row: usize, cols: usize) -> TerminalRow {
     let cells = VecModel::<TerminalCell>::default();
     let grid = term.grid();
     let line = Line(row as i32);
@@ -56,6 +56,6 @@ fn make_cell(cell: &Cell) -> TerminalCell {
 
 /// Term の現在の row 数を取得するヘルパ。
 #[allow(dead_code)]
-pub fn term_screen_lines(term: &Term<EventProxy>) -> usize {
+pub fn term_screen_lines<T: EventListener>(term: &Term<T>) -> usize {
     term.grid().screen_lines()
 }

--- a/src/ui_state/mod.rs
+++ b/src/ui_state/mod.rs
@@ -1,0 +1,61 @@
+//! Slint モデルへの詰め替えユーティリティ。
+//!
+//! 当面は Terminal ペインの `TerminalRow` / `TerminalCell` 構築だけを扱う。
+//! 将来 diff viewer が入る際もここに同種の builder を追加する想定。
+
+use std::rc::Rc;
+
+use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::index::{Column, Line, Point};
+use alacritty_terminal::term::{cell::Cell, Term};
+use slint::{Color, Model, ModelRc, SharedString, VecModel};
+
+use crate::terminal::EventProxy;
+use crate::{TerminalCell, TerminalRow};
+
+const FG: Color = Color::from_rgb_u8(0xee, 0xee, 0xee);
+const BG: Color = Color::from_rgb_u8(0x0b, 0x0b, 0x0b);
+
+pub fn empty_row(cols: usize) -> TerminalRow {
+    let cells = VecModel::<TerminalCell>::default();
+    for _ in 0..cols {
+        cells.push(TerminalCell {
+            ch: SharedString::from(" "),
+            fg: FG,
+            bg: BG,
+        });
+    }
+    TerminalRow {
+        cells: ModelRc::from(Rc::new(cells) as Rc<dyn Model<Data = TerminalCell>>),
+    }
+}
+
+pub fn build_row(term: &Term<EventProxy>, row: usize, cols: usize) -> TerminalRow {
+    let cells = VecModel::<TerminalCell>::default();
+    let grid = term.grid();
+    let line = Line(row as i32);
+    for col in 0..cols {
+        let point = Point::new(line, Column(col));
+        let cell = &grid[point];
+        cells.push(make_cell(cell));
+    }
+    TerminalRow {
+        cells: ModelRc::from(Rc::new(cells) as Rc<dyn Model<Data = TerminalCell>>),
+    }
+}
+
+fn make_cell(cell: &Cell) -> TerminalCell {
+    let mut buf = [0u8; 4];
+    let ch: &str = cell.c.encode_utf8(&mut buf);
+    TerminalCell {
+        ch: SharedString::from(ch),
+        fg: FG,
+        bg: BG,
+    }
+}
+
+/// Term の現在の row 数を取得するヘルパ。
+#[allow(dead_code)]
+pub fn term_screen_lines(term: &Term<EventProxy>) -> usize {
+    term.grid().screen_lines()
+}


### PR DESCRIPTION
## Summary / 概要

v0.1 coreの第一歩。\`src/main.rs\` べた書きの PoC 状態を解消し、v0.1 以降の実装が乗る土台を置く。

Closes #200

## Motivation / モチベーション

Codex の相談結果 (#196) で:
- 「Comment ではなく PromptDraft として設計する」
- 「parser boundary は今すぐ、tree-sitter UI は後で」
- 「PR viewer ではなく ReviewTarget viewer を目指す」

と明確になったため、v0.1 の他サブ Issue (#201-#206) がこれらの型に依存できるように先に型と境界を置く。

## Scope / スコープ

**In scope:**
- \`src/main.rs\` を composition root のみに削り、以下に分割:
  - \`src/terminal/\` — PTY + alacritty_terminal + key translate
  - \`src/ui_state/\` — Slint モデル詰め替え
  - \`src/github/\` — 空モジュール（#201/#206 で使う）
  - \`src/review/\` — ドメイン型
- \`src/review/\` 配下のドメイン型を新規追加:
  - \`ReviewTarget\` (GitHubPr / LocalCompare / WorkingTree)
  - \`SourceSnapshot\` / \`FileId\` / \`Revision\` / \`UnsupportedFile\`
  - \`FileDiff\` / \`Hunk\` / \`DiffLine\` / \`LineKind\`
  - \`SelectionAnchor\` / \`Granularity\` / \`Side\`
  - \`PromptDraft\` / \`DraftEntry\` / \`SendMode\`
- 各型にユニットテスト（計 14 本）

**Out of scope:**
- octocrab 呼び出し実装 (#201)
- diff 描画 (#201)
- selection→draft 蓄積 UI (#202)
- PromptDraft の PTY 送信 (#203)
- parser-adapter 契約 (#205)

## 3 コミット構成

1. refactor: extract terminal / ui_state / github modules out of main.rs
2. feat(core): add review domain types under src/review/
3. chore: add sprint spec for #200

## Validation / 検証

- [x] \`cargo build\` ✅
- [x] \`cargo clippy --all-targets -- -D warnings\` ✅
- [x] \`cargo test\` ✅ 19 passed
- [x] Terminal pane 既存挙動（\`cargo run -- bash\` 相当）が壊れていないことをコード差分で確認（挙動を変えない純粋な move + 型追加）
- [ ] 実機ウィンドウ起動確認（手元で要確認）

## AI Review Loop / AI レビューループ

- [ ] Gemini scout (quota 中のため skip か低優先)
- [ ] Codex verifier (next)

## ADR 参照

- [ADR 0004](../blob/main/docs/adr/0004-semantic-change-ir.md) — parser-adapter + Semantic Change IR 境界
- [ADR 0005](../blob/main/docs/adr/0005-rust-slint-native-rewrite.md) — Rust/Slint native + Terminal ペイン委譲方針

🤖 Generated with [Claude Code](https://claude.com/claude-code)