### PR TITLE
feat: tracing crate 導入 + eprintln! を tracing::warn! に置換 (#234)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,6 +3187,8 @@ dependencies = [
  "slint",
  "slint-build",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "which",
 ]
 
@@ -3244,6 +3246,15 @@ checksum = "5c463f9c428b7fc5ec885dcd39ce4aa61e29111d0e33483f6f98c74e89d8621e"
 dependencies = [
  "lyon_geom",
  "num-traits",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -3444,6 +3455,15 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-bigint"
@@ -5123,6 +5143,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5706,6 +5735,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6014,6 +6052,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -6227,6 +6295,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ portable-pty = "0.9.0"
 similar = "3.1.0"
 slint = "1.15.1"
 tokio = { version = "1.52.0", features = ["rt-multi-thread", "macros"] }
+tracing = "0.1.42"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 which = "8.0.2"
 
 [build-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,10 @@ use ui_state::diff_view::build_diff_file_views;
 use ui_state::draft_view::{anchor_label, build_draft_entry_views, side_from_line_kind};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // i18n を最初に初期化する。LANG が未設定なら locus 既定の ja に揃える。
+    // tracing-subscriber を最初に初期化する。LOCUS_LOG=debug 等で詳細
+    // レベルを上げられる。設定なしでは warn 以上のみ stderr に出る。
+    init_logging();
+    // i18n を初期化する。LANG が未設定なら locus 既定の ja に揃える。
     let _ = i18n::init_from_env();
 
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -67,6 +70,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             std::process::exit(2);
         }
     }
+}
+
+/// `LOCUS_LOG` 環境変数 (`error` / `warn` / `info` / `debug` / `trace`)
+/// を tracing-subscriber の EnvFilter に流し込む。未設定時は `warn`。
+fn init_logging() {
+    use tracing_subscriber::EnvFilter;
+    let filter = EnvFilter::try_from_env("LOCUS_LOG")
+        .unwrap_or_else(|_| EnvFilter::new("warn"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init();
 }
 
 fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -109,7 +124,7 @@ fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
                     ui.set_visible_rows(rows_now as i32);
                 }
                 Err(e) => {
-                    eprintln!("warn: terminal resize failed ({cols}x{rows}): {e}");
+                    tracing::warn!(%cols, %rows, error = %e, "terminal resize failed");
                 }
             }
         });
@@ -362,7 +377,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
     let agent_resolution = which::which(&agent_cmd);
     let terminal_pane: Option<Rc<terminal::TerminalPane>> = match agent_resolution {
         Err(e) => {
-            eprintln!("warn: agent command '{agent_cmd}' not found in PATH: {e}");
+            tracing::warn!(agent_cmd, error = %e, "agent command not found in PATH");
             ui.set_terminal_available(false);
             ui.set_terminal_status(SharedString::from(i18n::tr_args(
                 "{}: not found in PATH",
@@ -392,9 +407,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
                 Some(pane_rc)
             }
             Err(e) => {
-                eprintln!(
-                    "warn: failed to launch terminal pane with '{agent_cmd}': {e} (continuing without terminal)"
-                );
+                tracing::warn!(agent_cmd, error = %e, "failed to launch terminal pane (continuing without terminal)");
                 ui.set_terminal_available(false);
                 let err = e.to_string();
                 ui.set_terminal_status(SharedString::from(i18n::tr_args(
@@ -666,7 +679,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
                 let snapshot = match snapshot_res {
                     Ok(s) => s,
                     Err(e) => {
-                        eprintln!("warn: failed to fetch PR #{new_number}: {e}");
+                        tracing::warn!(pr = new_number, error = %e, "failed to fetch PR");
                         let err_str = e.to_string();
                         let weak = weak_for_task.clone();
                         let _ = slint::invoke_from_event_loop(move || {
@@ -831,7 +844,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
             let snapshot = match snapshot_res {
                 Ok(s) => s,
                 Err(e) => {
-                    eprintln!("warn: initial hydrate snapshot failed: {e}");
+                    tracing::warn!(error = %e, "initial hydrate snapshot failed");
                     let err_str = e.to_string();
                     let weak = weak_for_task.clone();
                     let pr_str = pr_number.to_string();
@@ -931,7 +944,7 @@ fn wire_terminal_resize(
                 ui.set_terminal_rows_count(rows_now as i32);
             }
             Err(e) => {
-                eprintln!("warn: terminal resize failed ({cols}x{rows}): {e}");
+                tracing::warn!(%cols, %rows, error = %e, "terminal resize failed");
             }
         }
     });


### PR DESCRIPTION
Closes #234

## 変更
- tracing 0.1.42 + tracing-subscriber 0.3.20 (env-filter feature) 追加
- LOCUS_LOG=warn|info|debug|trace で出力レベルを制御 (default warn)
- 既存の "warn: ..." eprintln! 6 箇所を `tracing::warn!` に置換
- Usage メッセージは eprintln! のまま (subscriber 初期化前)

## Test plan
- [x] cargo clippy / cargo test (123 passed)
- [ ] (手動) LOCUS_LOG=debug で詳細ログが出る
- [ ] (手動) LOCUS_LOG なしで warn のみ出る