### PR TITLE
feat(#242): map ANSI Cell colors and INVERSE/DIM to terminal pane

### DIFF
--- a/src/ui_state/color.rs
+++ b/src/ui_state/color.rs
@@ -14,53 +14,50 @@ use slint::Color;
 const FG: Color = Color::from_rgb_u8(0xee, 0xee, 0xee);
 const BG: Color = Color::from_rgb_u8(0x0b, 0x0b, 0x0b);
 
-/// xterm 互換の標準 16 色。
+/// xterm が出荷時に使う標準 16 色 (X11 rgb.txt の名前色)。
+///
+/// 参照: https://invisible-island.net/xterm/xterm.faq.html#color_by_number
 const PALETTE_16: [Color; 16] = [
     Color::from_rgb_u8(0x00, 0x00, 0x00), // 0 black
-    Color::from_rgb_u8(0xcd, 0x31, 0x31), // 1 red
-    Color::from_rgb_u8(0x0d, 0xbc, 0x79), // 2 green
-    Color::from_rgb_u8(0xe5, 0xe5, 0x10), // 3 yellow
-    Color::from_rgb_u8(0x24, 0x72, 0xc8), // 4 blue
-    Color::from_rgb_u8(0xbc, 0x3f, 0xbc), // 5 magenta
-    Color::from_rgb_u8(0x11, 0xa8, 0xcd), // 6 cyan
-    Color::from_rgb_u8(0xe5, 0xe5, 0xe5), // 7 white (light gray)
-    Color::from_rgb_u8(0x66, 0x66, 0x66), // 8 bright black
-    Color::from_rgb_u8(0xf1, 0x4c, 0x4c), // 9 bright red
-    Color::from_rgb_u8(0x23, 0xd1, 0x8b), // 10 bright green
-    Color::from_rgb_u8(0xf5, 0xf5, 0x43), // 11 bright yellow
-    Color::from_rgb_u8(0x3b, 0x8e, 0xea), // 12 bright blue
-    Color::from_rgb_u8(0xd6, 0x70, 0xd6), // 13 bright magenta
-    Color::from_rgb_u8(0x29, 0xb8, 0xdb), // 14 bright cyan
-    Color::from_rgb_u8(0xff, 0xff, 0xff), // 15 bright white
+    Color::from_rgb_u8(0xcd, 0x00, 0x00), // 1 red3
+    Color::from_rgb_u8(0x00, 0xcd, 0x00), // 2 green3
+    Color::from_rgb_u8(0xcd, 0xcd, 0x00), // 3 yellow3
+    Color::from_rgb_u8(0x00, 0x00, 0xee), // 4 blue2
+    Color::from_rgb_u8(0xcd, 0x00, 0xcd), // 5 magenta3
+    Color::from_rgb_u8(0x00, 0xcd, 0xcd), // 6 cyan3
+    Color::from_rgb_u8(0xe5, 0xe5, 0xe5), // 7 gray90
+    Color::from_rgb_u8(0x7f, 0x7f, 0x7f), // 8 gray50
+    Color::from_rgb_u8(0xff, 0x00, 0x00), // 9 red
+    Color::from_rgb_u8(0x00, 0xff, 0x00), // 10 green
+    Color::from_rgb_u8(0xff, 0xff, 0x00), // 11 yellow
+    Color::from_rgb_u8(0x5c, 0x5c, 0xff), // 12 rgb:5c/5c/ff (xterm)
+    Color::from_rgb_u8(0xff, 0x00, 0xff), // 13 magenta
+    Color::from_rgb_u8(0x00, 0xff, 0xff), // 14 cyan
+    Color::from_rgb_u8(0xff, 0xff, 0xff), // 15 white
 ];
 
 /// 16〜231 の 6x6x6 RGB cube 用のレベル変換テーブル。
 const CUBE_LEVELS: [u8; 6] = [0x00, 0x5f, 0x87, 0xaf, 0xd7, 0xff];
 
 pub fn cell_fg(cell: &Cell) -> Color {
-    let (fg_color, bg_color) = base_colors(cell);
-    let inverse = cell.flags.contains(Flags::INVERSE);
-    if inverse {
-        bg_color
-    } else if cell.flags.contains(Flags::DIM) {
-        dim(fg_color)
-    } else {
-        fg_color
-    }
+    let (fg, bg) = resolve_fg_bg(cell);
+    if cell.flags.contains(Flags::INVERSE) { bg } else { fg }
 }
 
 pub fn cell_bg(cell: &Cell) -> Color {
-    let (fg_color, bg_color) = base_colors(cell);
-    if cell.flags.contains(Flags::INVERSE) {
-        fg_color
-    } else {
-        bg_color
-    }
+    let (fg, bg) = resolve_fg_bg(cell);
+    if cell.flags.contains(Flags::INVERSE) { fg } else { bg }
 }
 
-fn base_colors(cell: &Cell) -> (Color, Color) {
-    let fg = ansi_to_slint(cell.fg, FG);
+/// upstream alacritty に倣い、INVERSE swap の前に DIM を fg に適用する。
+/// Indexed(0..15) + DIM の場合は通常 palette ではなく dim 色 (rgb 2/3 倍) を
+/// 使う。これにより DIM+INVERSE を併用したセルで bg として dim 色が見える。
+fn resolve_fg_bg(cell: &Cell) -> (Color, Color) {
+    let mut fg = ansi_to_slint(cell.fg, FG);
     let bg = ansi_to_slint(cell.bg, BG);
+    if cell.flags.contains(Flags::DIM) {
+        fg = dim(fg);
+    }
     (fg, bg)
 }
 
@@ -173,5 +170,53 @@ mod tests {
     #[test]
     fn named_red_is_palette_red() {
         assert_eq!(named_to_color(NamedColor::Red, FG), PALETTE_16[1]);
+    }
+
+    #[test]
+    fn xterm_default_palette_values() {
+        // 主要色について xterm 既定値で固定する
+        assert_eq!(
+            (PALETTE_16[1].red(), PALETTE_16[1].green(), PALETTE_16[1].blue()),
+            (0xcd, 0x00, 0x00)
+        );
+        assert_eq!(
+            (PALETTE_16[2].red(), PALETTE_16[2].green(), PALETTE_16[2].blue()),
+            (0x00, 0xcd, 0x00)
+        );
+        assert_eq!(
+            (PALETTE_16[4].red(), PALETTE_16[4].green(), PALETTE_16[4].blue()),
+            (0x00, 0x00, 0xee)
+        );
+        assert_eq!(
+            (PALETTE_16[12].red(), PALETTE_16[12].green(), PALETTE_16[12].blue()),
+            (0x5c, 0x5c, 0xff)
+        );
+    }
+
+    fn make_cell_with(flags: Flags, fg: AnsiColor, bg: AnsiColor) -> Cell {
+        Cell {
+            fg,
+            bg,
+            flags,
+            ..Cell::default()
+        }
+    }
+
+    #[test]
+    fn dim_then_inverse_swaps_dimmed_fg_into_bg() {
+        let red = AnsiColor::Indexed(1);
+        let blue = AnsiColor::Indexed(4);
+        let cell = make_cell_with(Flags::DIM | Flags::INVERSE, red, blue);
+        // INVERSE swap 後の fg = もとの bg、bg = DIM 適用済の fg
+        let fg = cell_fg(&cell);
+        let bg = cell_bg(&cell);
+        // 元の bg=blue が fg に
+        let expected_fg = PALETTE_16[4];
+        assert_eq!(
+            (fg.red(), fg.green(), fg.blue()),
+            (expected_fg.red(), expected_fg.green(), expected_fg.blue())
+        );
+        // bg は DIM(red) なので元 red より暗い (R 成分が下がる)
+        assert!((bg.red() as u32) < 0xcd);
     }
 }

--- a/src/ui_state/color.rs
+++ b/src/ui_state/color.rs
@@ -1,0 +1,177 @@
+//! alacritty_terminal の Cell に入っている `vte::ansi::Color` を Slint の
+//! `slint::Color` に変換するパレット定義。
+//!
+//! 既定の前景 / 背景は terminal pane のテーマに合わせて持つ。Named / Spec
+//! / Indexed の 3 形態すべてに対応する。
+//!
+//! 今は default の 16 色 + 6x6x6 cube + grayscale を採用。bold/italic/
+//! underline は将来扱う予定だが、INVERSE と DIM は cell 単位で適用する。
+
+use alacritty_terminal::term::cell::{Cell, Flags};
+use alacritty_terminal::vte::ansi::{Color as AnsiColor, NamedColor, Rgb};
+use slint::Color;
+
+const FG: Color = Color::from_rgb_u8(0xee, 0xee, 0xee);
+const BG: Color = Color::from_rgb_u8(0x0b, 0x0b, 0x0b);
+
+/// xterm 互換の標準 16 色。
+const PALETTE_16: [Color; 16] = [
+    Color::from_rgb_u8(0x00, 0x00, 0x00), // 0 black
+    Color::from_rgb_u8(0xcd, 0x31, 0x31), // 1 red
+    Color::from_rgb_u8(0x0d, 0xbc, 0x79), // 2 green
+    Color::from_rgb_u8(0xe5, 0xe5, 0x10), // 3 yellow
+    Color::from_rgb_u8(0x24, 0x72, 0xc8), // 4 blue
+    Color::from_rgb_u8(0xbc, 0x3f, 0xbc), // 5 magenta
+    Color::from_rgb_u8(0x11, 0xa8, 0xcd), // 6 cyan
+    Color::from_rgb_u8(0xe5, 0xe5, 0xe5), // 7 white (light gray)
+    Color::from_rgb_u8(0x66, 0x66, 0x66), // 8 bright black
+    Color::from_rgb_u8(0xf1, 0x4c, 0x4c), // 9 bright red
+    Color::from_rgb_u8(0x23, 0xd1, 0x8b), // 10 bright green
+    Color::from_rgb_u8(0xf5, 0xf5, 0x43), // 11 bright yellow
+    Color::from_rgb_u8(0x3b, 0x8e, 0xea), // 12 bright blue
+    Color::from_rgb_u8(0xd6, 0x70, 0xd6), // 13 bright magenta
+    Color::from_rgb_u8(0x29, 0xb8, 0xdb), // 14 bright cyan
+    Color::from_rgb_u8(0xff, 0xff, 0xff), // 15 bright white
+];
+
+/// 16〜231 の 6x6x6 RGB cube 用のレベル変換テーブル。
+const CUBE_LEVELS: [u8; 6] = [0x00, 0x5f, 0x87, 0xaf, 0xd7, 0xff];
+
+pub fn cell_fg(cell: &Cell) -> Color {
+    let (fg_color, bg_color) = base_colors(cell);
+    let inverse = cell.flags.contains(Flags::INVERSE);
+    if inverse {
+        bg_color
+    } else if cell.flags.contains(Flags::DIM) {
+        dim(fg_color)
+    } else {
+        fg_color
+    }
+}
+
+pub fn cell_bg(cell: &Cell) -> Color {
+    let (fg_color, bg_color) = base_colors(cell);
+    if cell.flags.contains(Flags::INVERSE) {
+        fg_color
+    } else {
+        bg_color
+    }
+}
+
+fn base_colors(cell: &Cell) -> (Color, Color) {
+    let fg = ansi_to_slint(cell.fg, FG);
+    let bg = ansi_to_slint(cell.bg, BG);
+    (fg, bg)
+}
+
+fn ansi_to_slint(color: AnsiColor, fallback: Color) -> Color {
+    match color {
+        AnsiColor::Named(name) => named_to_color(name, fallback),
+        AnsiColor::Spec(Rgb { r, g, b }) => Color::from_rgb_u8(r, g, b),
+        AnsiColor::Indexed(idx) => indexed_to_color(idx, fallback),
+    }
+}
+
+fn named_to_color(name: NamedColor, _fallback: Color) -> Color {
+    match name {
+        NamedColor::Black => PALETTE_16[0],
+        NamedColor::Red => PALETTE_16[1],
+        NamedColor::Green => PALETTE_16[2],
+        NamedColor::Yellow => PALETTE_16[3],
+        NamedColor::Blue => PALETTE_16[4],
+        NamedColor::Magenta => PALETTE_16[5],
+        NamedColor::Cyan => PALETTE_16[6],
+        NamedColor::White => PALETTE_16[7],
+        NamedColor::BrightBlack => PALETTE_16[8],
+        NamedColor::BrightRed => PALETTE_16[9],
+        NamedColor::BrightGreen => PALETTE_16[10],
+        NamedColor::BrightYellow => PALETTE_16[11],
+        NamedColor::BrightBlue => PALETTE_16[12],
+        NamedColor::BrightMagenta => PALETTE_16[13],
+        NamedColor::BrightCyan => PALETTE_16[14],
+        NamedColor::BrightWhite => PALETTE_16[15],
+        NamedColor::Foreground | NamedColor::BrightForeground | NamedColor::DimForeground => FG,
+        NamedColor::Background => BG,
+        NamedColor::Cursor => FG,
+        NamedColor::DimBlack => dim(PALETTE_16[0]),
+        NamedColor::DimRed => dim(PALETTE_16[1]),
+        NamedColor::DimGreen => dim(PALETTE_16[2]),
+        NamedColor::DimYellow => dim(PALETTE_16[3]),
+        NamedColor::DimBlue => dim(PALETTE_16[4]),
+        NamedColor::DimMagenta => dim(PALETTE_16[5]),
+        NamedColor::DimCyan => dim(PALETTE_16[6]),
+        NamedColor::DimWhite => dim(PALETTE_16[7]),
+    }
+}
+
+
+fn indexed_to_color(idx: u8, fallback: Color) -> Color {
+    match idx {
+        0..=15 => PALETTE_16[idx as usize],
+        16..=231 => {
+            let v = (idx - 16) as usize;
+            let r = CUBE_LEVELS[v / 36];
+            let g = CUBE_LEVELS[(v / 6) % 6];
+            let b = CUBE_LEVELS[v % 6];
+            Color::from_rgb_u8(r, g, b)
+        }
+        232..=255 => {
+            // 24 段グレースケール (8..238、step 10)
+            let level = 8u8.saturating_add((idx - 232).saturating_mul(10));
+            Color::from_rgb_u8(level, level, level)
+        }
+        #[allow(unreachable_patterns)]
+        _ => fallback,
+    }
+}
+
+fn dim(c: Color) -> Color {
+    let r = (c.red() as u32 * 2 / 3) as u8;
+    let g = (c.green() as u32 * 2 / 3) as u8;
+    let b = (c.blue() as u32 * 2 / 3) as u8;
+    Color::from_rgb_u8(r, g, b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn indexed_0_to_15_is_palette() {
+        for i in 0u8..16 {
+            assert_eq!(indexed_to_color(i, FG), PALETTE_16[i as usize]);
+        }
+    }
+
+    #[test]
+    fn indexed_16_is_cube_origin() {
+        let c = indexed_to_color(16, FG);
+        // (0, 0, 0)
+        assert_eq!((c.red(), c.green(), c.blue()), (0x00, 0x00, 0x00));
+    }
+
+    #[test]
+    fn indexed_231_is_cube_corner() {
+        let c = indexed_to_color(231, FG);
+        // (5, 5, 5) -> (255, 255, 255)
+        assert_eq!((c.red(), c.green(), c.blue()), (0xff, 0xff, 0xff));
+    }
+
+    #[test]
+    fn indexed_232_is_dark_gray() {
+        let c = indexed_to_color(232, FG);
+        // 8
+        assert_eq!((c.red(), c.green(), c.blue()), (8, 8, 8));
+    }
+
+    #[test]
+    fn dim_reduces_components() {
+        let c = dim(Color::from_rgb_u8(0xff, 0xff, 0xff));
+        assert!(c.red() < 0xff);
+    }
+
+    #[test]
+    fn named_red_is_palette_red() {
+        assert_eq!(named_to_color(NamedColor::Red, FG), PALETTE_16[1]);
+    }
+}

--- a/src/ui_state/mod.rs
+++ b/src/ui_state/mod.rs
@@ -3,6 +3,7 @@
 //! 当面は Terminal ペインの `TerminalRow` / `TerminalCell` 構築だけを扱う。
 //! 将来 diff viewer が入る際もここに同種の builder を追加する想定。
 
+pub mod color;
 pub mod diff_view;
 pub mod draft_view;
 
@@ -94,12 +95,7 @@ pub fn build_row<T: EventListener>(term: &Term<T>, row: usize, cols: usize) -> T
             next_col += next_base as usize;
         }
 
-        cells.push(TerminalCell {
-            ch: SharedString::from(s.as_str()),
-            fg: FG,
-            bg: BG,
-            span: total_span,
-        });
+        cells.push(cell_to_terminal_cell(cell, total_span, s.as_str()));
         // メインの 1 セル目の右側を spacer で埋めてグリッド整列を保つ
         for _ in 1..total_span {
             cells.push(spacer_cell());
@@ -118,6 +114,15 @@ fn spacer_cell() -> TerminalCell {
         fg: FG,
         bg: BG,
         span: 0,
+    }
+}
+
+fn cell_to_terminal_cell(cell: &Cell, span: i32, ch: &str) -> TerminalCell {
+    TerminalCell {
+        ch: SharedString::from(ch),
+        fg: color::cell_fg(cell),
+        bg: color::cell_bg(cell),
+        span,
     }
 }
 


### PR DESCRIPTION
## Summary

terminal pane で agent CLI が出す ANSI 色とスタイル (INVERSE / DIM) を反映する。bash の \`ls --color\` や claude / codex の警告色などが正しく見えるようになる。

Closes #242

## 実装

- src/ui_state/color.rs 新規: xterm 互換の 16 色 PALETTE_16 + 6x6x6 cube + grayscale 256-color。Named / Spec / Indexed の 3 形態を slint::Color に変換。INVERSE で fg/bg 反転、DIM で fg 2/3 減衰
- src/ui_state/mod.rs: build_row の merged cell に色を反映する cell_to_terminal_cell ヘルパ追加

## 検証

- cargo build / clippy --all-targets -- -D warnings / test (100 passed, 6 新規)
- 手元: \`ls --color\` で色付き表示確認 (要)

## AI Review

- [ ] Codex verifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)