### PR TITLE
feat: ファイル切替時に diff scroll 位置を保持 (#230)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -762,6 +762,8 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
                             st.draft.clear();
                             st.current_anchor = None;
                             st.pending_range = false;
+                            // snapshot 切替で旧 PR の scroll cache を引きずらない (#230)
+                            st.scroll_positions.clear();
                         }
                         refresh_current_anchor_label(&ui, state);
                         refresh_draft_panel(&ui, state);
@@ -925,7 +927,10 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
                 let Some(ui) = weak_for_task.upgrade() else { return };
                 apply_snapshot_to_ui(&ui, &snapshot, &linked);
                 with_app_state(|state| {
-                    state.borrow_mut().snapshot = snapshot;
+                    let mut st = state.borrow_mut();
+                    st.snapshot = snapshot;
+                    // snapshot 切替で旧 file index の scroll cache を引きずらない
+                    st.scroll_positions.clear();
                 });
             });
         });
@@ -1005,6 +1010,10 @@ fn apply_snapshot_to_ui(
     let model = std::rc::Rc::new(slint::VecModel::from(file_views));
     ui.set_files(slint::ModelRc::from(model));
     ui.set_selected_file_index(0);
+    // snapshot 切替で files が差し替わるため、index-keyed scroll cache を
+    // 引きずらないよう viewport-y をリセットする (#230)。HashMap 自体の
+    // クリアは状態へのアクセスが必要なので呼び出し側 (with_app_state) で行う。
+    ui.set_diff_scroll_y(0.0);
 }
 
 fn build_pr_list_model(

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,9 @@ struct DiffAppState {
     /// 表示中のトースト。new -> bottom 順 (UI 側 index で逆順表示)。
     toasts: Vec<ToastEntry>,
     next_toast_id: i32,
+    /// ファイル切替時に viewport-y を保存する HashMap (#230)。
+    /// key は selected-file-index、value は logical px。
+    scroll_positions: std::collections::HashMap<usize, f32>,
 }
 
 #[derive(Debug, Clone)]
@@ -361,6 +364,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
         list_generation: 0,
         toasts: Vec::new(),
         next_toast_id: 0,
+        scroll_positions: std::collections::HashMap::new(),
     }));
     DIFF_APP_STATE.with(|cell| *cell.borrow_mut() = Some(state.clone()));
     ACTIVE_DIFF_WINDOW.with(|cell| *cell.borrow_mut() = Some(ui.as_weak()));
@@ -590,6 +594,32 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
             let Some(ui) = ui_weak.upgrade() else { return };
             state.borrow_mut().cancel_range_on_file_switch();
             refresh_current_anchor_label(&ui, &state);
+        });
+    }
+
+    // file-switch-requested (#230): file row click から呼ばれる。
+    // 現在の diff-scroll-y を 旧 file index で保存し、selected-file-index を
+    // 切り替えた後に新 index に対する保存値を復元する。
+    {
+        let state = state.clone();
+        let ui_weak = ui.as_weak();
+        ui.on_file_switch_requested(move |new_idx| {
+            let Some(ui) = ui_weak.upgrade() else { return };
+            let old_idx = ui.get_selected_file_index() as usize;
+            let cur_scroll = ui.get_diff_scroll_y();
+            state.borrow_mut().scroll_positions.insert(old_idx, cur_scroll);
+
+            ui.set_selected_file_index(new_idx);
+
+            let restore = state
+                .borrow()
+                .scroll_positions
+                .get(&(new_idx as usize))
+                .copied()
+                .unwrap_or(0.0);
+            ui.set_diff_scroll_y(restore);
+
+            ui.invoke_file_switched(new_idx);
         });
     }
 
@@ -1351,6 +1381,7 @@ mod tests {
         list_generation: 0,
         toasts: Vec::new(),
         next_toast_id: 0,
+        scroll_positions: std::collections::HashMap::new(),
         }
     }
 

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -181,6 +181,10 @@ export component DiffViewerWindow inherits Window {
     in property <[IssueContextView]> linked-issues;
     in property <[DiffFileView]> files;
     in-out property <int> selected-file-index: 0;
+    // diff content ListView の scroll 位置 (logical px)。Rust 側が
+    // ファイル毎の HashMap として保存し、file-switch-requested の中で
+    // 切替前後に save / restore する。
+    in-out property <length> diff-scroll-y;
 
     in property <string> current-anchor-label: @tr("(no selection)");
     in property <bool> has-selection: false;
@@ -241,6 +245,9 @@ export component DiffViewerWindow inherits Window {
     callback remove-draft-entry(int);
     callback clear-current-selection();
     callback file-switched(int);
+    // file 切替を Rust 経由で実行する。Rust 側で diff-scroll-y を save → 切替 →
+    // restore の順に行うため、Slint だけで selected-file-index を書き換えない。
+    callback file-switch-requested(int);
 
     callback refresh-preview();
     callback send-insert-only(string);
@@ -639,8 +646,10 @@ export component DiffViewerWindow inherits Window {
 
                         touch := TouchArea {
                             clicked => {
-                                root.selected-file-index = idx;
-                                root.file-switched(idx);
+                                // Rust 側で scroll 位置の save / restore を伴って
+                                // 順次処理する。selected-file-index も file-switched
+                                // も Rust から発火する。
+                                root.file-switch-requested(idx);
                             }
                             changed has-hover => {
                                 if (self.has-hover) {
@@ -709,6 +718,9 @@ export component DiffViewerWindow inherits Window {
                         if root.files.length > 0
                             && !root.files[root.selected-file-index].is-unsupported:
                         ListView {
+                            // viewport-y を root のプロパティに紐付け、Rust 側で
+                            // ファイル毎に save / restore する (#230)。
+                            viewport-y <=> root.diff-scroll-y;
                             for line in root.files[root.selected-file-index].lines: Rectangle {
                                 height: 18px;
                                 background: line.is-hunk-header ? #1a1a28


### PR DESCRIPTION
Closes #230

## 設計
- Slint ListView.viewport-y を root.diff-scroll-y に双方向 binding
- file row click は file-switch-requested(idx) callback 経由
- Rust が save (旧 idx) → set_selected_file_index → restore (新 idx) の順序制御
- DiffAppState.scroll_positions: HashMap<usize, f32>

## Test plan
- [x] cargo clippy / cargo test (126 passed)
- [ ] (手動) file A 中央までスクロール → file B → file A で位置復元