### PR TITLE
feat(#236): pre-validate LOCUS_AGENT_CMD with which

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,6 +3187,7 @@ dependencies = [
  "slint",
  "slint-build",
  "tokio",
+ "which",
 ]
 
 [[package]]
@@ -6563,6 +6564,15 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ portable-pty = "0.9.0"
 similar = "3.1.0"
 slint = "1.15.1"
 tokio = { version = "1.52.0", features = ["rt-multi-thread", "macros"] }
+which = "8.0.2"
 
 [build-dependencies]
 slint-build = "1.15.1"

--- a/lang/ja/LC_MESSAGES/locus.po
+++ b/lang/ja/LC_MESSAGES/locus.po
@@ -116,3 +116,12 @@ msgstr "PR 一覧の取得に失敗しました"
 
 msgid "Failed to fetch {} linked issue(s)"
 msgstr "{} 件の関連 issue の取得に失敗しました"
+
+msgid "{}: not found in PATH"
+msgstr "{}: PATH に見つかりません"
+
+msgid "Agent command not found"
+msgstr "エージェントコマンドが見つかりません"
+
+msgid "{}: not found in PATH (set LOCUS_AGENT_CMD)"
+msgstr "{}: PATH に見つかりません (LOCUS_AGENT_CMD を設定してください)"

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -129,6 +129,11 @@ fn translate_ja(key: &str) -> Option<&'static str> {
         // terminal status
         "{} (running)" => "{} (起動中)",
         "{}: failed to start ({})" => "{}: 起動失敗 ({})",
+        "{}: not found in PATH" => "{}: PATH に見つかりません",
+        "Agent command not found" => "エージェントコマンドが見つかりません",
+        "{}: not found in PATH (set LOCUS_AGENT_CMD)" => {
+            "{}: PATH に見つかりません (LOCUS_AGENT_CMD を設定してください)"
+        }
         _ => return None,
     })
 }
@@ -150,6 +155,22 @@ mod tests {
     fn lang_string() {
         assert_eq!(Locale::Ja.as_lang_string(), "ja");
         assert_eq!(Locale::En.as_lang_string(), "en");
+    }
+
+    #[test]
+    fn translate_ja_covers_agent_not_found_keys() {
+        assert_eq!(
+            translate_ja("{}: not found in PATH"),
+            Some("{}: PATH に見つかりません")
+        );
+        assert_eq!(
+            translate_ja("Agent command not found"),
+            Some("エージェントコマンドが見つかりません")
+        );
+        assert_eq!(
+            translate_ja("{}: not found in PATH (set LOCUS_AGENT_CMD)"),
+            Some("{}: PATH に見つかりません (LOCUS_AGENT_CMD を設定してください)")
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,41 +316,60 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Terminal pane を立ち上げる。起動コマンドは LOCUS_AGENT_CMD 環境変数で
-    // 上書きできる（既定は claude）。
+    // 上書きできる（既定は claude）。PATH に存在しなければ起動前に弾いて
+    // toast でユーザーに知らせ、launch 自体は skip する。
     let agent_cmd =
         std::env::var("LOCUS_AGENT_CMD").unwrap_or_else(|_| "claude".to_string());
-    let terminal_pane = match terminal::launch_for_diff_viewer(&ui, &agent_cmd) {
-        Ok(p) => {
-            ui.set_terminal_available(true);
+    let agent_resolution = which::which(&agent_cmd);
+    let terminal_pane: Option<Rc<terminal::TerminalPane>> = match agent_resolution {
+        Err(e) => {
+            eprintln!("warn: agent command '{agent_cmd}' not found in PATH: {e}");
+            ui.set_terminal_available(false);
             ui.set_terminal_status(SharedString::from(i18n::tr_args(
-                "{} (running)",
+                "{}: not found in PATH",
                 &[agent_cmd.as_str()],
             )));
-            Some(Rc::new(p))
-        }
-        Err(e) => {
-            eprintln!(
-                "warn: failed to launch terminal pane with '{agent_cmd}': {e} (continuing without terminal)"
-            );
-            ui.set_terminal_available(false);
-            let err = e.to_string();
-            ui.set_terminal_status(SharedString::from(i18n::tr_args(
-                "{}: failed to start ({})",
-                &[agent_cmd.as_str(), err.as_str()],
-            )));
-            // toast でユーザーに通知
-            let toast_id = state.borrow_mut().push_toast(
+            let id = state.borrow_mut().push_toast(
                 ToastKind::Error,
-                i18n::tr("Terminal pane failed to start"),
+                i18n::tr("Agent command not found"),
                 i18n::tr_args(
-                    "{}: {}",
-                    &[agent_cmd.as_str(), err.as_str()],
+                    "{}: not found in PATH (set LOCUS_AGENT_CMD)",
+                    &[agent_cmd.as_str()],
                 ),
             );
             refresh_toasts(&ui, &state);
-            schedule_toast_auto_dismiss(toast_id);
+            schedule_toast_auto_dismiss(id);
             None
         }
+        Ok(_) => match terminal::launch_for_diff_viewer(&ui, &agent_cmd) {
+            Ok(p) => {
+                ui.set_terminal_available(true);
+                ui.set_terminal_status(SharedString::from(i18n::tr_args(
+                    "{} (running)",
+                    &[agent_cmd.as_str()],
+                )));
+                Some(Rc::new(p))
+            }
+            Err(e) => {
+                eprintln!(
+                    "warn: failed to launch terminal pane with '{agent_cmd}': {e} (continuing without terminal)"
+                );
+                ui.set_terminal_available(false);
+                let err = e.to_string();
+                ui.set_terminal_status(SharedString::from(i18n::tr_args(
+                    "{}: failed to start ({})",
+                    &[agent_cmd.as_str(), err.as_str()],
+                )));
+                let toast_id = state.borrow_mut().push_toast(
+                    ToastKind::Error,
+                    i18n::tr("Terminal pane failed to start"),
+                    i18n::tr_args("{}: {}", &[agent_cmd.as_str(), err.as_str()]),
+                );
+                refresh_toasts(&ui, &state);
+                schedule_toast_auto_dismiss(toast_id);
+                None
+            }
+        },
     };
 
     refresh_current_anchor_label(&ui, &state);


### PR DESCRIPTION
## Summary

Terminal pane を起動する前に which::which() で LOCUS_AGENT_CMD の PATH 解決を試み、見つからなければ launch を skip して toast 通知。

Closes #236

## 検証
cargo build / clippy / test (106 passed)

## AI Review
- [ ] Codex verifier