### PR TITLE
feat: font metric measurement / PTY winsize / window resize 追従 (#252)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -35,9 +35,13 @@ impl UiConfig {
         }
     }
 
-    /// monospace の典型的な比率 (advance ≈ 0.6 em, line height ≈ 1.4 em)
-    /// から cell width/height をピクセルに変換する。
-    /// 本物の glyph metric を測る代わりに、十分実用的な近似値。
+    /// monospace の典型的な比率 (advance ≈ 0.6 em, line height ≈ 1.45 em)
+    /// から cell width/height をピクセルに変換する暫定値。
+    ///
+    /// 起動直後の Slint layout が settling していない短時間 (probe Text の
+    /// `preferred-width` / `preferred-height` がまだ 0) に fallback として
+    /// 使われる。実 glyph metric は `terminal-resized` callback 経由で
+    /// `measured-terminal-cell-w` / `measured-terminal-cell-h` から取得する。
     pub fn terminal_cell_w(&self) -> f32 {
         (self.terminal_font_size * 0.6).round().max(4.0)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,8 +76,41 @@ fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
     ui.set_font_size(ui_cfg.terminal_font_size);
     ui.set_cell_w(ui_cfg.terminal_cell_w());
     ui.set_cell_h(ui_cfg.terminal_cell_h());
-    let _pane = terminal::launch(&ui, command)?;
+    let pane = Rc::new(terminal::launch(&ui, command)?);
+    {
+        let pane = pane.clone();
+        let ui_weak = ui.as_weak();
+        let fallback_cell_w = ui_cfg.terminal_cell_w();
+        let fallback_cell_h = ui_cfg.terminal_cell_h();
+        ui.on_resized(move |w_logical: f32, h_logical: f32| {
+            let Some(ui) = ui_weak.upgrade() else {
+                return;
+            };
+            let mut cell_w = ui.get_measured_cell_w();
+            let mut cell_h = ui.get_measured_cell_h();
+            if cell_w <= 0.0 {
+                cell_w = fallback_cell_w;
+            }
+            if cell_h <= 0.0 {
+                cell_h = fallback_cell_h;
+            }
+            ui.set_cell_w(cell_w);
+            ui.set_cell_h(cell_h);
+            let (cols, rows) = terminal::compute_grid_size(w_logical, h_logical, cell_w, cell_h);
+            match pane.resize(cols, rows) {
+                Ok(()) => {
+                    let (cols_now, rows_now) = pane.current_size();
+                    ui.set_cols(cols_now as i32);
+                    ui.set_visible_rows(rows_now as i32);
+                }
+                Err(e) => {
+                    eprintln!("warn: terminal resize failed ({cols}x{rows}): {e}");
+                }
+            }
+        });
+    }
     ui.run()?;
+    drop(pane);
     Ok(())
 }
 
@@ -348,7 +381,9 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
                     "{} (running)",
                     &[agent_cmd.as_str()],
                 )));
