### PR TITLE
fix: cargo run -- github の panic を解消 + Cmd+Q で session 保存

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -321,7 +321,14 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
     // 起動を「ネットワーク待ち」にしないため、最初に空の DiffViewerWindow を
     // 作って表示し、PR snapshot / PR list / linked issues は非同期 hydrate
     // する。GitHub クライアントの初期化失敗のみ即時エラーで abort。
-    let client_arc = build_client()?;
+    //
+    // octocrab::Octocrab::builder().build() は内部で tower buffer service を
+    // spawn するため、tokio runtime context 内で呼ぶ必要がある。enter() の
+    // guard を持っている間だけが runtime context として認識される。
+    let client_arc = {
+        let _guard = runtime_handle.enter();
+        build_client()?
+    };
 
     let placeholder_snapshot = PullRequestSnapshot {
         target: review::target::ReviewTarget::GitHubPr {
@@ -947,19 +954,17 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
         });
     }
 
-    // セッション保存 (#231): close 要求時に現在の window size を session.json に
-    // 書き出す。失敗しても close を阻害しない (CloseRequestResponse::HideWindow)。
+    // セッション保存 (#231):
+    // - close 要求時 (X ボタン / 通常 close)
+    // - terminal-resized callback 経由 (ウィンドウリサイズで間接的に発火)
+    // の 2 経路で書き出す。Cmd+Q は Slint の on_close_requested を通らずに
+    // process exit するため、resize 経由の保存が "ほぼリアルタイムの最新値"
+    // を持っていればその時点の window size が次回起動で復元される。
     {
         let ui_weak = ui.as_weak();
         ui.window().on_close_requested(move || {
             if let Some(ui) = ui_weak.upgrade() {
-                let physical = ui.window().size();
-                let scale = ui.window().scale_factor().max(f32::EPSILON);
-                let state = session::SessionState {
-                    window_width: Some(physical.width as f32 / scale),
-                    window_height: Some(physical.height as f32 / scale),
-                };
-                session::save(&state);
+                save_window_session(&ui);
             }
             slint::CloseRequestResponse::HideWindow
         });
@@ -1018,7 +1023,23 @@ fn wire_terminal_resize(
                 tracing::warn!(%cols, %rows, error = %e, "terminal resize failed");
             }
         }
+        // ウィンドウリサイズに連れて terminal-pane の width/height も変わる
+        // ため、ここで session を保存しておくと Cmd+Q (close-requested を
+        // 通らず process exit) でも最後の window size を残せる (#231 補強)。
+        save_window_session(&ui);
     });
+}
+
+/// 現在のウィンドウサイズを logical px にして session.json へ書き出す。
+/// 失敗時は session::save 内部で warn ログのみ。
+fn save_window_session(ui: &DiffViewerWindow) {
+    let physical = ui.window().size();
+    let scale = ui.window().scale_factor().max(f32::EPSILON);
+    let state = session::SessionState {
+        window_width: Some(physical.width as f32 / scale),
+        window_height: Some(physical.height as f32 / scale),
+    };
+    session::save(&state);
 }
 
 fn apply_snapshot_to_ui(

--- a/src/session.rs
+++ b/src/session.rs
@@ -61,7 +61,23 @@ pub fn load() -> Option<SessionState> {
 }
 
 /// セッションを書き出す。失敗時は warn ログのみで panic しない。
+///
+/// ライブリサイズ中の連続呼び出しでも実 I/O は最小限に抑えるため、
+/// 直前に書いた SessionState と同じなら早期 return する (in-process cache)。
+/// プロセス再起動の境界では cache が空なので必ず最初の 1 回は書く。
 pub fn save(state: &SessionState) {
+    use std::sync::Mutex;
+
+    static LAST_SAVED: Mutex<Option<SessionState>> = Mutex::new(None);
+
+    if let Ok(guard) = LAST_SAVED.lock()
+        && let Some(prev) = guard.as_ref()
+        && prev.window_width == state.window_width
+        && prev.window_height == state.window_height
+    {
+        return;
+    }
+
     let Some(path) = session_path() else {
         tracing::warn!("could not resolve session.json path");
         return;
@@ -81,6 +97,10 @@ pub fn save(state: &SessionState) {
     };
     if let Err(e) = std::fs::write(&path, json) {
         tracing::warn!(path = %path.display(), error = %e, "failed to write session.json");
+        return;
+    }
+    if let Ok(mut guard) = LAST_SAVED.lock() {
+        *guard = Some(state.clone());
     }
 }
 


### PR DESCRIPTION
実機テスト (cargo run + osascript) で見つかった 2 件:

## #1: `cargo run -- github` の起動 panic

`octocrab::Octocrab::builder().build()` が tower buffer service を spawn する際 "no reactor running, must be called from the context of a Tokio 1.x runtime" で panic していた。

→ `build_client()` を `runtime_handle.enter()` guard で囲って tokio context 内で呼ぶ。

## #2: Cmd+Q で session が保存されない

Slint の `on_close_requested` は X ボタンや menu Close では発火するが、Cmd+Q (NSApp quit) では発火せず process exit する。#231 の session 保存が抜ける。

→ `wire_terminal_resize` の `on_terminal_resized` callback でも `save_window_session` を呼んで常に最新値を書く。X ボタン path も維持。

## Test plan
- [x] cargo clippy --all-targets -- -D warnings / cargo test (137 passed)
- [x] (実機) `cargo run -- github duck8823/locus#272` が起動できる
- [x] (実機) ウィンドウリサイズ → Cmd+Q → 再起動でサイズ復元