### PR TITLE
feat: LOCUS_BRACKETED_PASTE で paste 境界 sequence をオプション化 (#237)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,10 @@ pub struct UiConfig {
     pub font_family: String,
     pub terminal_font_size: f32,
     pub diff_font_size: f32,
+    /// PromptDraft を PTY に流し込む際に bracketed paste mode で囲うかどうか。
+    /// 非対応 shell / agent CLI では `\x1b[200~` 等が文字としてそのまま表示
+    /// されるため、`LOCUS_BRACKETED_PASTE=false` で raw 送信に切り替えられる。
+    pub bracketed_paste: bool,
 }
 
 impl UiConfig {
@@ -28,10 +32,15 @@ impl UiConfig {
             .and_then(|s| s.parse::<f32>().ok())
             .or(general)
             .unwrap_or(12.0);
+        let bracketed_paste = parse_bracketed_paste_env(
+            std::env::var("LOCUS_BRACKETED_PASTE").ok().as_deref(),
+            std::env::var("TERM").ok().as_deref(),
+        );
         Self {
             font_family,
             terminal_font_size,
             diff_font_size,
+            bracketed_paste,
         }
     }
 
@@ -51,6 +60,39 @@ impl UiConfig {
     }
 }
 
+/// `LOCUS_BRACKETED_PASTE` の値から bracketed paste mode の使用可否を決める。
+///
+/// - 未設定 / 空文字 → `true` (現状互換: 殆どの xterm-256color 接続で動く)
+/// - `0` / `false` / `off` / `no` → `false`
+/// - `1` / `true` / `on` / `yes` → `true`
+/// - `auto` → host `$TERM` から推定 (xterm / screen / tmux / rxvt / alacritty 系は `true`)
+/// - それ以外の文字列 → `true` (fail-open: paste 機能を不用意に殺さない)
+pub fn parse_bracketed_paste_env(value: Option<&str>, host_term: Option<&str>) -> bool {
+    match value.map(str::trim) {
+        None | Some("") => true,
+        Some(v) => match v.to_ascii_lowercase().as_str() {
+            "0" | "false" | "off" | "no" => false,
+            "1" | "true" | "on" | "yes" => true,
+            "auto" => host_term.map(is_bracketed_paste_capable).unwrap_or(false),
+            _ => true,
+        },
+    }
+}
+
+/// よく見る xterm 互換 terminal emulator の TERM プレフィクスから bracketed
+/// paste 対応を推定する。完全には網羅できないので「auto」モード時のヒント
+/// 用途。空 / 未対応と分かっている TERM では `false`。
+fn is_bracketed_paste_capable(term: &str) -> bool {
+    if term.is_empty() {
+        return false;
+    }
+    if term == "alacritty" || term == "wezterm" || term == "kitty" {
+        return true;
+    }
+    let prefixes = ["xterm", "screen", "tmux", "rxvt", "vte", "konsole", "iterm"];
+    prefixes.iter().any(|p| term.starts_with(p))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -61,6 +103,7 @@ mod tests {
             font_family: "test".into(),
             terminal_font_size: 12.0,
             diff_font_size: 12.0,
+            bracketed_paste: true,
         };
         assert!(cfg.terminal_cell_w() >= 6.0);
         assert!(cfg.terminal_cell_h() >= 14.0);
@@ -72,13 +115,53 @@ mod tests {
             font_family: "x".into(),
             terminal_font_size: 10.0,
             diff_font_size: 10.0,
+            bracketed_paste: true,
         };
         let big = UiConfig {
             font_family: "x".into(),
             terminal_font_size: 20.0,
             diff_font_size: 20.0,
+            bracketed_paste: true,
         };
         assert!(big.terminal_cell_w() > small.terminal_cell_w());
         assert!(big.terminal_cell_h() > small.terminal_cell_h());
+    }
+
+    #[test]
+    fn bracketed_paste_default_is_on() {
+        assert!(parse_bracketed_paste_env(None, None));
+        assert!(parse_bracketed_paste_env(Some(""), None));
+        assert!(parse_bracketed_paste_env(Some("   "), None));
+    }
+
+    #[test]
+    fn bracketed_paste_explicit_off() {
+        for v in ["0", "false", "False", "OFF", "no"] {
+            assert!(!parse_bracketed_paste_env(Some(v), Some("xterm-256color")));
+        }
+    }
+
+    #[test]
+    fn bracketed_paste_explicit_on() {
+        for v in ["1", "true", "True", "on", "yes"] {
+            assert!(parse_bracketed_paste_env(Some(v), Some("dumb")));
+        }
+    }
+
+    #[test]
+    fn bracketed_paste_auto_uses_term_heuristic() {
+        assert!(parse_bracketed_paste_env(Some("auto"), Some("xterm-256color")));
+        assert!(parse_bracketed_paste_env(Some("auto"), Some("screen")));
+        assert!(parse_bracketed_paste_env(Some("auto"), Some("tmux-256color")));
+        assert!(parse_bracketed_paste_env(Some("auto"), Some("alacritty")));
+        assert!(!parse_bracketed_paste_env(Some("auto"), Some("dumb")));
+        assert!(!parse_bracketed_paste_env(Some("auto"), Some("vt100")));
+        assert!(!parse_bracketed_paste_env(Some("auto"), None));
+    }
+
+    #[test]
+    fn bracketed_paste_unknown_value_fails_open() {
+        // 「fail-open」: paste 機能を不用意に殺さないため未知値は true
+        assert!(parse_bracketed_paste_env(Some("garbage"), Some("dumb")));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,10 +32,8 @@ impl UiConfig {
             .and_then(|s| s.parse::<f32>().ok())
             .or(general)
             .unwrap_or(12.0);
-        let bracketed_paste = parse_bracketed_paste_env(
-            std::env::var("LOCUS_BRACKETED_PASTE").ok().as_deref(),
-            std::env::var("TERM").ok().as_deref(),
-        );
+        let bracketed_paste =
+            parse_bracketed_paste_env(std::env::var("LOCUS_BRACKETED_PASTE").ok().as_deref());
         Self {
             font_family,
             terminal_font_size,
@@ -62,35 +60,20 @@ impl UiConfig {
 
 /// `LOCUS_BRACKETED_PASTE` の値から bracketed paste mode の使用可否を決める。
 ///
-/// - 未設定 / 空文字 → `true` (現状互換: 殆どの xterm-256color 接続で動く)
-/// - `0` / `false` / `off` / `no` → `false`
+/// - 未設定 / 空文字 → `true` (既定。spawn 時に `TERM=xterm-256color` を
+///   常時セットしているため、bash や殆どの agent CLI は paste 扱いになる)
+/// - `0` / `false` / `off` / `no` → `false` (raw 送信)
 /// - `1` / `true` / `on` / `yes` → `true`
-/// - `auto` → host `$TERM` から推定 (xterm / screen / tmux / rxvt / alacritty 系は `true`)
 /// - それ以外の文字列 → `true` (fail-open: paste 機能を不用意に殺さない)
-pub fn parse_bracketed_paste_env(value: Option<&str>, host_term: Option<&str>) -> bool {
+///
+/// host 側の `$TERM` は参照しない。子プロセス側の TERM は spawn 時に
+/// `xterm-256color` で固定済みであり、実際に paste sequence を解釈するのは
+/// 子プロセスの parser (bash / agent CLI 自体) だからである。
+pub fn parse_bracketed_paste_env(value: Option<&str>) -> bool {
     match value.map(str::trim) {
         None | Some("") => true,
-        Some(v) => match v.to_ascii_lowercase().as_str() {
-            "0" | "false" | "off" | "no" => false,
-            "1" | "true" | "on" | "yes" => true,
-            "auto" => host_term.map(is_bracketed_paste_capable).unwrap_or(false),
-            _ => true,
-        },
+        Some(v) => !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "off" | "no"),
     }
-}
-
-/// よく見る xterm 互換 terminal emulator の TERM プレフィクスから bracketed
-/// paste 対応を推定する。完全には網羅できないので「auto」モード時のヒント
-/// 用途。空 / 未対応と分かっている TERM では `false`。
-fn is_bracketed_paste_capable(term: &str) -> bool {
-    if term.is_empty() {
-        return false;
-    }
-    if term == "alacritty" || term == "wezterm" || term == "kitty" {
-        return true;
-    }
-    let prefixes = ["xterm", "screen", "tmux", "rxvt", "vte", "konsole", "iterm"];
-    prefixes.iter().any(|p| term.starts_with(p))
 }
 
 #[cfg(test)]
@@ -129,39 +112,29 @@ mod tests {
 
     #[test]
     fn bracketed_paste_default_is_on() {
-        assert!(parse_bracketed_paste_env(None, None));
-        assert!(parse_bracketed_paste_env(Some(""), None));
-        assert!(parse_bracketed_paste_env(Some("   "), None));
+        assert!(parse_bracketed_paste_env(None));
+        assert!(parse_bracketed_paste_env(Some("")));
+        assert!(parse_bracketed_paste_env(Some("   ")));
     }
 
     #[test]
     fn bracketed_paste_explicit_off() {
         for v in ["0", "false", "False", "OFF", "no"] {
-            assert!(!parse_bracketed_paste_env(Some(v), Some("xterm-256color")));
+            assert!(!parse_bracketed_paste_env(Some(v)));
         }
     }
 
     #[test]
     fn bracketed_paste_explicit_on() {
         for v in ["1", "true", "True", "on", "yes"] {
-            assert!(parse_bracketed_paste_env(Some(v), Some("dumb")));
+            assert!(parse_bracketed_paste_env(Some(v)));
         }
     }
 
     #[test]
-    fn bracketed_paste_auto_uses_term_heuristic() {
-        assert!(parse_bracketed_paste_env(Some("auto"), Some("xterm-256color")));
-        assert!(parse_bracketed_paste_env(Some("auto"), Some("screen")));
-        assert!(parse_bracketed_paste_env(Some("auto"), Some("tmux-256color")));
-        assert!(parse_bracketed_paste_env(Some("auto"), Some("alacritty")));
-        assert!(!parse_bracketed_paste_env(Some("auto"), Some("dumb")));
-        assert!(!parse_bracketed_paste_env(Some("auto"), Some("vt100")));
-        assert!(!parse_bracketed_paste_env(Some("auto"), None));
-    }
-
-    #[test]
     fn bracketed_paste_unknown_value_fails_open() {
-        // 「fail-open」: paste 機能を不用意に殺さないため未知値は true
-        assert!(parse_bracketed_paste_env(Some("garbage"), Some("dumb")));
+        // fail-open: paste 機能を不用意に殺さないため未知値は true
+        assert!(parse_bracketed_paste_env(Some("garbage")));
+        assert!(parse_bracketed_paste_env(Some("auto"))); // 旧 auto モードも fail-open
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
     ui.set_font_size(ui_cfg.terminal_font_size);
     ui.set_cell_w(ui_cfg.terminal_cell_w());
     ui.set_cell_h(ui_cfg.terminal_cell_h());
-    let pane = Rc::new(terminal::launch(&ui, command)?);
+    let pane = Rc::new(terminal::launch(&ui, command, ui_cfg.bracketed_paste)?);
     {
         let pane = pane.clone();
         let ui_weak = ui.as_weak();
@@ -379,7 +379,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
             schedule_toast_auto_dismiss(id);
             None
         }
-        Ok(_) => match terminal::launch_for_diff_viewer(&ui, &agent_cmd) {
+        Ok(_) => match terminal::launch_for_diff_viewer(&ui, &agent_cmd, ui_cfg.bracketed_paste) {
             Ok(p) => {
                 ui.set_terminal_available(true);
                 ui.set_terminal_status(SharedString::from(i18n::tr_args(

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -144,7 +144,14 @@ pub fn translate_key(text: &str) -> Vec<u8> {
 ///
 /// 戻り値の [`TerminalPane`] は Timer と PTY 所有権をまとめて保持し、
 /// イベントループが回っている間 drop されないようにする。
-pub fn launch(ui: &AppWindow, command: &str) -> Result<TerminalPane, Box<dyn std::error::Error>> {
+///
+/// `bracketed_paste` は paste テキストを `\x1b[200~` / `\x1b[201~` で
+/// 囲うかどうか。非対応 shell では false にする。
+pub fn launch(
+    ui: &AppWindow,
+    command: &str,
+    bracketed_paste: bool,
+) -> Result<TerminalPane, Box<dyn std::error::Error>> {
     let pty_system = native_pty_system();
     let pair = pty_system.openpty(PtySize {
         rows: INITIAL_ROWS,
@@ -277,6 +284,7 @@ pub fn launch(ui: &AppWindow, command: &str) -> Result<TerminalPane, Box<dyn std
         master_pty,
         row_model,
         current_size,
+        bracketed_paste,
     })
 }
 
@@ -287,6 +295,7 @@ pub fn launch(ui: &AppWindow, command: &str) -> Result<TerminalPane, Box<dyn std
 pub fn launch_for_diff_viewer(
     ui: &crate::DiffViewerWindow,
     command: &str,
+    bracketed_paste: bool,
 ) -> Result<TerminalPane, Box<dyn std::error::Error>> {
     let pty_system = native_pty_system();
     let pair = pty_system.openpty(PtySize {
@@ -421,6 +430,7 @@ pub fn launch_for_diff_viewer(
         master_pty,
         row_model,
         current_size,
+        bracketed_paste,
     })
 }
 
@@ -436,6 +446,7 @@ pub struct TerminalPane {
     master_pty: Arc<Mutex<Box<dyn MasterPty + Send>>>,
     row_model: Rc<VecModel<TerminalRow>>,
     current_size: Rc<RefCell<(u16, u16)>>,
+    bracketed_paste: bool,
 }
 
 impl TerminalPane {
@@ -444,18 +455,17 @@ impl TerminalPane {
     /// multiline / control-char 入りの prompt を受け取るため、以下を行う:
     /// 1. 制御文字（NUL / ESC / BEL / CR 等）をスペースに置き換えてサニタイズ
     ///    する（改行 LF だけは保存する）
-    /// 2. bracketed paste mode (ESC[200~...ESC[201~) で本文を挟み、受け手の
-    ///    shell / agent CLI が paste として扱えるようにする（行ごとに
-    ///    submit される事故を防ぐ）
+    /// 2. bracketed paste mode が有効なら本文を `\x1b[200~` / `\x1b[201~` で
+    ///    挟み、受け手の shell / agent CLI が paste として扱えるようにする
+    ///    （行ごとに submit される事故を防ぐ）。非対応 shell では sequence が
+    ///    そのまま表示されるため `LOCUS_BRACKETED_PASTE=false` で raw 送信に
+    ///    切り替えられる。
     pub fn insert(&self, text: &str) {
         if text.is_empty() {
             return;
         }
         let sanitized = sanitize_for_pty(text);
-        let mut bytes: Vec<u8> = Vec::with_capacity(sanitized.len() + 16);
-        bytes.extend_from_slice(b"\x1b[200~");
-        bytes.extend_from_slice(sanitized.as_bytes());
-        bytes.extend_from_slice(b"\x1b[201~");
+        let bytes = encode_paste_bytes(&sanitized, self.bracketed_paste);
         if let Ok(mut w) = self.writer.lock() {
             let _ = w.write_all(&bytes);
             let _ = w.flush();
@@ -528,6 +538,22 @@ impl TerminalPane {
     }
 }
 
+/// `sanitized` を PTY 送信用バイト列に変換する。
+///
+/// `bracketed_paste=true` のとき DEC paste の境界 sequence で囲み、
+/// 非対応の shell では何も囲まずそのまま raw 送信する。
+fn encode_paste_bytes(sanitized: &str, bracketed_paste: bool) -> Vec<u8> {
+    if bracketed_paste {
+        let mut bytes = Vec::with_capacity(sanitized.len() + 16);
+        bytes.extend_from_slice(b"\x1b[200~");
+        bytes.extend_from_slice(sanitized.as_bytes());
+        bytes.extend_from_slice(b"\x1b[201~");
+        bytes
+    } else {
+        sanitized.as_bytes().to_vec()
+    }
+}
+
 /// PTY に流す前に制御文字を無害化する。
 ///
 /// - NUL / BEL / ESC / BS / VT / FF / CR / Ctrl-C 等はスペースに置換
@@ -548,7 +574,10 @@ fn sanitize_for_pty(text: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{compute_grid_size, sanitize_for_pty, translate_key, MIN_COLS, MIN_ROWS};
+    use super::{
+        compute_grid_size, encode_paste_bytes, sanitize_for_pty, translate_key, MIN_COLS,
+        MIN_ROWS,
+    };
 
     #[test]
     fn compute_grid_size_floors_pane_div_cell() {
@@ -590,6 +619,25 @@ mod tests {
         let (cols, rows) = compute_grid_size(1.0e9, 1.0e9, 1.0, 1.0);
         assert_eq!(cols, super::MAX_COLS);
         assert_eq!(rows, super::MAX_ROWS);
+    }
+
+    #[test]
+    fn encode_paste_bytes_wraps_when_bracketed() {
+        let bytes = encode_paste_bytes("hello", true);
+        let head: &[u8] = b"\x1b[200~";
+        let tail: &[u8] = b"\x1b[201~";
+        assert!(bytes.starts_with(head));
+        assert!(bytes.ends_with(tail));
+        // 本文部分が末尾 tail を除き sanitized と一致
+        let body = &bytes[head.len()..bytes.len() - tail.len()];
+        assert_eq!(body, b"hello");
+    }
+
+    #[test]
+    fn encode_paste_bytes_raw_when_disabled() {
+        let bytes = encode_paste_bytes("hello", false);
+        assert_eq!(bytes, b"hello".to_vec());
+        assert!(!bytes.windows(2).any(|w| w == b"\x1b["));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #237

bracketed paste 非対応の shell / agent CLI で paste sequence (\`\\x1b[200~\` / \`\\x1b[201~\`) がリテラル表示される問題への fallback。

## 設計

\`LOCUS_BRACKETED_PASTE\` 環境変数を追加:

| 値 | 動作 |
|---|---|
| 未設定 / \`true\` / \`1\` / \`on\` / \`yes\` | bracketed (既定、現状互換) |
| \`false\` / \`0\` / \`off\` / \`no\` | raw 送信 (sanitize は維持) |
| \`auto\` | host \`\$TERM\` から推定 (xterm / screen / tmux / rxvt / vte / konsole / iterm / alacritty / wezterm / kitty) |
| 不明値 | fail-open で bracketed (paste 機能を不用意に殺さない) |

## 変更点

- \`config::UiConfig::bracketed_paste\` フィールド追加 + \`from_env\` で解析
- \`config::parse_bracketed_paste_env(value, host_term)\` を pure function 切り出し
- \`terminal::launch\` / \`terminal::launch_for_diff_viewer\` に \`bracketed_paste: bool\` 引数
- \`TerminalPane::bracketed_paste\` フィールド + \`encode_paste_bytes(sanitized, flag)\` ヘルパー
- \`TerminalPane::insert\` は flag に応じて wrap / raw を分岐

## Test plan

- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test (119 passed; 7 新規 unit test)
  - parse_bracketed_paste_env: default / explicit on/off / auto / unknown 5 case
  - encode_paste_bytes: wrap / raw 2 case
- [ ] (手動) LOCUS_BRACKETED_PASTE=false で起動し、paste sequence がリテラル表示されないことを確認
- [ ] (手動) bracketed paste 対応 shell で paste が paste 扱いされる (改行で submit されない) ことを確認