### PR TITLE
feat: PromptDraft 最大文字数警告と override checkbox (#226)

### DIFF
--- a/lang/ja/LC_MESSAGES/locus.po
+++ b/lang/ja/LC_MESSAGES/locus.po
@@ -147,3 +147,10 @@ msgstr "送信ボタンは無効化されています。LOCUS_AGENT_CMD を設�
 
 msgid "Click: select line  •  Range button: extend to range  •  File button: whole file  •  Esc: clear selection  •  ⌘↵: Insert+Send  •  ⌘C: Copy"
 msgstr "クリック: 行を選択  •  Range ボタン: 範囲に拡張  •  File ボタン: ファイル全選択  •  Esc: 選択解除  •  ⌘↵: 挿入+送信  •  ⌘C: コピー"
+
+# Preview size warning (#226)
+msgid "Preview exceeds the limit. Send buttons are disabled."
+msgstr "プレビューが上限を超えています。送信ボタンは無効化されています。"
+
+msgid "Send anyway (override)"
+msgstr "上限を無視して送信"

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,10 @@ pub struct UiConfig {
     /// 非対応 shell / agent CLI では `\x1b[200~` 等が文字としてそのまま表示
     /// されるため、`LOCUS_BRACKETED_PASTE=false` で raw 送信に切り替えられる。
     pub bracketed_paste: bool,
+    /// preview text の上限文字数。`LOCUS_PROMPT_MAX_CHARS` で上書き可能。
+    /// 既定 32000 (Claude API context window の安全圏内目安)。超過すると
+    /// preview pane に warning が出るが、override checkbox で送信は可能。
+    pub prompt_max_chars: usize,
 }
 
 impl UiConfig {
@@ -34,11 +38,15 @@ impl UiConfig {
             .unwrap_or(12.0);
         let bracketed_paste =
             parse_bracketed_paste_env(std::env::var("LOCUS_BRACKETED_PASTE").ok().as_deref());
+        let prompt_max_chars = parse_prompt_max_chars_env(
+            std::env::var("LOCUS_PROMPT_MAX_CHARS").ok().as_deref(),
+        );
         Self {
             font_family,
             terminal_font_size,
             diff_font_size,
             bracketed_paste,
+            prompt_max_chars,
         }
     }
 
@@ -76,6 +84,17 @@ pub fn parse_bracketed_paste_env(value: Option<&str>) -> bool {
     }
 }
 
+/// `LOCUS_PROMPT_MAX_CHARS` を usize にパースする。
+///
+/// - 未設定 / 空 / 解釈不能な値 → 既定 32000
+/// - 0 や 1 などの極端値もそのまま受け入れる (warning が常に出るだけで害はない)
+pub fn parse_prompt_max_chars_env(value: Option<&str>) -> usize {
+    const DEFAULT: usize = 32_000;
+    value
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,6 +106,7 @@ mod tests {
             terminal_font_size: 12.0,
             diff_font_size: 12.0,
             bracketed_paste: true,
+            prompt_max_chars: 32_000,
         };
         assert!(cfg.terminal_cell_w() >= 6.0);
         assert!(cfg.terminal_cell_h() >= 14.0);
@@ -99,12 +119,14 @@ mod tests {
             terminal_font_size: 10.0,
             diff_font_size: 10.0,
             bracketed_paste: true,
+            prompt_max_chars: 32_000,
         };
         let big = UiConfig {
             font_family: "x".into(),
             terminal_font_size: 20.0,
             diff_font_size: 20.0,
             bracketed_paste: true,
+            prompt_max_chars: 32_000,
         };
         assert!(big.terminal_cell_w() > small.terminal_cell_w());
         assert!(big.terminal_cell_h() > small.terminal_cell_h());
@@ -129,6 +151,20 @@ mod tests {
         for v in ["1", "true", "True", "on", "yes"] {
             assert!(parse_bracketed_paste_env(Some(v)));
         }
+    }
+
+    #[test]
+    fn prompt_max_chars_default() {
+        assert_eq!(parse_prompt_max_chars_env(None), 32_000);
+        assert_eq!(parse_prompt_max_chars_env(Some("")), 32_000);
+        assert_eq!(parse_prompt_max_chars_env(Some("garbage")), 32_000);
+    }
+
+    #[test]
+    fn prompt_max_chars_explicit() {
+        assert_eq!(parse_prompt_max_chars_env(Some("8000")), 8_000);
+        assert_eq!(parse_prompt_max_chars_env(Some("  4096  ")), 4_096);
+        assert_eq!(parse_prompt_max_chars_env(Some("0")), 0);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
     ui.set_diff_font_size(ui_cfg.diff_font_size);
     ui.set_terminal_cell_w(ui_cfg.terminal_cell_w());
     ui.set_terminal_cell_h(ui_cfg.terminal_cell_h());
+    ui.set_preview_max_chars(ui_cfg.prompt_max_chars.min(i32::MAX as usize) as i32);
     apply_snapshot_to_ui(&ui, &placeholder_snapshot, &[]);
     ui.set_current_pr_number(pr_number as i32);
     ui.set_pr_list(build_pr_list_model(&[]));
@@ -1089,6 +1090,8 @@ fn refresh_preview(ui: &DiffViewerWindow, state: &Rc<RefCell<DiffAppState>>) {
         .collect();
     let text = format_prompt(&st.draft, &entries);
     ui.set_preview_text(SharedString::from(text));
+    // preview-length は Slint 側で root.preview-text.character-count から
+    // 自動計算されるので Rust から set する必要はない。
 }
 
 fn append_history(state: &Rc<RefCell<DiffAppState>>, mode: SendMode, body: &str) {

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -1,4 +1,4 @@
-import { VerticalBox, HorizontalBox, ListView, ScrollView, LineEdit, Button } from "std-widgets.slint";
+import { VerticalBox, HorizontalBox, ListView, ScrollView, LineEdit, Button, CheckBox } from "std-widgets.slint";
 
 // ===== Terminal pane モード (既存) =====
 
@@ -188,6 +188,12 @@ export component DiffViewerWindow inherits Window {
     in-out property <string> note-input-text;
 
     in-out property <string> preview-text;
+    in property <int> preview-max-chars: 32000;
+    in-out property <bool> preview-override: false;
+    // preview-text の文字数 (code-point ベース)。Slint 側で自動再計算するので
+    // Rust から set する必要はなく、TextInput でユーザーが編集した場合も
+    // 即時反映される。
+    out property <int> preview-length: root.preview-text.character-count;
     in property <[HistoryEntryView]> history-entries;
 
     in property <[TerminalRow]> terminal-rows;
@@ -812,6 +818,13 @@ export component DiffViewerWindow inherits Window {
                                     font-size: 11px;
                                     vertical-alignment: center;
                                 }
+                                Text {
+                                    text: root.preview-length + " / " + root.preview-max-chars;
+                                    color: root.preview-length > root.preview-max-chars ? #e58585 : #5a5a6a;
+                                    font-size: 10px;
+                                    font-family: root.font-family;
+                                    vertical-alignment: center;
+                                }
                                 Rectangle { horizontal-stretch: 1; }
                                 Button {
                                     text: @tr("Refresh");
@@ -819,17 +832,46 @@ export component DiffViewerWindow inherits Window {
                                 }
                                 Button {
                                     text: @tr("Insert");
-                                    enabled: root.terminal-available;
+                                    enabled: root.terminal-available
+                                        && (root.preview-length <= root.preview-max-chars
+                                            || root.preview-override);
                                     clicked => { root.send-insert-only(root.preview-text); }
                                 }
                                 Button {
                                     text: @tr("Insert+Send");
-                                    enabled: root.terminal-available;
+                                    enabled: root.terminal-available
+                                        && (root.preview-length <= root.preview-max-chars
+                                            || root.preview-override);
                                     clicked => { root.send-insert-and-send(root.preview-text); }
                                 }
                                 Button {
                                     text: @tr("Copy");
+                                    enabled: root.preview-length <= root.preview-max-chars
+                                        || root.preview-override;
                                     clicked => { root.send-copy-to-clipboard(root.preview-text); }
+                                }
+                            }
+
+                            // Over-limit warning + override checkbox (#226)
+                            if root.preview-length > root.preview-max-chars: HorizontalBox {
+                                spacing: 8px;
+                                alignment: start;
+                                Text {
+                                    text: "⚠";
+                                    color: #ffb060;
+                                    font-size: 14px;
+                                    vertical-alignment: center;
+                                }
+                                Text {
+                                    text: @tr("Preview exceeds the limit. Send buttons are disabled.");
+                                    color: #e58585;
+                                    font-size: 11px;
+                                    vertical-alignment: center;
+                                    horizontal-stretch: 1;
+                                }
+                                CheckBox {
+                                    text: @tr("Send anyway (override)");
+                                    checked <=> root.preview-override;
                                 }
                             }
 

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -359,13 +359,21 @@ export component DiffViewerWindow inherits Window {
                 root.clear-current-selection();
                 return accept;
             }
+            // Send / Copy ショートカットも preview-limit / override の判定に
+                // 従う。ボタン側 enabled 条件と揃えてサイズ制限を bypass されない
+                // ようにする。
             if (event.text == Key.Return
-                && (event.modifiers.meta || event.modifiers.control)) {
+                && (event.modifiers.meta || event.modifiers.control)
+                && root.terminal-available
+                && (root.preview-length <= root.preview-max-chars
+                    || root.preview-override)) {
                 root.send-insert-and-send(root.preview-text);
                 return accept;
             }
             if (event.text == "c"
-                && (event.modifiers.meta || event.modifiers.control)) {
+                && (event.modifiers.meta || event.modifiers.control)
+                && (root.preview-length <= root.preview-max-chars
+                    || root.preview-override)) {
                 root.send-copy-to-clipboard(root.preview-text);
                 return accept;
             }


### PR DESCRIPTION
Closes #226

format_prompt の出力サイズが \`LOCUS_PROMPT_MAX_CHARS\` (既定 32000) を超えたら preview pane 上部に警告 + override checkbox を出し、override が外れている間は Insert / Insert+Send / Copy を disabled にする。

## 変更
- \`config::UiConfig::prompt_max_chars\` 追加 (\`LOCUS_PROMPT_MAX_CHARS\` で上書き、既定 32000)
- Slint: \`preview-length\` を \`preview-text.character-count\` から自動計算 (TextInput 編集にも反応)
- Slint: charcount/limit カウンタ + 超過時の警告 banner + CheckBox (\`preview-override\`)
- 3 つの送信ボタン enabled 条件に under-limit || override を追加
- ja 翻訳 2 キー (Slint @tr 経由)

## Test plan
- [x] cargo clippy / cargo test (120 passed; 2 新規)
- [ ] (手動) LOCUS_PROMPT_MAX_CHARS=100 で起動して大量 selection で警告表示
- [ ] (手動) override checkbox で送信できる