### PR TITLE
docs(adr): 0006 thread-local DIFF_APP_STATE を記録 (#225)

### DIFF
--- a/docs/adr/0006-thread-local-app-state.ja.md
+++ b/docs/adr/0006-thread-local-app-state.ja.md
@@ -1,0 +1,74 @@
+# ADR 0006: diff viewer の DIFF_APP_STATE に thread_local を採用する
+
+> English: [0006-thread-local-app-state.md](0006-thread-local-app-state.md)
+
+- Status: Accepted
+- Date: 2026-04-20
+
+## Context（背景）
+
+diff viewer の non-blocking 化 (issue #204) で、以下のすべてが共有 `DiffAppState` にアクセスする必要が出てきた:
+
+- Slint UI コールバック (例: `on_select_line`, `on_pr_clicked`)
+- PR snapshot や linked issue を取りにいく `tokio::spawn` の future
+- fetch 完了後に UI スレッドへ戻る `slint::invoke_from_event_loop` クロージャ
+
+state の実体は `Rc<RefCell<DiffAppState>>` で、理由は:
+
+- `Rc` で refcount を atomic 不要にできる。値が構築後にスレッド境界を跨がないため。
+- `RefCell` で `Mutex` API をコードベースに撒かずに nested callback 内で mutate できる。
+
+しかし `Rc<RefCell<T>>` は **`Send` ではない**。Slint UI コールバック (すべて同じ UI スレッドで動く) なら問題ないが、`tokio::spawn` は `Send + 'static` 要求があるため致命的。素直に `state.clone()` を `tokio::spawn` の中にキャプチャするとコンパイルが通らない。
+
+これに対応する一般的な方法は 2 つ:
+
+1. **`Arc<Mutex<DiffAppState>>` に全置換**: borrow をすべて lock に書き換える。スレッド境界を超えられる。
+2. **Actor モデル**: state を 1 つの task に閉じ込め、callback はメッセージ送信。
+
+どちらも今の段階では過剰だった:
+
+- Locus は Slint window を 1 つ、UI スレッドを 1 つしか持たない。state は実態としてはスレッド間で共有されておらず、必要なのは「アクセス経路が `Send` であること」だけ。
+- `Rc<RefCell<T>>` → `Arc<Mutex<T>>` への置換は mechanical refactor で全コールバックに波及し、なおかつ `RefCell` の nested borrow 落とし穴を `Mutex` 上で再発させる (再入 lock = deadlock)。
+- Actor モデルはメッセージング boilerplate と間接層を、競合のない UI に対して導入することになる。
+
+## Decision（決定）
+
+**`thread_local!` slot** を使い、spawn された future がクロージャに `Rc` をキャプチャしないでも state を取れるようにする:
+
+```rust
+thread_local! {
+    static DIFF_APP_STATE: RefCell<Option<Rc<RefCell<DiffAppState>>>> = const {
+        RefCell::new(None)
+    };
+}
+
+fn with_app_state<R>(f: impl FnOnce(&Rc<RefCell<DiffAppState>>) -> R) -> Option<R> {
+    DIFF_APP_STATE.with(|cell| cell.borrow().as_ref().map(f))
+}
+```
+
+- `run_diff_viewer` が `ui.run()` の前に UI スレッド上で 1 度だけ slot に値を入れる。
+- `tokio::spawn` のクロージャは `Rc` を **キャプチャしない**。async 仕事を済ませて `slint::invoke_from_event_loop(...)` を呼び、その内側 (UI スレッド上で実行される) クロージャから `with_app_state(...)` 経由で state を取る。
+- `with_app_state` は UI スレッドのコールバックからしか呼ばれないため `thread_local!` のアクセスは常に安全で、spawn された future 自体は `Send` を保つ。
+
+これにより diff viewer 全体で使っている `Rc<RefCell<DiffAppState>>` の使い勝手を維持しつつ、tokio の `Send` 要求を spawn 境界で満たせる。
+
+## Consequences（結果）
+
+### 正の影響
+
+- 影響範囲が小さい: `thread_local!` slot は 1 つだけ、`with_app_state(...)` 経由でしかアクセスしない。
+- 既存の `Rc<RefCell<>>` 流儀がそのまま (`state.borrow_mut().push_toast(...)` 等)。
+- spawn された future を `Send` のままに保てる。全コールバックを mutex / actor に書き換える必要がない。
+
+### 負の影響
+
+- DIFF_APP_STATE は *グローバル可変状態* (UI スレッドスコープ) である。教科書的にはグローバル可変状態は避けるべきだが、ここでは (a) Locus の UI スレッドが 1 本しかない、(b) slot は 1 度だけ初期化される、(c) 読み取りはすべて `with_app_state` 経由、という前提で許容している。
+- state 依存テストは slot に値が入っていることを期待できないため、`DiffAppState` を直接組み立てる必要がある。今の unit test では十分だが、Slint を起動せずに行ける UI integration テストの範囲には限度がある。
+- 将来 2 つ目の window (preferences、history のポップアウトなど) を持つ場合、同じ slot を別 state で再利用できない。その時点で本 ADR を見直し、以下のいずれかに移行する:
+  - slot を window ごとの registry に置き換える
+  - 真の actor モデルへ移行する
+
+### 境界
+
+`thread_local!` パターンは **`DIFF_APP_STATE` のみ** で使う。他の共有状態 (terminal の `Term`、PTY master、alacritty processor) は非 UI スレッド (PTY 読み取りスレッド、Timer 駆動の tick) からもアクセスされるため、`Arc<Mutex<...>>` が引き続き適切。lock コストはこれら境界では妥当。

--- a/docs/adr/0006-thread-local-app-state.ja.md
+++ b/docs/adr/0006-thread-local-app-state.ja.md
@@ -48,8 +48,8 @@ fn with_app_state<R>(f: impl FnOnce(&Rc<RefCell<DiffAppState>>) -> R) -> Option<
 ```
 
 - `run_diff_viewer` が `ui.run()` の前に UI スレッド上で 1 度だけ slot に値を入れる。
-- `tokio::spawn` のクロージャは `Rc` を **キャプチャしない**。async 仕事を済ませて `slint::invoke_from_event_loop(...)` を呼び、その内側 (UI スレッド上で実行される) クロージャから `with_app_state(...)` 経由で state を取る。
-- `with_app_state` は UI スレッドのコールバックからしか呼ばれないため `thread_local!` のアクセスは常に安全で、spawn された future 自体は `Send` を保つ。
+- `tokio::spawn` の future は `Rc` を **キャプチャせず**、`DIFF_APP_STATE` も **直接は読まない**。async 仕事 (例: HTTP fetch) を終えてから `slint::invoke_from_event_loop(|| { ... })` を呼ぶ。そこに渡したクロージャは UI スレッド上で動き、*そのクロージャの中で* `with_app_state(...)` を呼んで結果を適用する。
+- `with_app_state` は UI スレッドのコールバック (Slint callback と `invoke_from_event_loop` のクロージャ) からしか呼ばれないため、`thread_local!` のアクセスは常に初期化と同じスレッド上であり、spawn された future 自体は `Send` のまま保てる。
 
 これにより diff viewer 全体で使っている `Rc<RefCell<DiffAppState>>` の使い勝手を維持しつつ、tokio の `Send` 要求を spawn 境界で満たせる。
 
@@ -57,7 +57,7 @@ fn with_app_state<R>(f: impl FnOnce(&Rc<RefCell<DiffAppState>>) -> R) -> Option<
 
 ### 正の影響
 
-- 影響範囲が小さい: `thread_local!` slot は 1 つだけ、`with_app_state(...)` 経由でしかアクセスしない。
+- `DiffAppState` の影響範囲が小さい: `thread_local!` slot は `DIFF_APP_STATE` 1 つだけ、`with_app_state(...)` 経由でしかアクセスしない。(コードベースにはもう 1 つ、無関係な `thread_local!` `ACTIVE_DIFF_WINDOW` があり、こちらは toast 自動 dismiss `slint::Timer` が live window を `Weak` で取り出すためだけに使う小さな handle であり、本 ADR のスコープ外である。)
 - 既存の `Rc<RefCell<>>` 流儀がそのまま (`state.borrow_mut().push_toast(...)` 等)。
 - spawn された future を `Send` のままに保てる。全コールバックを mutex / actor に書き換える必要がない。
 
@@ -71,4 +71,4 @@ fn with_app_state<R>(f: impl FnOnce(&Rc<RefCell<DiffAppState>>) -> R) -> Option<
 
 ### 境界
 
-`thread_local!` パターンは **`DIFF_APP_STATE` のみ** で使う。他の共有状態 (terminal の `Term`、PTY master、alacritty processor) は非 UI スレッド (PTY 読み取りスレッド、Timer 駆動の tick) からもアクセスされるため、`Arc<Mutex<...>>` が引き続き適切。lock コストはこれら境界では妥当。
+`thread_local!` パターンは **`DiffAppState` 用には `DIFF_APP_STATE` のみ** に限定する。コードベース上にはもう 1 つ `ACTIVE_DIFF_WINDOW` (`Weak<DiffViewerWindow>`) があり、これは toast 自動 dismiss timer 用の単機能 UI スレッド handle であり、toast システムの実装詳細として扱う。他の共有状態 (terminal の `Term`、PTY master、alacritty processor) は非 UI スレッド (PTY 読み取りスレッド、Timer 駆動の tick) からもアクセスされるため、`Arc<Mutex<...>>` が引き続き適切。lock コストはこれら境界では妥当。

--- a/docs/adr/0006-thread-local-app-state.md
+++ b/docs/adr/0006-thread-local-app-state.md
@@ -1,0 +1,74 @@
+# ADR 0006: thread_local-based DIFF_APP_STATE for the diff viewer
+
+> 日本語: [0006-thread-local-app-state.ja.md](0006-thread-local-app-state.ja.md)
+
+- Status: Accepted
+- Date: 2026-04-20
+
+## Context
+
+When the diff viewer was made non-blocking (issue #204), several callbacks needed to access the shared `DiffAppState`:
+
+- Slint UI callbacks (e.g. `on_select_line`, `on_pr_clicked`)
+- `tokio::spawn` futures that fetch a PR snapshot or linked issues
+- `slint::invoke_from_event_loop` closures that hop back to the UI thread after a fetch completes
+
+The state itself is `Rc<RefCell<DiffAppState>>` because:
+
+- `Rc` keeps refcounting cheap (no atomic), and the value is never sent across threads after construction.
+- `RefCell` allows mutation under nested callback paths without surfacing `Mutex` lock APIs throughout the codebase.
+
+`Rc<RefCell<T>>` is **not `Send`**. That is fine for Slint UI callbacks (which all run on the same UI thread), but it is fatal for `tokio::spawn`, whose argument must be `Send + 'static`. Capturing `state.clone()` into a `tokio::spawn` future therefore fails to compile.
+
+Two patterns commonly resolve this:
+
+1. **`Arc<Mutex<DiffAppState>>` everywhere.** Replaces every borrow site with a lock; works across threads.
+2. **An actor model.** State lives in one task; callbacks send messages to it.
+
+Neither felt right at this stage:
+
+- Locus has a single Slint window with a single UI thread. State is *not* actually shared across threads — only the access path needs to be `Send`.
+- Replacing `Rc<RefCell<T>>` with `Arc<Mutex<T>>` is a mechanical refactor that ripples through every callback, and reintroduces the nested-borrow pitfalls in `Mutex` form (re-entrant lock = deadlock).
+- An actor model adds messaging boilerplate and indirection for a UI that has no contention.
+
+## Decision
+
+Use a **`thread_local!` slot** to hand state to spawned futures without making the closure capture the `Rc`:
+
+```rust
+thread_local! {
+    static DIFF_APP_STATE: RefCell<Option<Rc<RefCell<DiffAppState>>>> = const {
+        RefCell::new(None)
+    };
+}
+
+fn with_app_state<R>(f: impl FnOnce(&Rc<RefCell<DiffAppState>>) -> R) -> Option<R> {
+    DIFF_APP_STATE.with(|cell| cell.borrow().as_ref().map(f))
+}
+```
+
+- `run_diff_viewer` populates the slot once, on the UI thread, before `ui.run()`.
+- `tokio::spawn` closures **do not** capture the `Rc`. They do their async work, then call `slint::invoke_from_event_loop(...)`, and inside that closure (which runs on the UI thread) they fetch the state via `with_app_state(...)`.
+- Because `with_app_state` is only invoked from UI-thread callbacks, the `thread_local!` access is always safe, and the spawned future itself is `Send`.
+
+This preserves the ergonomic `Rc<RefCell<DiffAppState>>` model used throughout the diff viewer while satisfying tokio's `Send` requirement at the spawn boundary.
+
+## Consequences
+
+### Positive
+
+- No global blast radius: only one `thread_local!` slot, accessed through `with_app_state(...)`.
+- Existing `Rc<RefCell<>>` ergonomics remain (`state.borrow_mut().push_toast(...)`, etc.).
+- Spawned futures stay `Send` without restructuring every callback to lock a mutex or marshal messages.
+
+### Negative
+
+- DIFF_APP_STATE is *global mutable state*, scoped to the UI thread. Conventional wisdom says global mutable state should be avoided. We accept this here because (a) Locus has exactly one UI thread, (b) the slot is initialized exactly once, and (c) every read is gated through `with_app_state`.
+- Tests that touch state-dependent behaviour cannot rely on the slot being populated; they must construct `DiffAppState` directly. This is fine for the current unit tests but limits how much UI integration can be tested without spinning up Slint.
+- A future second window (e.g. preferences, history pop-out) cannot reuse the slot for a different state. If that day comes, this ADR should be revisited and either:
+  - the slot is replaced with a per-window registry, or
+  - the design moves to a proper actor model.
+
+### Boundaries
+
+The `thread_local!` pattern is **only** used for `DIFF_APP_STATE`. Other shared state (terminal `Term`, PTY master, alacritty processor) lives behind `Arc<Mutex<...>>` because those are accessed from non-UI threads (PTY reader thread, timer ticks) and the cost of a lock is appropriate there.

--- a/docs/adr/0006-thread-local-app-state.md
+++ b/docs/adr/0006-thread-local-app-state.md
@@ -48,8 +48,8 @@ fn with_app_state<R>(f: impl FnOnce(&Rc<RefCell<DiffAppState>>) -> R) -> Option<
 ```
 
 - `run_diff_viewer` populates the slot once, on the UI thread, before `ui.run()`.
-- `tokio::spawn` closures **do not** capture the `Rc`. They do their async work, then call `slint::invoke_from_event_loop(...)`, and inside that closure (which runs on the UI thread) they fetch the state via `with_app_state(...)`.
-- Because `with_app_state` is only invoked from UI-thread callbacks, the `thread_local!` access is always safe, and the spawned future itself is `Send`.
+- `tokio::spawn` futures **do not** capture the `Rc` and do not read `DIFF_APP_STATE` themselves. They do their async work (e.g. an HTTP fetch), then call `slint::invoke_from_event_loop(|| { ... })`. The closure handed to `invoke_from_event_loop` runs on the UI thread, and *that* closure is what calls `with_app_state(...)` to apply the result.
+- Because `with_app_state` is only invoked from UI-thread callbacks (Slint callbacks and `invoke_from_event_loop` closures), the `thread_local!` access is always on the same thread that initialized it, and the spawned future itself stays `Send`.
 
 This preserves the ergonomic `Rc<RefCell<DiffAppState>>` model used throughout the diff viewer while satisfying tokio's `Send` requirement at the spawn boundary.
 
@@ -57,7 +57,7 @@ This preserves the ergonomic `Rc<RefCell<DiffAppState>>` model used throughout t
 
 ### Positive
 
-- No global blast radius: only one `thread_local!` slot, accessed through `with_app_state(...)`.
+- No global blast radius for `DiffAppState`: it lives in exactly one `thread_local!` slot (`DIFF_APP_STATE`), accessed only through `with_app_state(...)`. (A second, unrelated `thread_local!` — `ACTIVE_DIFF_WINDOW` — exists for the toast auto-dismiss `slint::Timer` to look up the live window via a `Weak`; that one is a small, single-purpose handle and not in scope of this ADR.)
 - Existing `Rc<RefCell<>>` ergonomics remain (`state.borrow_mut().push_toast(...)`, etc.).
 - Spawned futures stay `Send` without restructuring every callback to lock a mutex or marshal messages.
 
@@ -71,4 +71,4 @@ This preserves the ergonomic `Rc<RefCell<DiffAppState>>` model used throughout t
 
 ### Boundaries
 
-The `thread_local!` pattern is **only** used for `DIFF_APP_STATE`. Other shared state (terminal `Term`, PTY master, alacritty processor) lives behind `Arc<Mutex<...>>` because those are accessed from non-UI threads (PTY reader thread, timer ticks) and the cost of a lock is appropriate there.
+The `thread_local!` pattern is used here **specifically for `DiffAppState`**, via the `DIFF_APP_STATE` slot. The codebase has one other `thread_local!` (`ACTIVE_DIFF_WINDOW`) which holds a `Weak<DiffViewerWindow>` for the toast auto-dismiss timer; it is a single-purpose UI-thread handle and is treated as an implementation detail of the toast system. Other shared state (terminal `Term`, PTY master, alacritty processor) lives behind `Arc<Mutex<...>>` because those are accessed from non-UI threads (PTY reader thread, timer ticks) and the cost of a lock is appropriate there.


### PR DESCRIPTION
Closes #225

#204 の async 化で導入した `thread_local DIFF_APP_STATE` のグローバル可変状態としての許容理由・代替案・境界条件を ADR 0006 として en/ja 両方で記録する。

## 主な内容
- Context: tokio::spawn の Send 要件 vs Rc<RefCell<>> 非 Send / Slint 単一 UI スレッド
- Decision: thread_local + with_app_state ヘルパで spawn closure を Send に保つ
- Alternatives: Arc<Mutex<>> (全置換 + nested borrow 再発), Actor (over-engineering)
- Consequences: 別 window 拡張 / Slint integration test 時の見直し条件

## Test plan
- [x] docs only