### PR TITLE
feat(ui): LOCUS_CONFIRM_SEND で Insert+Send 確認 checkbox を要求 (#238)

### DIFF
--- a/lang/ja/LC_MESSAGES/locus.po
+++ b/lang/ja/LC_MESSAGES/locus.po
@@ -156,8 +156,11 @@ msgid "Send anyway (override)"
 msgstr "上限を無視して送信"
 
 # Insert+Send confirmation (#238)
-msgid "Confirm to send (LOCUS_CONFIRM_SEND)"
-msgstr "送信前に確認 (LOCUS_CONFIRM_SEND)"
+msgid "Confirm to send"
+msgstr "送信前に確認"
+
+msgid "chars"
+msgstr "文字"
 
 msgid "Confirm"
 msgstr "確認"

--- a/lang/ja/LC_MESSAGES/locus.po
+++ b/lang/ja/LC_MESSAGES/locus.po
@@ -154,3 +154,10 @@ msgstr "プレビューが上限を超えています。送信ボタンは無効
 
 msgid "Send anyway (override)"
 msgstr "上限を無視して送信"
+
+# Insert+Send confirmation (#238)
+msgid "Confirm to send (LOCUS_CONFIRM_SEND)"
+msgstr "送信前に確認 (LOCUS_CONFIRM_SEND)"
+
+msgid "Confirm"
+msgstr "確認"

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,9 @@ pub struct UiConfig {
     /// 既定 32000 (Claude API context window の安全圏内目安)。超過すると
     /// preview pane に warning が出るが、override checkbox で送信は可能。
     pub prompt_max_chars: usize,
+    /// Insert+Send 押下前に「送信していい？」と確認 checkbox を要求するかどうか。
+    /// `LOCUS_CONFIRM_SEND=true` で有効化、既定 false (毎回の確認はうざいため)。
+    pub confirm_send: bool,
 }
 
 impl UiConfig {
@@ -41,12 +44,16 @@ impl UiConfig {
         let prompt_max_chars = parse_prompt_max_chars_env(
             std::env::var("LOCUS_PROMPT_MAX_CHARS").ok().as_deref(),
         );
+        let confirm_send = parse_confirm_send_env(
+            std::env::var("LOCUS_CONFIRM_SEND").ok().as_deref(),
+        );
         Self {
             font_family,
             terminal_font_size,
             diff_font_size,
             bracketed_paste,
             prompt_max_chars,
+            confirm_send,
         }
     }
 
@@ -84,6 +91,17 @@ pub fn parse_bracketed_paste_env(value: Option<&str>) -> bool {
     }
 }
 
+/// `LOCUS_CONFIRM_SEND` の値で Insert+Send 確認 checkbox を要求するかどうか。
+///
+/// - 未設定 / 空 / 不明値 / `0` / `false` / `off` / `no` → false (既定)
+/// - `1` / `true` / `on` / `yes` → true
+pub fn parse_confirm_send_env(value: Option<&str>) -> bool {
+    match value.map(|s| s.trim().to_ascii_lowercase()) {
+        Some(v) => matches!(v.as_str(), "1" | "true" | "on" | "yes"),
+        None => false,
+    }
+}
+
 /// `LOCUS_PROMPT_MAX_CHARS` を usize にパースする。
 ///
 /// - 未設定 / 空 / 解釈不能な値 → 既定 32000
@@ -107,6 +125,7 @@ mod tests {
             diff_font_size: 12.0,
             bracketed_paste: true,
             prompt_max_chars: 32_000,
+            confirm_send: false,
         };
         assert!(cfg.terminal_cell_w() >= 6.0);
         assert!(cfg.terminal_cell_h() >= 14.0);
@@ -120,6 +139,7 @@ mod tests {
             diff_font_size: 10.0,
             bracketed_paste: true,
             prompt_max_chars: 32_000,
+            confirm_send: false,
         };
         let big = UiConfig {
             font_family: "x".into(),
@@ -127,6 +147,7 @@ mod tests {
             diff_font_size: 20.0,
             bracketed_paste: true,
             prompt_max_chars: 32_000,
+            confirm_send: false,
         };
         assert!(big.terminal_cell_w() > small.terminal_cell_w());
         assert!(big.terminal_cell_h() > small.terminal_cell_h());
@@ -150,6 +171,27 @@ mod tests {
     fn bracketed_paste_explicit_on() {
         for v in ["1", "true", "True", "on", "yes"] {
             assert!(parse_bracketed_paste_env(Some(v)));
+        }
+    }
+
+    #[test]
+    fn confirm_send_default_off() {
+        assert!(!parse_confirm_send_env(None));
+        assert!(!parse_confirm_send_env(Some("")));
+        assert!(!parse_confirm_send_env(Some("garbage")));
+    }
+
+    #[test]
+    fn confirm_send_explicit_on() {
+        for v in ["1", "true", "True", "on", "yes", "ON"] {
+            assert!(parse_confirm_send_env(Some(v)));
+        }
+    }
+
+    #[test]
+    fn confirm_send_explicit_off() {
+        for v in ["0", "false", "off", "no"] {
+            assert!(!parse_confirm_send_env(Some(v)));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,6 +340,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
     ui.set_terminal_cell_w(ui_cfg.terminal_cell_w());
     ui.set_terminal_cell_h(ui_cfg.terminal_cell_h());
     ui.set_preview_max_chars(ui_cfg.prompt_max_chars.min(i32::MAX as usize) as i32);
+    ui.set_require_send_confirm(ui_cfg.confirm_send);
     apply_snapshot_to_ui(&ui, &placeholder_snapshot, &[]);
     ui.set_current_pr_number(pr_number as i32);
     ui.set_pr_list(build_pr_list_model(&[]));

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -190,6 +190,9 @@ export component DiffViewerWindow inherits Window {
     in-out property <string> preview-text;
     in property <int> preview-max-chars: 32000;
     in-out property <bool> preview-override: false;
+    // LOCUS_CONFIRM_SEND=true で「Confirm to send」チェックボックスを必須化。
+    in property <bool> require-send-confirm: false;
+    in-out property <bool> send-confirmed: false;
     // preview-text の文字数 (code-point ベース)。Slint 側で自動再計算するので
     // Rust から set する必要はなく、TextInput でユーザーが編集した場合も
     // 即時反映される。
@@ -366,8 +369,10 @@ export component DiffViewerWindow inherits Window {
                 && (event.modifiers.meta || event.modifiers.control)
                 && root.terminal-available
                 && (root.preview-length <= root.preview-max-chars
-                    || root.preview-override)) {
+                    || root.preview-override)
+                && (!root.require-send-confirm || root.send-confirmed)) {
                 root.send-insert-and-send(root.preview-text);
+                root.send-confirmed = false;
                 return accept;
             }
             if (event.text == "c"
@@ -857,14 +862,40 @@ export component DiffViewerWindow inherits Window {
                                     text: @tr("Insert+Send");
                                     enabled: root.terminal-available
                                         && (root.preview-length <= root.preview-max-chars
-                                            || root.preview-override);
-                                    clicked => { root.send-insert-and-send(root.preview-text); }
+                                            || root.preview-override)
+                                        && (!root.require-send-confirm || root.send-confirmed);
+                                    clicked => {
+                                        root.send-insert-and-send(root.preview-text);
+                                        root.send-confirmed = false;
+                                    }
                                 }
                                 Button {
                                     text: @tr("Copy");
                                     enabled: root.preview-length <= root.preview-max-chars
                                         || root.preview-override;
                                     clicked => { root.send-copy-to-clipboard(root.preview-text); }
+                                }
+                            }
+
+                            // LOCUS_CONFIRM_SEND=true 時の confirm checkbox (#238)
+                            if root.require-send-confirm: HorizontalBox {
+                                spacing: 8px;
+                                alignment: start;
+                                Text {
+                                    text: "🔒";
+                                    font-size: 12px;
+                                    vertical-alignment: center;
+                                }
+                                Text {
+                                    text: @tr("Confirm to send (LOCUS_CONFIRM_SEND)");
+                                    color: #b0b0c0;
+                                    font-size: 11px;
+                                    vertical-alignment: center;
+                                    horizontal-stretch: 1;
+                                }
+                                CheckBox {
+                                    text: @tr("Confirm");
+                                    checked <=> root.send-confirmed;
                                 }
                             }
 

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -193,6 +193,13 @@ export component DiffViewerWindow inherits Window {
     // LOCUS_CONFIRM_SEND=true で「Confirm to send」チェックボックスを必須化。
     in property <bool> require-send-confirm: false;
     in-out property <bool> send-confirmed: false;
+
+    // preview-text が動いたら confirm をリセットする。これにより、Confirm 済み
+    // 状態のまま preview を編集 / Refresh / selection 切替して別内容を送信する
+    // 事故を防ぐ (#238 MUST)。
+    changed preview-text => {
+        root.send-confirmed = false;
+    }
     // preview-text の文字数 (code-point ベース)。Slint 側で自動再計算するので
     // Rust から set する必要はなく、TextInput でユーザーが編集した場合も
     // 即時反映される。
@@ -887,7 +894,7 @@ export component DiffViewerWindow inherits Window {
                                     vertical-alignment: center;
                                 }
                                 Text {
-                                    text: @tr("Confirm to send (LOCUS_CONFIRM_SEND)");
+                                    text: @tr("Confirm to send") + ": " + root.preview-length + " " + @tr("chars");
                                     color: #b0b0c0;
                                     font-size: 11px;
                                     vertical-alignment: center;


### PR DESCRIPTION
Closes #238

## 設計
- LOCUS_CONFIRM_SEND=true で require-send-confirm を有効化、Confirm checkbox を画面に表示
- checkbox がオフの間は Insert+Send ボタンと Cmd+Enter ショートカット両方を disabled
- 送信成功後に checkbox 自動オフ → 連続送信でも毎回確認

## Test plan
- [x] cargo clippy / cargo test (126 passed; 3 新規)
- [ ] (手動) LOCUS_CONFIRM_SEND=true で送信前に confirm 必須となること