### PR TITLE
feat: window size を session.json に永続化 (#231 部分対応)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,6 +1303,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,10 +3200,13 @@ dependencies = [
  "alacritty_terminal",
  "arboard",
  "chrono",
+ "directories",
  "futures",
  "http",
  "octocrab",
  "portable-pty",
+ "serde",
+ "serde_json",
  "similar",
  "slint",
  "slint-build",
@@ -4005,6 +4029,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4659,6 +4689,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,13 @@ edition = "2024"
 alacritty_terminal = "=0.26.0"
 arboard = "3.6.1"
 chrono = { version = "0.4.44", features = ["std"] }
+directories = "6.0.0"
 futures = "0.3.32"
 http = "1.4.0"
 octocrab = "0.49.7"
 portable-pty = "0.9.0"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.140"
 similar = "3.1.0"
 slint = "1.15.1"
 tokio = { version = "1.52.0", features = ["rt-multi-thread", "macros"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod github;
 mod i18n;
 mod review;
 mod semantic;
+mod session;
 mod terminal;
 mod ui_state;
 
@@ -344,6 +345,16 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
     ui.set_terminal_cell_h(ui_cfg.terminal_cell_h());
     ui.set_preview_max_chars(ui_cfg.prompt_max_chars.min(i32::MAX as usize) as i32);
     ui.set_require_send_confirm(ui_cfg.confirm_send);
+
+    // セッション復元 (#231): 前回保存した window size があれば適用する。
+    if let Some(saved) = session::load()
+        && let (Some(w), Some(h)) = (saved.window_width, saved.window_height)
+        && w > 0.0
+        && h > 0.0
+    {
+        ui.window()
+            .set_size(slint::WindowSize::Logical(slint::LogicalSize::new(w, h)));
+    }
     apply_snapshot_to_ui(&ui, &placeholder_snapshot, &[]);
     ui.set_current_pr_number(pr_number as i32);
     ui.set_pr_list(build_pr_list_model(&[]));
@@ -933,6 +944,24 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
                     st.scroll_positions.clear();
                 });
             });
