### PR TITLE
feat(ui): empty state placeholder + key hint bar + terminal failure banner (#220)

### DIFF
--- a/lang/ja/LC_MESSAGES/locus.po
+++ b/lang/ja/LC_MESSAGES/locus.po
@@ -145,5 +145,5 @@ msgstr "ヒント: 差分の行 / ハンクヘッダ / ファイル全体ボタ�
 msgid "Send buttons are disabled. Set LOCUS_AGENT_CMD or install the agent CLI on PATH, then restart locus."
 msgstr "送信ボタンは無効化されています。LOCUS_AGENT_CMD を設定するか PATH 上にエージェント CLI を配置して locus を再起動してください。"
 
-msgid "Click: select line  •  Shift+Click: extend to range  •  File button: whole file  •  Esc: clear selection"
-msgstr "クリック: 行を選択  •  Shift+クリック: 範囲に拡張  •  ファイル全体ボタン: ファイル全選択  •  Esc: 選択解除"
+msgid "Click: select line  •  Range button: extend to range  •  File button: whole file  •  Clear button: clear selection"
+msgstr "クリック: 行を選択  •  Range ボタン: 範囲に拡張  •  File ボタン: ファイル全選択  •  Clear ボタン: 選択解除"

--- a/lang/ja/LC_MESSAGES/locus.po
+++ b/lang/ja/LC_MESSAGES/locus.po
@@ -125,3 +125,25 @@ msgstr "エージェントコマンドが見つかりません"
 
 msgid "{}: not found in PATH (set LOCUS_AGENT_CMD)"
 msgstr "{}: PATH に見つかりません (LOCUS_AGENT_CMD を設定してください)"
+
+# Empty state placeholders (#220)
+msgid "(empty draft)"
+msgstr "(下書きは空です)"
+
+msgid "Click a diff line and press \"Add to draft\" to collect anchors here."
+msgstr "差分の行をクリックし「下書きに追加」を押すと、ここに蓄積されます。"
+
+msgid "(no send history yet)"
+msgstr "(送信履歴はまだありません)"
+
+msgid "Each Insert / Insert+Send / Copy will be logged here."
+msgstr "挿入 / 挿入+送信 / コピー の操作はここに記録されます。"
+
+msgid "Tip: Click a diff line, hunk header, or the File button to start selecting."
+msgstr "ヒント: 差分の行 / ハンクヘッダ / ファイル全体ボタン から選択を始められます。"
+
+msgid "Send buttons are disabled. Set LOCUS_AGENT_CMD or install the agent CLI on PATH, then restart locus."
+msgstr "送信ボタンは無効化されています。LOCUS_AGENT_CMD を設定するか PATH 上にエージェント CLI を配置して locus を再起動してください。"
+
+msgid "Click: select line  •  Shift+Click: extend to range  •  File button: whole file  •  Esc: clear selection"
+msgstr "クリック: 行を選択  •  Shift+クリック: 範囲に拡張  •  ファイル全体ボタン: ファイル全選択  •  Esc: 選択解除"

--- a/src/main.rs
+++ b/src/main.rs
@@ -982,6 +982,7 @@ fn build_pr_list_model(
 
 fn refresh_current_anchor_label(ui: &DiffViewerWindow, state: &Rc<RefCell<DiffAppState>>) {
     let st = state.borrow();
+    let has_selection = st.current_anchor.is_some();
     let label = match &st.current_anchor {
         Some(a) => {
             let base = anchor_label(a);
@@ -994,6 +995,7 @@ fn refresh_current_anchor_label(ui: &DiffViewerWindow, state: &Rc<RefCell<DiffAp
         None => i18n::tr("(no selection)"),
     };
     ui.set_current_anchor_label(SharedString::from(label));
+    ui.set_has_selection(has_selection);
 }
 
 fn refresh_draft_panel(ui: &DiffViewerWindow, state: &Rc<RefCell<DiffAppState>>) {

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -976,57 +976,57 @@ export component DiffViewerWindow inherits Window {
                         }
 
                         if root.draft-entries.length > 0: ListView {
-                        for entry[idx] in root.draft-entries: Rectangle {
-                            height: 44px;
-                            background: #14141a;
-                            border-width: 1px;
-                            border-color: #1c1c24;
+                            for entry[idx] in root.draft-entries: Rectangle {
+                                height: 44px;
+                                background: #14141a;
+                                border-width: 1px;
+                                border-color: #1c1c24;
 
-                            HorizontalBox {
-                                padding-left: 8px;
-                                padding-right: 8px;
-                                padding-top: 4px;
-                                padding-bottom: 4px;
-                                spacing: 6px;
+                                HorizontalBox {
+                                    padding-left: 8px;
+                                    padding-right: 8px;
+                                    padding-top: 4px;
+                                    padding-bottom: 4px;
+                                    spacing: 6px;
 
-                                VerticalBox {
-                                    horizontal-stretch: 1;
-                                    spacing: 2px;
-                                    Text {
-                                        text: entry.label;
-                                        color: #d0d0d5;
-                                        font-size: 11px;
-                                        font-family: root.font-family;
-                                        overflow: elide;
-                                    }
-                                    Text {
-                                        text: entry.note;
-                                        color: #8a8a95;
-                                        font-size: 11px;
-                                        overflow: elide;
-                                    }
-                                }
-
-                                delete-btn := TouchArea {
-                                    width: 24px;
-                                    height: 24px;
-                                    clicked => {
-                                        root.remove-draft-entry(idx);
-                                    }
-                                    Rectangle {
-                                        background: delete-btn.has-hover ? #3a1a1a : transparent;
-                                        border-radius: 4px;
+                                    VerticalBox {
+                                        horizontal-stretch: 1;
+                                        spacing: 2px;
                                         Text {
-                                            text: "×";
-                                            color: #e58585;
-                                            font-size: 16px;
-                                            horizontal-alignment: center;
-                                            vertical-alignment: center;
+                                            text: entry.label;
+                                            color: #d0d0d5;
+                                            font-size: 11px;
+                                            font-family: root.font-family;
+                                            overflow: elide;
+                                        }
+                                        Text {
+                                            text: entry.note;
+                                            color: #8a8a95;
+                                            font-size: 11px;
+                                            overflow: elide;
+                                        }
+                                    }
+
+                                    delete-btn := TouchArea {
+                                        width: 24px;
+                                        height: 24px;
+                                        clicked => {
+                                            root.remove-draft-entry(idx);
+                                        }
+                                        Rectangle {
+                                            background: delete-btn.has-hover ? #3a1a1a : transparent;
+                                            border-radius: 4px;
+                                            Text {
+                                                text: "×";
+                                                color: #e58585;
+                                                font-size: 16px;
+                                                horizontal-alignment: center;
+                                                vertical-alignment: center;
+                                            }
                                         }
                                     }
                                 }
                             }
-                        }
                         }
                     }
 
@@ -1122,7 +1122,7 @@ export component DiffViewerWindow inherits Window {
                 spacing: 14px;
                 alignment: start;
                 Text {
-                    text: @tr("Click: select line  •  Shift+Click: extend to range  •  File button: whole file  •  Esc: clear selection");
+                    text: @tr("Click: select line  •  Range button: extend to range  •  File button: whole file  •  Clear button: clear selection");
                     color: #6a6a75;
                     font-size: 10px;
                     vertical-alignment: center;

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -183,6 +183,7 @@ export component DiffViewerWindow inherits Window {
     in-out property <int> selected-file-index: 0;
 
     in property <string> current-anchor-label: @tr("(no selection)");
+    in property <bool> has-selection: false;
     in property <[DraftEntryView]> draft-entries;
     in-out property <string> note-input-text;
 
@@ -728,6 +729,13 @@ export component DiffViewerWindow inherits Window {
                                 }
                             }
 
+                            if !root.has-selection: Text {
+                                text: @tr("Tip: Click a diff line, hunk header, or the File button to start selecting.");
+                                color: #8a8a95;
+                                font-size: 10px;
+                                wrap: word-wrap;
+                            }
+
                             HorizontalBox {
                                 spacing: 6px;
                                 note-input := LineEdit {
@@ -808,27 +816,46 @@ export component DiffViewerWindow inherits Window {
                         }
                     }
 
-                    // Terminal status label
+                    // Terminal status — 通常時は薄い 1 行、起動失敗時は赤バナー化して
+                    // ユーザーに env / PATH 設定 (LOCUS_AGENT_CMD) を促す。
                     Rectangle {
-                        height: 22px;
-                        background: #1a1a22;
+                        height: root.terminal-available ? 22px : 48px;
+                        background: root.terminal-available ? #1a1a22 : #3a1010;
+                        border-width: root.terminal-available ? 0 : 1px;
+                        border-color: #c04040;
+
                         HorizontalBox {
                             padding-left: 10px;
                             padding-right: 10px;
+                            padding-top: 4px;
+                            padding-bottom: 4px;
                             alignment: start;
-                            spacing: 6px;
+                            spacing: 8px;
                             Text {
-                                text: @tr("agent:");
-                                color: #8a8a95;
-                                font-size: 10px;
+                                text: root.terminal-available ? @tr("agent:") : "⚠";
+                                color: root.terminal-available ? #8a8a95 : #ffb060;
+                                font-size: root.terminal-available ? 10px : 16px;
                                 vertical-alignment: center;
                             }
-                            Text {
-                                text: root.terminal-status;
-                                color: root.terminal-available ? #8fd98f : #e58585;
-                                font-size: 10px;
-                                font-family: root.font-family;
-                                vertical-alignment: center;
+                            VerticalBox {
+                                horizontal-stretch: 1;
+                                spacing: 0;
+                                padding: 0;
+                                Text {
+                                    text: root.terminal-status;
+                                    color: root.terminal-available ? #8fd98f : #ffd4d4;
+                                    font-size: root.terminal-available ? 10px : 12px;
+                                    font-weight: root.terminal-available ? 400 : 600;
+                                    font-family: root.font-family;
+                                    vertical-alignment: center;
+                                    overflow: elide;
+                                }
+                                if !root.terminal-available: Text {
+                                    text: @tr("Send buttons are disabled. Set LOCUS_AGENT_CMD or install the agent CLI on PATH, then restart locus.");
+                                    color: #e0a0a0;
+                                    font-size: 10px;
+                                    overflow: elide;
+                                }
                             }
                         }
                     }
@@ -927,8 +954,28 @@ export component DiffViewerWindow inherits Window {
                         }
                     }
 
-                    ListView {
+                    Rectangle {
                         vertical-stretch: 1;
+                        background: #101014;
+
+                        if root.draft-entries.length == 0: VerticalBox {
+                            alignment: center;
+                            Text {
+                                text: @tr("(empty draft)");
+                                color: #5a5a6a;
+                                font-size: 11px;
+                                horizontal-alignment: center;
+                            }
+                            Text {
+                                text: @tr("Click a diff line and press \"Add to draft\" to collect anchors here.");
+                                color: #5a5a6a;
+                                font-size: 10px;
+                                horizontal-alignment: center;
+                                wrap: word-wrap;
+                            }
+                        }
+
+                        if root.draft-entries.length > 0: ListView {
                         for entry[idx] in root.draft-entries: Rectangle {
                             height: 44px;
                             background: #14141a;
@@ -980,6 +1027,7 @@ export component DiffViewerWindow inherits Window {
                                 }
                             }
                         }
+                        }
                     }
 
                     // History section
@@ -1004,7 +1052,24 @@ export component DiffViewerWindow inherits Window {
                         height: 180px;
                         background: #14141a;
 
-                        ListView {
+                        if root.history-entries.length == 0: VerticalBox {
+                            alignment: center;
+                            Text {
+                                text: @tr("(no send history yet)");
+                                color: #5a5a6a;
+                                font-size: 11px;
+                                horizontal-alignment: center;
+                            }
+                            Text {
+                                text: @tr("Each Insert / Insert+Send / Copy will be logged here.");
+                                color: #5a5a6a;
+                                font-size: 10px;
+                                horizontal-alignment: center;
+                                wrap: word-wrap;
+                            }
+                        }
+
+                        if root.history-entries.length > 0: ListView {
                             for h in root.history-entries: Rectangle {
                                 height: 44px;
                                 background: #14141a;
@@ -1041,6 +1106,27 @@ export component DiffViewerWindow inherits Window {
                             }
                         }
                     }
+                }
+            }
+        }
+
+        // Bottom key hint bar
+        Rectangle {
+            height: 22px;
+            background: #1a1a22;
+            border-width: 1px;
+            border-color: #24242c;
+            HorizontalBox {
+                padding-left: 10px;
+                padding-right: 10px;
+                spacing: 14px;
+                alignment: start;
+                Text {
+                    text: @tr("Click: select line  •  Shift+Click: extend to range  •  File button: whole file  •  Esc: clear selection");
+                    color: #6a6a75;
+                    font-size: 10px;
+                    vertical-alignment: center;
+                    overflow: elide;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Closes #220

初見ユーザーが「次に何をすべきか」を画面内で把握できるよう、空状態のプレースホルダ・キー操作ヒント・terminal 起動失敗バナーを追加。

## 変更点

| 領域 | 変更 |
|---|---|
| Draft 一覧 | 0 件時に「(下書きは空です) / 差分の行をクリックし『下書きに追加』…」を表示 |
| History 一覧 | 0 件時に「(送信履歴はまだありません) / 挿入 / 挿入+送信 / コピー の操作はここに記録されます」を表示 |
| Selection 未設定 | \`has-selection=false\` のとき current-anchor-label の下にヒント「差分の行 / ハンクヘッダ / ファイル全体ボタン から選択を始められます」 |
| Terminal 失敗 | \`terminal-available=false\` のとき agent: ステータス行を 22px → 48px の赤バナーに拡張、⚠ + LOCUS_AGENT_CMD 設定誘導 |
| Bottom hint bar | 22px 常設、「クリック: 行を選択 / Shift+クリック: 範囲に拡張 / ファイル全体ボタン: ファイル全選択 / Esc: 選択解除」 |

## i18n

\`lang/ja/LC_MESSAGES/locus.po\` に 7 キー追加。Slint \`@tr()\` で読み込まれるため \`src/i18n.rs::translate_ja\` への登録は不要 (Rust 側で参照しないため)。

## Test plan

- [x] cargo build / clippy --all-targets -- -D warnings (PASS)
- [x] cargo test (118 passed; 既存テスト維持)
- [ ] (手動) 起動直後で empty state プレースホルダが見えること
- [ ] (手動) selection 操作後にヒントが消えること
- [ ] (手動) LOCUS_AGENT_CMD=foo (PATH に無し) で起動して赤バナーが表示されること