### PR TITLE
feat(#219): font family / size environment overrides

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,7 @@ impl UiConfig {
             .ok()
             .and_then(|s| s.parse::<f32>().ok())
             .or(general)
-            .unwrap_or(11.0);
+            .unwrap_or(13.0);
         let diff_font_size = std::env::var("LOCUS_DIFF_FONT_SIZE")
             .ok()
             .and_then(|s| s.parse::<f32>().ok())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,80 @@
+//! 起動時の環境変数ベース設定。
+//!
+//! 動的なリロードは v0.0.x 時点では行わない。フォント / フォントサイズなど
+//! UI 表示に関わる値を 1 箇所にまとめ、起動時に Slint プロパティとして
+//! 注入する。
+
+#[derive(Debug, Clone)]
+pub struct UiConfig {
+    pub font_family: String,
+    pub terminal_font_size: f32,
+    pub diff_font_size: f32,
+}
+
+impl UiConfig {
+    pub fn from_env() -> Self {
+        let font_family = std::env::var("LOCUS_FONT_FAMILY")
+            .unwrap_or_else(|_| "Menlo, Consolas, monospace".to_string());
+        let general = std::env::var("LOCUS_FONT_SIZE")
+            .ok()
+            .and_then(|s| s.parse::<f32>().ok());
+        let terminal_font_size = std::env::var("LOCUS_TERMINAL_FONT_SIZE")
+            .ok()
+            .and_then(|s| s.parse::<f32>().ok())
+            .or(general)
+            .unwrap_or(11.0);
+        let diff_font_size = std::env::var("LOCUS_DIFF_FONT_SIZE")
+            .ok()
+            .and_then(|s| s.parse::<f32>().ok())
+            .or(general)
+            .unwrap_or(12.0);
+        Self {
+            font_family,
+            terminal_font_size,
+            diff_font_size,
+        }
+    }
+
+    /// monospace の典型的な比率 (advance ≈ 0.6 em, line height ≈ 1.4 em)
+    /// から cell width/height をピクセルに変換する。
+    /// 本物の glyph metric を測る代わりに、十分実用的な近似値。
+    pub fn terminal_cell_w(&self) -> f32 {
+        (self.terminal_font_size * 0.6).round().max(4.0)
+    }
+
+    pub fn terminal_cell_h(&self) -> f32 {
+        (self.terminal_font_size * 1.45).round().max(8.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_metrics_are_reasonable() {
+        let cfg = UiConfig {
+            font_family: "test".into(),
+            terminal_font_size: 12.0,
+            diff_font_size: 12.0,
+        };
+        assert!(cfg.terminal_cell_w() >= 6.0);
+        assert!(cfg.terminal_cell_h() >= 14.0);
+    }
+
+    #[test]
+    fn cell_metrics_scale_with_font_size() {
+        let small = UiConfig {
+            font_family: "x".into(),
+            terminal_font_size: 10.0,
+            diff_font_size: 10.0,
+        };
+        let big = UiConfig {
+            font_family: "x".into(),
+            terminal_font_size: 20.0,
+            diff_font_size: 20.0,
+        };
+        assert!(big.terminal_cell_w() > small.terminal_cell_w());
+        assert!(big.terminal_cell_h() > small.terminal_cell_h());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use slint::{ComponentHandle, SharedString};
 
 slint::include_modules!();
 
+mod config;
 mod github;
 mod i18n;
 mod review;
@@ -69,7 +70,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let ui_cfg = config::UiConfig::from_env();
     let ui = AppWindow::new()?;
+    ui.set_font_family(SharedString::from(ui_cfg.font_family.as_str()));
+    ui.set_font_size(ui_cfg.terminal_font_size);
+    ui.set_cell_w(ui_cfg.terminal_cell_w());
+    ui.set_cell_h(ui_cfg.terminal_cell_h());
     let _pane = terminal::launch(&ui, command)?;
     ui.run()?;
     Ok(())
@@ -267,7 +273,13 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
         files: Vec::new(),
     };
 
+    let ui_cfg = config::UiConfig::from_env();
     let ui = DiffViewerWindow::new()?;
+    ui.set_font_family(SharedString::from(ui_cfg.font_family.as_str()));
+    ui.set_terminal_font_size(ui_cfg.terminal_font_size);
+    ui.set_diff_font_size(ui_cfg.diff_font_size);
+    ui.set_terminal_cell_w(ui_cfg.terminal_cell_w());
+    ui.set_terminal_cell_h(ui_cfg.terminal_cell_h());
     apply_snapshot_to_ui(&ui, &placeholder_snapshot, &[]);
     ui.set_current_pr_number(pr_number as i32);
     ui.set_pr_list(build_pr_list_model(&[]));

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -593,7 +593,7 @@ export component DiffViewerWindow inherits Window {
                                                 text: line.old-line-no;
                                                 color: #5a5a65;
                                                 font-family: root.font-family;
-                                                font-size: 11px;
+                                                font-size: root.diff-font-size;
                                                 width: 36px;
                                                 horizontal-alignment: right;
                                             }
@@ -601,7 +601,7 @@ export component DiffViewerWindow inherits Window {
                                                 text: line.new-line-no;
                                                 color: #5a5a65;
                                                 font-family: root.font-family;
-                                                font-size: 11px;
+                                                font-size: root.diff-font-size;
                                                 width: 36px;
                                                 horizontal-alignment: right;
                                             }
@@ -618,7 +618,7 @@ export component DiffViewerWindow inherits Window {
                                             : (line.kind == 1 ? #8fd98f
                                             : (line.kind == 2 ? #e58585 : #c8c8d0));
                                         font-family: root.font-family;
-                                        font-size: 12px;
+                                        font-size: root.diff-font-size;
                                         overflow: elide;
                                     }
                                 }

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -22,6 +22,8 @@ export component AppWindow inherits Window {
     in property <length> cell-h: 18px;
     in property <int> cursor-col: 0;
     in property <int> cursor-row: 0;
+    in property <string> font-family: "Menlo, Consolas, monospace";
+    in property <length> font-size: 13px;
 
     callback key-pressed(string);
     callback resized(length, length);
@@ -60,8 +62,8 @@ export component AppWindow inherits Window {
                     Text {
                         text: cell.ch;
                         color: cell.fg;
-                        font-family: "Menlo, Consolas, monospace";
-                        font-size: 13px;
+                        font-family: root.font-family;
+                        font-size: root.font-size;
                         horizontal-alignment: left;
                         vertical-alignment: center;
                     }
@@ -162,6 +164,10 @@ export component DiffViewerWindow inherits Window {
     in property <int> terminal-cursor-row: 0;
     in property <bool> terminal-available: false;
     in property <string> terminal-status: @tr("not started");
+
+    in property <string> font-family: "Menlo, Consolas, monospace";
+    in property <length> terminal-font-size: 11px;
+    in property <length> diff-font-size: 12px;
 
     in property <[PullRequestListItemView]> pr-list;
     in-out property <int> pr-list-filter: 0; // 0=open, 1=closed, 2=all
@@ -286,7 +292,7 @@ export component DiffViewerWindow inherits Window {
                     text: @tr("base") + " " + root.base-sha + "  ←  " + @tr("head") + " " + root.head-sha;
                     color: #8a8a95;
                     font-size: 11px;
-                    font-family: "Menlo, Consolas, monospace";
+                    font-family: root.font-family;
                 }
                 if root.pr-body-excerpt != "": Text {
                     text: root.pr-body-excerpt;
@@ -330,7 +336,7 @@ export component DiffViewerWindow inherits Window {
                                             ? #e58585
                                             : (issue.state == "closed" ? #c07ac0 : #7ac07a);
                                         font-size: 10px;
-                                        font-family: "Menlo, Consolas, monospace";
+                                        font-family: root.font-family;
                                         font-weight: 600;
                                     }
                                     Text {
@@ -453,7 +459,7 @@ export component DiffViewerWindow inherits Window {
                                         text: pr.number_label;
                                         color: pr.state == "closed" ? #c07ac0 : #7ac07a;
                                         font-size: 10px;
-                                        font-family: "Menlo, Consolas, monospace";
+                                        font-family: root.font-family;
                                         font-weight: 600;
                                     }
                                     Text {
@@ -503,7 +509,7 @@ export component DiffViewerWindow inherits Window {
                                 text: file.status-label;
                                 color: #8a8a95;
                                 font-size: 10px;
-                                font-family: "Menlo, Consolas, monospace";
+                                font-family: root.font-family;
                                 width: 30px;
                             }
                             Text {
@@ -586,7 +592,7 @@ export component DiffViewerWindow inherits Window {
                                             Text {
                                                 text: line.old-line-no;
                                                 color: #5a5a65;
-                                                font-family: "Menlo, Consolas, monospace";
+                                                font-family: root.font-family;
                                                 font-size: 11px;
                                                 width: 36px;
                                                 horizontal-alignment: right;
@@ -594,7 +600,7 @@ export component DiffViewerWindow inherits Window {
                                             Text {
                                                 text: line.new-line-no;
                                                 color: #5a5a65;
-                                                font-family: "Menlo, Consolas, monospace";
+                                                font-family: root.font-family;
                                                 font-size: 11px;
                                                 width: 36px;
                                                 horizontal-alignment: right;
@@ -611,7 +617,7 @@ export component DiffViewerWindow inherits Window {
                                         color: line.is-hunk-header ? #7a7ac0
                                             : (line.kind == 1 ? #8fd98f
                                             : (line.kind == 2 ? #e58585 : #c8c8d0));
-                                        font-family: "Menlo, Consolas, monospace";
+                                        font-family: root.font-family;
                                         font-size: 12px;
                                         overflow: elide;
                                     }
@@ -644,7 +650,7 @@ export component DiffViewerWindow inherits Window {
                                     text: root.current-anchor-label;
                                     color: #d0d0d5;
                                     font-size: 12px;
-                                    font-family: "Menlo, Consolas, monospace";
+                                    font-family: root.font-family;
                                     vertical-alignment: center;
                                 }
                                 Rectangle { horizontal-stretch: 1; }
@@ -733,7 +739,7 @@ export component DiffViewerWindow inherits Window {
                                     y: 2px;
                                     text <=> root.preview-text;
                                     color: #d0d0d5;
-                                    font-family: "Menlo, Consolas, monospace";
+                                    font-family: root.font-family;
                                     font-size: 11px;
                                     wrap: word-wrap;
                                     single-line: false;
@@ -761,7 +767,7 @@ export component DiffViewerWindow inherits Window {
                                 text: root.terminal-status;
                                 color: root.terminal-available ? #8fd98f : #e58585;
                                 font-size: 10px;
-                                font-family: "Menlo, Consolas, monospace";
+                                font-family: root.font-family;
                                 vertical-alignment: center;
                             }
                         }
@@ -799,8 +805,8 @@ export component DiffViewerWindow inherits Window {
                                     Text {
                                         text: cell.ch;
                                         color: cell.fg;
-                                        font-family: "Menlo, Consolas, monospace";
-                                        font-size: 11px;
+                                        font-family: root.font-family;
+                                        font-size: root.terminal-font-size;
                                         horizontal-alignment: left;
                                         vertical-alignment: center;
                                     }
@@ -876,7 +882,7 @@ export component DiffViewerWindow inherits Window {
                                         text: entry.label;
                                         color: #d0d0d5;
                                         font-size: 11px;
-                                        font-family: "Menlo, Consolas, monospace";
+                                        font-family: root.font-family;
                                         overflow: elide;
                                     }
                                     Text {
@@ -950,7 +956,7 @@ export component DiffViewerWindow inherits Window {
                                             text: h.timestamp;
                                             color: #8a8a95;
                                             font-size: 10px;
-                                            font-family: "Menlo, Consolas, monospace";
+                                            font-family: root.font-family;
                                         }
                                         Text {
                                             text: h.mode;


### PR DESCRIPTION
## Summary

LOCUS_FONT_FAMILY / LOCUS_FONT_SIZE / LOCUS_TERMINAL_FONT_SIZE / LOCUS_DIFF_FONT_SIZE で UI フォントを上書きできるようにする。日本語等幅フォント (HackGen, NotoSansJPMono 等) を選べる。

Closes #219

## 実装

- src/config.rs (UiConfig::from_env, terminal_cell_w/h を font_size 近似計算)
- ui/app.slint: font-family / terminal-font-size / diff-font-size プロパティ追加。Text の font-family を全箇所 root.font-family にバインド
- main.rs: run_terminal / run_diff_viewer で UiConfig を読み Slint プロパティに注入

## 注意

フォント変更時の PTY winsize 再ネゴは v0.0.x 範囲外。COLS/ROWS は 100x30 固定。再起動で値を変える。

## 検証

cargo build / clippy / test (106 passed, 2 新規)

## AI Review

- [ ] Codex verifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)