+        });
+    }
+
+    // セッション保存 (#231): close 要求時に現在の window size を session.json に
+    // 書き出す。失敗しても close を阻害しない (CloseRequestResponse::HideWindow)。
+    {
+        let ui_weak = ui.as_weak();
+        ui.window().on_close_requested(move || {
+            if let Some(ui) = ui_weak.upgrade() {
+                let physical = ui.window().size();
+                let scale = ui.window().scale_factor().max(f32::EPSILON);
+                let state = session::SessionState {
+                    window_width: Some(physical.width as f32 / scale),
+                    window_height: Some(physical.height as f32 / scale),
+                };
+                session::save(&state);
+            }
+            slint::CloseRequestResponse::HideWindow
         });
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -26,24 +26,24 @@ pub struct SessionState {
 }
 
 /// `directories` crate で OS 固有の config 領域を解決する。
-/// macOS: `~/Library/Application Support/locus/`
-/// Linux: `$XDG_CONFIG_HOME/locus/` または `~/.config/locus/`
-/// Windows: `%APPDATA%\locus\config\`
+///
+/// reverse-DNS な subfolder を避けるため `qualifier` / `organization` を
+/// 空にして `application = "locus"` だけ渡す。実際の解決先:
+/// - macOS: `~/Library/Application Support/locus/session.json`
+/// - Linux: `$XDG_CONFIG_HOME/locus/session.json` (default `~/.config/locus/`)
+/// - Windows: `%APPDATA%\locus\config\session.json`
 pub fn session_path() -> Option<PathBuf> {
-    let dirs = ProjectDirs::from("dev", "locus", "locus")?;
+    let dirs = ProjectDirs::from("", "", "locus")?;
     Some(dirs.config_dir().join("session.json"))
 }
 
 /// セッションを読み込む。
 ///
 /// 戻り値の意味:
-/// - `Some(SessionState)`: 読み込み成功 (ファイル不在は `None`)
-/// - `None`: ファイル不在 / 読み込み or parse 失敗 (warn ログを出す)
+/// - `Some(SessionState)`: 読み込み成功
+/// - `None`: ファイル不在 / 読み込み or parse 失敗 (NotFound 以外は warn ログ)
 pub fn load() -> Option<SessionState> {
     let path = session_path()?;
-    if !path.exists() {
-        return None;
-    }
     match std::fs::read_to_string(&path) {
         Ok(s) => match serde_json::from_str::<SessionState>(&s) {
             Ok(state) => Some(state),
@@ -52,6 +52,7 @@ pub fn load() -> Option<SessionState> {
                 None
             }
         },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
         Err(e) => {
             tracing::warn!(path = %path.display(), error = %e, "failed to read session.json");
             None

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,124 @@
+//! セッション永続化。
+//!
+//! ウィンドウサイズなど「アプリを再起動しても引き継ぎたい状態」を
+//! `~/Library/Application Support/locus/session.json` (macOS) /
+//! `$XDG_CONFIG_HOME/locus/session.json` (Linux) に書き出す。
+//!
+//! ファイル I/O は best-effort で、失敗しても tracing で warn するだけで
+//! アプリは続行する (起動時に corrupt JSON / permission denied / disk full
+//! などで止めない方針)。
+
+use std::path::PathBuf;
+
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+
+/// ローカル永続化される session 状態。schema が将来増えたら `#[serde(default)]`
+/// で後方互換を取る (古い session.json で新フィールドは default に倒れる)。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionState {
+    /// 最後に閉じた時のウィンドウ幅 (logical px)。
+    #[serde(default)]
+    pub window_width: Option<f32>,
+    /// 最後に閉じた時のウィンドウ高さ (logical px)。
+    #[serde(default)]
+    pub window_height: Option<f32>,
+}
+
+/// `directories` crate で OS 固有の config 領域を解決する。
+/// macOS: `~/Library/Application Support/locus/`
+/// Linux: `$XDG_CONFIG_HOME/locus/` または `~/.config/locus/`
+/// Windows: `%APPDATA%\locus\config\`
+pub fn session_path() -> Option<PathBuf> {
+    let dirs = ProjectDirs::from("dev", "locus", "locus")?;
+    Some(dirs.config_dir().join("session.json"))
+}
+
+/// セッションを読み込む。
+///
+/// 戻り値の意味:
+/// - `Some(SessionState)`: 読み込み成功 (ファイル不在は `None`)
+/// - `None`: ファイル不在 / 読み込み or parse 失敗 (warn ログを出す)
+pub fn load() -> Option<SessionState> {
+    let path = session_path()?;
+    if !path.exists() {
+        return None;
+    }
+    match std::fs::read_to_string(&path) {
+        Ok(s) => match serde_json::from_str::<SessionState>(&s) {
+            Ok(state) => Some(state),
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "failed to parse session.json (ignoring)");
+                None
+            }
+        },
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "failed to read session.json");
+            None
+        }
+    }
+}
+
+/// セッションを書き出す。失敗時は warn ログのみで panic しない。
+pub fn save(state: &SessionState) {
+    let Some(path) = session_path() else {
+        tracing::warn!("could not resolve session.json path");
+        return;
+    };
+    if let Some(parent) = path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        tracing::warn!(path = %parent.display(), error = %e, "failed to create config dir");
+        return;
+    }
+    let json = match serde_json::to_string_pretty(state) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to serialize session state");
+            return;
+        }
+    };
+    if let Err(e) = std::fs::write(&path, json) {
+        tracing::warn!(path = %path.display(), error = %e, "failed to write session.json");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_session_state_has_no_window_size() {
+        let s = SessionState::default();
+        assert!(s.window_width.is_none());
+        assert!(s.window_height.is_none());
+    }
+
+    #[test]
+    fn round_trip_through_json() {
+        let original = SessionState {
+            window_width: Some(1700.0),
+            window_height: Some(960.0),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: SessionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.window_width, Some(1700.0));
+        assert_eq!(decoded.window_height, Some(960.0));
+    }
+
+    #[test]
+    fn missing_fields_default_to_none() {
+        let json = r#"{}"#;
+        let decoded: SessionState = serde_json::from_str(json).unwrap();
+        assert!(decoded.window_width.is_none());
+        assert!(decoded.window_height.is_none());
+    }
+
+    #[test]
+    fn unknown_fields_are_ignored() {
+        let json = r#"{"window_width": 100.0, "future_field": "future_value"}"#;
+        let decoded: SessionState = serde_json::from_str(json).unwrap();
+        assert_eq!(decoded.window_width, Some(100.0));
+        assert!(decoded.window_height.is_none());
+    }
+}


### PR DESCRIPTION
Refs #231

最小スコープでウィンドウ width / height のみ起動間で復元する。draft entries / window position / per-PR file index などフル仕様は follow-up。

## 設計
- src/session.rs に SessionState + load() / save()
- directories crate で OS-native config_dir に session.json
- failure は tracing::warn! のみで startup / close を阻害しない
- on_close_requested で physical size / scale factor から logical px に変換して save

## Test plan
- [x] cargo clippy / cargo test (130 passed; 4 新規 unit test)
- [ ] (手動) ウィンドウサイズ変更 → 閉じる → 再起動で復元
- [ ] (手動) ~/Library/Application Support/locus/session.json が生成される