-                Some(Rc::new(p))
+                let pane_rc = Rc::new(p);
+                wire_terminal_resize(&ui, pane_rc.clone(), &ui_cfg);
+                Some(pane_rc)
             }
             Err(e) => {
                 eprintln!(
@@ -843,6 +878,52 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
     ui.run()?;
     drop(terminal_pane);
     Ok(())
+}
+
+/// Slint の `terminal-resized` callback を `TerminalPane::resize` に橋渡しする。
+///
+/// Slint 側は terminal-pane Rectangle の `width` / `height` の changed callback
+/// から `terminal-resized(width, height)` を発火する。ここでは:
+///
+/// 1. UI から `measured-terminal-cell-w` / `measured-terminal-cell-h` を読み、
+///    cell-w / cell-h プロパティに反映する（render と PTY の grid を一致させる）。
+/// 2. (pane size / cell size) を floor して新しい cols / rows を算出する。
+/// 3. `TerminalPane::resize` で PTY + alacritty Term + row model を再構成する。
+fn wire_terminal_resize(
+    ui: &DiffViewerWindow,
+    pane: Rc<terminal::TerminalPane>,
+    fallback: &config::UiConfig,
+) {
+    let ui_weak = ui.as_weak();
+    let fallback_cell_w = fallback.terminal_cell_w();
+    let fallback_cell_h = fallback.terminal_cell_h();
+    ui.on_terminal_resized(move |w_logical: f32, h_logical: f32| {
+        let Some(ui) = ui_weak.upgrade() else {
+            return;
+        };
+        // 実 glyph metric が未測定 (= 0) の間は従来の比率近似を使う。
+        let mut cell_w = ui.get_measured_terminal_cell_w();
+        let mut cell_h = ui.get_measured_terminal_cell_h();
+        if cell_w <= 0.0 {
+            cell_w = fallback_cell_w;
+        }
+        if cell_h <= 0.0 {
+            cell_h = fallback_cell_h;
+        }
+        ui.set_terminal_cell_w(cell_w);
+        ui.set_terminal_cell_h(cell_h);
+        let (cols, rows) = terminal::compute_grid_size(w_logical, h_logical, cell_w, cell_h);
+        match pane.resize(cols, rows) {
+            Ok(()) => {
+                let (cols_now, rows_now) = pane.current_size();
+                ui.set_terminal_cols(cols_now as i32);
+                ui.set_terminal_rows_count(rows_now as i32);
+            }
+            Err(e) => {
+                eprintln!("warn: terminal resize failed ({cols}x{rows}): {e}");
+            }
+        }
+    });
 }
 
 fn apply_snapshot_to_ui(

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,11 @@ fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
             let Some(ui) = ui_weak.upgrade() else {
                 return;
             };
+            // 初期 layout settling や hidden 中の transient 0x0 では PTY を縮めない。
+            // measured-* も layout 確定前は 0 になるので両条件で skip する。
+            if w_logical <= 0.0 || h_logical <= 0.0 {
+                return;
+            }
             let mut cell_w = ui.get_measured_cell_w();
             let mut cell_h = ui.get_measured_cell_h();
             if cell_w <= 0.0 {
@@ -901,6 +906,11 @@ fn wire_terminal_resize(
         let Some(ui) = ui_weak.upgrade() else {
             return;
         };
+        // 初期 layout settling や hidden 中の transient 0x0 では PTY を縮めない。
+        // measured-* も layout 確定前は 0 になるので両条件で skip する。
+        if w_logical <= 0.0 || h_logical <= 0.0 {
+            return;
+        }
         // 実 glyph metric が未測定 (= 0) の間は従来の比率近似を使う。
         let mut cell_w = ui.get_measured_terminal_cell_w();
         let mut cell_h = ui.get_measured_terminal_cell_h();

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,12 +1,12 @@
 //! Terminal ペインの組み立て。
 //!
 //! `alacritty_terminal` の `Term` + `portable-pty` の子プロセスを Slint の
-//! `AppWindow` に接続する。既存挙動を壊さず `src/main.rs` からの一行呼び出しに
-//! まとめることだけを目的にしている。
+//! `AppWindow` に接続する。
 //!
-//! 注: v0.1 では Terminal ペインの COLS / ROWS を固定。リサイズ追従は後続
-//! Issue で扱う。
+//! 起動時の初期 grid サイズは `INITIAL_COLS` / `INITIAL_ROWS` だが、
+//! [`TerminalPane::resize`] でウィンドウリサイズや font 変更に追従する。
 
+use std::cell::RefCell;
 use std::io::{Read, Write};
 use std::rc::Rc;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
@@ -18,14 +18,56 @@ use alacritty_terminal::event::{Event, EventListener};
 use alacritty_terminal::grid::Dimensions;
 use alacritty_terminal::term::{Config, Term, TermDamage};
 use alacritty_terminal::vte::ansi::{Processor, StdSyncHandler};
-use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
 use crate::ui_state::{build_row, empty_row};
 use crate::{AppWindow, TerminalRow};
 
-const COLS: u16 = 100;
-const ROWS: u16 = 30;
+/// 起動時の初期グリッドサイズ。Slint の layout が走り `terminal-resized`
+/// callback が発火するまでの間だけ使われる暫定値。
+pub const INITIAL_COLS: u16 = 100;
+pub const INITIAL_ROWS: u16 = 30;
+
+/// `TerminalPane::resize` で受理する最小値。あまりに小さいと
+/// alacritty_terminal が panic するため。
+const MIN_COLS: u16 = 20;
+const MIN_ROWS: u16 = 5;
+
+/// 与えられた pane サイズと cell metric から (cols, rows) を算出する。
+///
+/// floor で求めた値を `MIN_COLS` / `MIN_ROWS` 以上 / `u16::MAX` 以下に
+/// 丸める。cell サイズが 0 以下のときは `MIN_COLS` / `MIN_ROWS` を返す
+/// （0 除算を避ける）。
+///
+/// pane サイズが負や 0 の場合も同様に最小値を返す。
+pub fn compute_grid_size(
+    pane_w: f32,
+    pane_h: f32,
+    cell_w: f32,
+    cell_h: f32,
+) -> (u16, u16) {
+    if cell_w <= 0.0 || cell_h <= 0.0 {
+        return (MIN_COLS, MIN_ROWS);
+    }
+    let raw_cols = if pane_w > 0.0 {
+        (pane_w / cell_w).floor() as i64
+    } else {
+        0
+    };
+    let raw_rows = if pane_h > 0.0 {
+        (pane_h / cell_h).floor() as i64
+    } else {
+        0
+    };
+    let cols = raw_cols
+        .max(MIN_COLS as i64)
+        .min(u16::MAX as i64) as u16;
+    let rows = raw_rows
+        .max(MIN_ROWS as i64)
+        .min(u16::MAX as i64) as u16;
+    (cols, rows)
+}
 
 /// alacritty_terminal に渡すイベントリスナ。PoC 以来何もしていない。
 #[derive(Clone, Default)]
@@ -101,8 +143,8 @@ pub fn translate_key(text: &str) -> Vec<u8> {
 pub fn launch(ui: &AppWindow, command: &str) -> Result<TerminalPane, Box<dyn std::error::Error>> {
     let pty_system = native_pty_system();
     let pair = pty_system.openpty(PtySize {
-        rows: ROWS,
-        cols: COLS,
+        rows: INITIAL_ROWS,
+        cols: INITIAL_COLS,
         pixel_width: 0,
         pixel_height: 0,
     })?;
@@ -121,12 +163,14 @@ pub fn launch(ui: &AppWindow, command: &str) -> Result<TerminalPane, Box<dyn std
         let _ = slint::quit_event_loop();
     });
 
-    let mut reader = pair.master.try_clone_reader()?;
-    let writer = Arc::new(Mutex::new(pair.master.take_writer()?));
+    let master = pair.master;
+    let mut reader = master.try_clone_reader()?;
+    let writer = Arc::new(Mutex::new(master.take_writer()?));
+    let master_pty: Arc<Mutex<Box<dyn MasterPty + Send>>> = Arc::new(Mutex::new(master));
 
     let size = TermSize {
-        cols: COLS as usize,
-        rows: ROWS as usize,
+        cols: INITIAL_COLS as usize,
+        rows: INITIAL_ROWS as usize,
     };
     let term = Arc::new(Mutex::new(Term::new(Config::default(), &size, EventProxy)));
 
@@ -146,12 +190,12 @@ pub fn launch(ui: &AppWindow, command: &str) -> Result<TerminalPane, Box<dyn std
         }
     });
 
-    ui.set_cols(COLS as i32);
-    ui.set_visible_rows(ROWS as i32);
+    ui.set_cols(INITIAL_COLS as i32);
+    ui.set_visible_rows(INITIAL_ROWS as i32);
 
     let row_model = Rc::new(VecModel::<TerminalRow>::default());
-    for _ in 0..ROWS {
-        row_model.push(empty_row(COLS as usize));
+    for _ in 0..INITIAL_ROWS {
+        row_model.push(empty_row(INITIAL_COLS as usize));
     }
     ui.set_rows(ModelRc::from(row_model.clone()));
 
@@ -170,9 +214,11 @@ pub fn launch(ui: &AppWindow, command: &str) -> Result<TerminalPane, Box<dyn std
     }
 
     let processor = Arc::new(Mutex::new(Processor::<StdSyncHandler>::new()));
+    let current_size = Rc::new(RefCell::new((INITIAL_COLS, INITIAL_ROWS)));
     let term_for_timer = term.clone();
     let processor_for_timer = processor.clone();
     let row_model_for_timer = row_model.clone();
+    let current_size_for_timer = current_size.clone();
     let ui_weak = ui.as_weak();
     let timer = slint::Timer::default();
     timer.start(
@@ -193,18 +239,20 @@ pub fn launch(ui: &AppWindow, command: &str) -> Result<TerminalPane, Box<dyn std
             }
             let damage = collect_damaged_lines(&mut *term_guard);
             let cursor = term_guard.grid().cursor.point;
-            let total_rows = ROWS as usize;
+            let (cols_now, rows_now) = *current_size_for_timer.borrow();
+            let total_rows = rows_now as usize;
+            let cols_usize = cols_now as usize;
             match damage {
                 DamageList::All => {
                     for r in 0..total_rows {
-                        let row = build_row(&*term_guard, r, COLS as usize);
+                        let row = build_row(&*term_guard, r, cols_usize);
                         row_model_for_timer.set_row_data(r, row);
                     }
                 }
                 DamageList::Some(lines) => {
                     for r in lines {
                         if r < total_rows {
-                            let row = build_row(&*term_guard, r, COLS as usize);
+                            let row = build_row(&*term_guard, r, cols_usize);
                             row_model_for_timer.set_row_data(r, row);
                         }
                     }
@@ -220,8 +268,11 @@ pub fn launch(ui: &AppWindow, command: &str) -> Result<TerminalPane, Box<dyn std
     Ok(TerminalPane {
         _timer: timer,
         writer,
-        _term: term,
+        term,
         _processor: processor,
+        master_pty,
+        row_model,
+        current_size,
     })
 }
 
@@ -235,8 +286,8 @@ pub fn launch_for_diff_viewer(
 ) -> Result<TerminalPane, Box<dyn std::error::Error>> {
     let pty_system = native_pty_system();
     let pair = pty_system.openpty(PtySize {
-        rows: ROWS,
-        cols: COLS,
+        rows: INITIAL_ROWS,
+        cols: INITIAL_COLS,
         pixel_width: 0,
         pixel_height: 0,
     })?;
@@ -256,12 +307,14 @@ pub fn launch_for_diff_viewer(
         // 死ぬのが想定される）。
     });
 
-    let mut reader = pair.master.try_clone_reader()?;
-    let writer = Arc::new(Mutex::new(pair.master.take_writer()?));
+    let master = pair.master;
+    let mut reader = master.try_clone_reader()?;
+    let writer = Arc::new(Mutex::new(master.take_writer()?));
+    let master_pty: Arc<Mutex<Box<dyn MasterPty + Send>>> = Arc::new(Mutex::new(master));
 
     let size = TermSize {
-        cols: COLS as usize,
-        rows: ROWS as usize,
+        cols: INITIAL_COLS as usize,
+        rows: INITIAL_ROWS as usize,
     };
     let term = Arc::new(Mutex::new(Term::new(Config::default(), &size, EventProxy)));
 
@@ -281,12 +334,12 @@ pub fn launch_for_diff_viewer(
         }
     });
 
-    ui.set_terminal_cols(COLS as i32);
-    ui.set_terminal_rows_count(ROWS as i32);
+    ui.set_terminal_cols(INITIAL_COLS as i32);
+    ui.set_terminal_rows_count(INITIAL_ROWS as i32);
 
     let row_model = Rc::new(VecModel::<TerminalRow>::default());
-    for _ in 0..ROWS {
-        row_model.push(empty_row(COLS as usize));
+    for _ in 0..INITIAL_ROWS {
+        row_model.push(empty_row(INITIAL_COLS as usize));
     }
     ui.set_terminal_rows(ModelRc::from(row_model.clone()));
 
@@ -305,9 +358,11 @@ pub fn launch_for_diff_viewer(
     }
 
     let processor = Arc::new(Mutex::new(Processor::<StdSyncHandler>::new()));
+    let current_size = Rc::new(RefCell::new((INITIAL_COLS, INITIAL_ROWS)));
     let term_for_timer = term.clone();
     let processor_for_timer = processor.clone();
     let row_model_for_timer = row_model.clone();
+    let current_size_for_timer = current_size.clone();
     let ui_weak = ui.as_weak();
     let timer = slint::Timer::default();
     timer.start(
@@ -328,18 +383,20 @@ pub fn launch_for_diff_viewer(
             }
             let damage = collect_damaged_lines(&mut *term_guard);
             let cursor = term_guard.grid().cursor.point;
-            let total_rows = ROWS as usize;
+            let (cols_now, rows_now) = *current_size_for_timer.borrow();
+            let total_rows = rows_now as usize;
+            let cols_usize = cols_now as usize;
             match damage {
                 DamageList::All => {
                     for r in 0..total_rows {
-                        let row = build_row(&*term_guard, r, COLS as usize);
+                        let row = build_row(&*term_guard, r, cols_usize);
                         row_model_for_timer.set_row_data(r, row);
                     }
                 }
                 DamageList::Some(lines) => {
                     for r in lines {
                         if r < total_rows {
-                            let row = build_row(&*term_guard, r, COLS as usize);
+                            let row = build_row(&*term_guard, r, cols_usize);
                             row_model_for_timer.set_row_data(r, row);
                         }
                     }
@@ -355,20 +412,26 @@ pub fn launch_for_diff_viewer(
     Ok(TerminalPane {
         _timer: timer,
         writer,
-        _term: term,
+        term,
         _processor: processor,
+        master_pty,
+        row_model,
+        current_size,
     })
 }
 
 /// Terminal ペインを活きた状態に保つためのオーナーシップ束。
 ///
-/// 所有者が drop されると Timer と PTY writer / Term も落ちる。呼び出し側は
-/// イベントループが終わるまでこの値を保持する責任がある。
+/// 所有者が drop されると Timer と PTY writer / Term / master も落ちる。
+/// 呼び出し側はイベントループが終わるまでこの値を保持する責任がある。
 pub struct TerminalPane {
     _timer: slint::Timer,
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
-    _term: Arc<Mutex<Term<EventProxy>>>,
+    term: Arc<Mutex<Term<EventProxy>>>,
     _processor: Arc<Mutex<Processor<StdSyncHandler>>>,
+    master_pty: Arc<Mutex<Box<dyn MasterPty + Send>>>,
+    row_model: Rc<VecModel<TerminalRow>>,
+    current_size: Rc<RefCell<(u16, u16)>>,
 }
 
 impl TerminalPane {
@@ -404,6 +467,61 @@ impl TerminalPane {
             let _ = w.flush();
         }
     }
+
+    /// 現在の (cols, rows)。Slint UI の表示行数同期に使う。
+    pub fn current_size(&self) -> (u16, u16) {
+        *self.current_size.borrow()
+    }
+
+    /// PTY / alacritty Term / Slint row model を新しい (cols, rows) に
+    /// 合わせて再構築する。サイズが変わらなければ no-op。
+    ///
+    /// PTY 側は SIGWINCH を子プロセスに送るため、bash や agent CLI は
+    /// 自動で折り返し位置を更新する。
+    pub fn resize(&self, cols: u16, rows: u16) -> Result<(), Box<dyn std::error::Error>> {
+        let cols = cols.max(MIN_COLS);
+        let rows = rows.max(MIN_ROWS);
+
+        {
+            let current = self.current_size.borrow();
+            if current.0 == cols && current.1 == rows {
+                return Ok(());
+            }
+        }
+
+        // PTY: ioctl(TIOCSWINSZ) を子プロセスに飛ばす。
+        self.master_pty.lock().unwrap().resize(PtySize {
+            cols,
+            rows,
+            pixel_width: 0,
+            pixel_height: 0,
+        })?;
+
+        // alacritty Term: グリッドを内部で再アロケート。
+        let mut term = self.term.lock().unwrap();
+        term.resize(TermSize {
+            cols: cols as usize,
+            rows: rows as usize,
+        });
+
+        // Slint VecModel: 行数を合わせ、全行を再描画。
+        let total = rows as usize;
+        let cols_usize = cols as usize;
+        while self.row_model.row_count() > total {
+            self.row_model.remove(self.row_model.row_count() - 1);
+        }
+        while self.row_model.row_count() < total {
+            self.row_model.push(empty_row(cols_usize));
+        }
+        for r in 0..total {
+            let row = build_row(&*term, r, cols_usize);
+            self.row_model.set_row_data(r, row);
+        }
+
+        *self.current_size.borrow_mut() = (cols, rows);
+
+        Ok(())
+    }
 }
 
 /// PTY に流す前に制御文字を無害化する。
@@ -426,7 +544,49 @@ fn sanitize_for_pty(text: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{sanitize_for_pty, translate_key};
+    use super::{compute_grid_size, sanitize_for_pty, translate_key, MIN_COLS, MIN_ROWS};
+
+    #[test]
+    fn compute_grid_size_floors_pane_div_cell() {
+        // 800px / 8px = 100 cols, 200px / 16px = 12.5 → 12 rows
+        let (cols, rows) = compute_grid_size(800.0, 200.0, 8.0, 16.0);
+        assert_eq!(cols, 100);
+        assert_eq!(rows, 12);
+    }
+
+    #[test]
+    fn compute_grid_size_clamps_below_minimum() {
+        // 50px / 8px = 6 → MIN_COLS, 30px / 16px = 1 → MIN_ROWS
+        let (cols, rows) = compute_grid_size(50.0, 30.0, 8.0, 16.0);
+        assert_eq!(cols, MIN_COLS);
+        assert_eq!(rows, MIN_ROWS);
+    }
+
+    #[test]
+    fn compute_grid_size_returns_minimum_for_zero_or_negative_inputs() {
+        let (cols, rows) = compute_grid_size(0.0, 0.0, 8.0, 16.0);
+        assert_eq!((cols, rows), (MIN_COLS, MIN_ROWS));
+        let (cols, rows) = compute_grid_size(-100.0, -100.0, 8.0, 16.0);
+        assert_eq!((cols, rows), (MIN_COLS, MIN_ROWS));
+    }
+
+    #[test]
+    fn compute_grid_size_returns_minimum_when_cell_size_invalid() {
+        let (cols, rows) = compute_grid_size(800.0, 200.0, 0.0, 16.0);
+        assert_eq!((cols, rows), (MIN_COLS, MIN_ROWS));
+        let (cols, rows) = compute_grid_size(800.0, 200.0, 8.0, 0.0);
+        assert_eq!((cols, rows), (MIN_COLS, MIN_ROWS));
+        let (cols, rows) = compute_grid_size(800.0, 200.0, -1.0, 16.0);
+        assert_eq!((cols, rows), (MIN_COLS, MIN_ROWS));
+    }
+
+    #[test]
+    fn compute_grid_size_caps_at_u16_max() {
+        // 巨大な pane / 極小 cell → u16::MAX で頭打ち
+        let (cols, rows) = compute_grid_size(1.0e9, 1.0e9, 1.0, 1.0);
+        assert_eq!(cols, u16::MAX);
+        assert_eq!(rows, u16::MAX);
+    }
 
     #[test]
     fn sanitize_preserves_newlines_and_tabs() {

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -34,10 +34,16 @@ pub const INITIAL_ROWS: u16 = 30;
 const MIN_COLS: u16 = 20;
 const MIN_ROWS: u16 = 5;
 
+/// `compute_grid_size` の上限。極小 cell metric や巨大 pane が来た際に
+/// alacritty Term / VecModel が現実離れしたサイズで構築されるのを防ぐ。
+/// 通常端末で 500 cols / 200 rows を超えるユースケースは想定しない。
+const MAX_COLS: u16 = 500;
+const MAX_ROWS: u16 = 200;
+
 /// 与えられた pane サイズと cell metric から (cols, rows) を算出する。
 ///
-/// floor で求めた値を `MIN_COLS` / `MIN_ROWS` 以上 / `u16::MAX` 以下に
-/// 丸める。cell サイズが 0 以下のときは `MIN_COLS` / `MIN_ROWS` を返す
+/// floor で求めた値を `MIN_COLS` / `MIN_ROWS` 以上、`MAX_COLS` / `MAX_ROWS`
+/// 以下に丸める。cell サイズが 0 以下のときは `MIN_COLS` / `MIN_ROWS` を返す
 /// （0 除算を避ける）。
 ///
 /// pane サイズが負や 0 の場合も同様に最小値を返す。
@@ -61,11 +67,9 @@ pub fn compute_grid_size(
         0
     };
     let cols = raw_cols
-        .max(MIN_COLS as i64)
-        .min(u16::MAX as i64) as u16;
+        .clamp(MIN_COLS as i64, MAX_COLS as i64) as u16;
     let rows = raw_rows
-        .max(MIN_ROWS as i64)
-        .min(u16::MAX as i64) as u16;
+        .clamp(MIN_ROWS as i64, MAX_ROWS as i64) as u16;
     (cols, rows)
 }
 
@@ -581,11 +585,11 @@ mod tests {
     }
 
     #[test]
-    fn compute_grid_size_caps_at_u16_max() {
-        // 巨大な pane / 極小 cell → u16::MAX で頭打ち
+    fn compute_grid_size_caps_at_max() {
+        // 巨大な pane / 極小 cell → MAX_COLS / MAX_ROWS で頭打ち
         let (cols, rows) = compute_grid_size(1.0e9, 1.0e9, 1.0, 1.0);
-        assert_eq!(cols, u16::MAX);
-        assert_eq!(rows, u16::MAX);
+        assert_eq!(cols, super::MAX_COLS);
+        assert_eq!(rows, super::MAX_ROWS);
     }
 
     #[test]

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -28,7 +28,10 @@ export component AppWindow inherits Window {
     // 隠し Text。フォントの実 advance 幅 / 行高を Slint の text shaping
     // 経由で取得する。font-family / font-size を変えると preferred-* も
     // 追従するので reactive に measured-* が更新される。
-    out property <length> measured-cell-w: monospace-probe.preferred-width;
+    //
+    // 単一 "M" だと丸め誤差が advance 幅 1px ぶん振れることがあるので、10 文字
+    // 並べた preferred-width を 10 で割って advance あたりに均す。
+    out property <length> measured-cell-w: monospace-probe.preferred-width / 10;
     out property <length> measured-cell-h: monospace-probe.preferred-height;
 
     callback key-pressed(string);
@@ -42,7 +45,7 @@ export component AppWindow inherits Window {
     forward-focus: focus-area;
 
     monospace-probe := Text {
-        text: "M";
+        text: "MMMMMMMMMM";
         font-family: root.font-family;
         font-size: root.font-size;
         visible: false;
@@ -228,11 +231,12 @@ export component DiffViewerWindow inherits Window {
     callback pr-filter-changed(int);
 
     // 隠し Text。Slint の text shaping で実 advance 幅 / 行高を測定する。
-    out property <length> measured-terminal-cell-w: terminal-monospace-probe.preferred-width;
+    // 単一 "M" だと丸め誤差が出やすいので 10 文字並べて 10 で割る。
+    out property <length> measured-terminal-cell-w: terminal-monospace-probe.preferred-width / 10;
     out property <length> measured-terminal-cell-h: terminal-monospace-probe.preferred-height;
 
     terminal-monospace-probe := Text {
-        text: "M";
+        text: "MMMMMMMMMM";
         font-family: root.font-family;
         font-size: root.terminal-font-size;
         visible: false;

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -25,6 +25,12 @@ export component AppWindow inherits Window {
     in property <string> font-family: "Menlo, Consolas, monospace";
     in property <length> font-size: 13px;
 
+    // 隠し Text。フォントの実 advance 幅 / 行高を Slint の text shaping
+    // 経由で取得する。font-family / font-size を変えると preferred-* も
+    // 追従するので reactive に measured-* が更新される。
+    out property <length> measured-cell-w: monospace-probe.preferred-width;
+    out property <length> measured-cell-h: monospace-probe.preferred-height;
+
     callback key-pressed(string);
     callback resized(length, length);
 
@@ -35,14 +41,39 @@ export component AppWindow inherits Window {
 
     forward-focus: focus-area;
 
+    monospace-probe := Text {
+        text: "M";
+        font-family: root.font-family;
+        font-size: root.font-size;
+        visible: false;
+        x: -10000px;
+        y: -10000px;
+    }
+
+    // フォントロード遅延で probe の measured-* が後追い更新されたケースの
+    // ためにバックアップ発火する。
+    changed measured-cell-w => {
+        root.resized(terminal-area.width, terminal-area.height);
+    }
+    changed measured-cell-h => {
+        root.resized(terminal-area.width, terminal-area.height);
+    }
+
     focus-area := FocusScope {
         key-pressed(event) => {
             root.key-pressed(event.text);
             accept
         }
 
-        Rectangle {
+        terminal-area := Rectangle {
             background: #0b0b0b;
+
+            changed width => {
+                root.resized(self.width, self.height);
+            }
+            changed height => {
+                root.resized(self.width, self.height);
+            }
 
             // セルグリッドを行ごとに重ねる
             for row[ri] in root.rows: Rectangle {
@@ -191,9 +222,34 @@ export component DiffViewerWindow inherits Window {
     callback send-insert-and-send(string);
     callback send-copy-to-clipboard(string);
     callback terminal-key-pressed(string);
+    callback terminal-resized(length, length);
 
     callback pr-clicked(int);
     callback pr-filter-changed(int);
+
+    // 隠し Text。Slint の text shaping で実 advance 幅 / 行高を測定する。
+    out property <length> measured-terminal-cell-w: terminal-monospace-probe.preferred-width;
+    out property <length> measured-terminal-cell-h: terminal-monospace-probe.preferred-height;
+
+    terminal-monospace-probe := Text {
+        text: "M";
+        font-family: root.font-family;
+        font-size: root.terminal-font-size;
+        visible: false;
+        x: -10000px;
+        y: -10000px;
+    }
+
+    // measured-* が初期 (=0) → 実測値 に切り替わったタイミングでも cols/rows を
+    // 再計算するため再発火する。terminal-pane の changed width/height が
+    // layout 確定で 1 回だけ呼ばれた後、フォントロード遅延で probe が
+    // 後追いした場合のためのバックアップ。
+    changed measured-terminal-cell-w => {
+        root.terminal-resized(terminal-pane.width, terminal-pane.height);
+    }
+    changed measured-terminal-cell-h => {
+        root.terminal-resized(terminal-pane.width, terminal-pane.height);
+    }
 
     title: @tr("locus — diff viewer");
     preferred-width: 1700px;
@@ -774,12 +830,19 @@ export component DiffViewerWindow inherits Window {
                     }
 
                     // Terminal pane (bottom)
-                    Rectangle {
+                    terminal-pane := Rectangle {
                         height: 258px;
                         background: #0b0b0b;
                         border-width: 1px;
                         border-color: #24242c;
                         clip: true;
+
+                        changed width => {
+                            root.terminal-resized(self.width, self.height);
+                        }
+                        changed height => {
+                            root.terminal-resized(self.width, self.height);
+                        }
 
                         terminal-focus := FocusScope {
                             key-pressed(event) => {


### PR DESCRIPTION
## Summary

Closes #252

#219 で env override は実装したが範囲外として残っていた以下を実装:
- font の実 glyph metric 測定 (Slint Text probe 経由)
- ウィンドウリサイズ時の COLS/ROWS 再計算 + PTY winsize 再ネゴ
- フォント変更時 (将来 runtime 切替時) も同じ経路を走る

## 変更点

### Slint (ui/app.slint)
- 隠し Text \`monospace-probe\` を追加。\`preferred-width\` / \`preferred-height\` を \`measured-cell-w\` / \`measured-cell-h\` (terminal pane 用は \`measured-terminal-*\`) として公開
- \`terminal-pane := Rectangle\` の \`changed width\` / \`changed height\` で \`terminal-resized\` callback 発火
- \`measured-*\` の \`changed\` で再発火 (font 遅延ロード対策)

### Rust (src/terminal/mod.rs)
- \`TerminalPane\` が \`master_pty\` / \`row_model\` / \`current_size\` を保持
- \`TerminalPane::resize(cols, rows)\` で PTY (TIOCSWINSZ) + alacritty Term + VecModel を一括再構成
- \`compute_grid_size(pane_w, pane_h, cell_w, cell_h)\` を pure function 切り出し + 5 case の境界 unit test
- \`MIN_COLS=20\` / \`MIN_ROWS=5\` で alacritty panic 回避
- \`INITIAL_COLS=100\` / \`INITIAL_ROWS=30\` は layout 確定までの暫定値

### Rust (src/main.rs)
- \`on_terminal_resized\` / \`on_resized\` を \`TerminalPane::resize\` に橋渡し
- \`measured-*\` を読んで \`terminal-cell-w/h\` を実測値で上書き
- \`measured-*\` が 0 のときは \`ui_cfg.terminal_cell_w/h()\` を fallback

### Rust (src/config.rs)
- \`terminal_cell_w/h\` docstring を「probe 確定までの fallback」と明記

## Acceptance Criteria 検証

- [x] LOCUS_TERMINAL_FONT_SIZE=20 等の大きいフォントで bash プロンプトが折り返される
  → probe で実測した cell サイズを使って cols が縮むので折り返しが揃う設計。実機目視は要確認
- [x] ウィンドウリサイズで terminal pane の cell が追従する
  → \`changed width\` で resized callback → PTY/Term/row_model 再構成。実機目視は要確認
- [x] HackGen / NotoSansJPMono 等の日本語等幅フォントで wrap がずれない
  → Slint の text shaping が advance 幅を返すので font に依存しない。実機目視は要確認

⚠️ UI 動作確認はヘッドレス環境では実施できていません。マージ前に LOCUS_TERMINAL_FONT_SIZE / LOCUS_FONT_FAMILY を変えながら手元で確認してください。

## Test plan
- [x] cargo clippy --all-targets -- -D warnings (PASS)
- [x] cargo test (112 passed, 5 新規)
- [ ] (手動) cargo run で AppWindow を起動し、ウィンドウ幅を変えて bash プロンプトの折り返しを確認
- [ ] (手動) cargo run -- github <pr> で diff viewer を起動し、terminal pane の cols が追従することを確認
- [ ] (手動) LOCUS_TERMINAL_FONT_SIZE=20 で起動し、cols が小さくなり折り返し位置が揃うことを確認