### PR TITLE
fix(ui): terminal pane の日本語 glyph 箱表示を解消 (#274)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -55,7 +55,7 @@ GitHub アクセス用 token は次の優先順位で解決されます:
 |---|---|---|
 | `LOCUS_LOCALE` | system / `LANG` | `ja` / `en`。未設定時は `LANG` を見て、未対応値や未設定時は `ja` にフォールバック。 |
 | `LOCUS_AGENT_CMD` | `claude` | 内蔵 terminal pane で起動するコマンド。 |
-| `LOCUS_FONT_FAMILY` | `Menlo, Consolas, monospace` | terminal + diff のフォントファミリ。 |
+| `LOCUS_FONT_FAMILY` | OS 別 (macOS: `Menlo, Hiragino Sans, Consolas, monospace`) | terminal + diff のフォントファミリ。既定で CJK fallback を含むため日本語 / 中国語 / 韓国語の glyph が箱化しない。 |
 | `LOCUS_FONT_SIZE` | (未設定) | terminal/diff 両方のフォントサイズを一括指定。 |
 | `LOCUS_TERMINAL_FONT_SIZE` | `13.0` | terminal pane のフォントサイズ (logical px)。 |
 | `LOCUS_DIFF_FONT_SIZE` | `12.0` | diff pane のフォントサイズ (logical px)。 |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For GitHub access, locus reads tokens in this order:
 |---|---|---|
 | `LOCUS_LOCALE` | system / `LANG` | `ja` or `en`. Reads `LANG` when unset; falls back to `ja` for unsupported values. |
 | `LOCUS_AGENT_CMD` | `claude` | Command launched in the embedded terminal pane. |
-| `LOCUS_FONT_FAMILY` | `Menlo, Consolas, monospace` | Font family for terminal + diff. |
+| `LOCUS_FONT_FAMILY` | OS-specific (macOS: `Menlo, Hiragino Sans, Consolas, monospace`) | Font family for terminal + diff. The default already includes a CJK fallback so Japanese / Chinese / Korean glyphs render. |
 | `LOCUS_FONT_SIZE` | (unset) | Single override for both terminal and diff font sizes. |
 | `LOCUS_TERMINAL_FONT_SIZE` | `13.0` | Terminal pane font size in logical pixels. |
 | `LOCUS_DIFF_FONT_SIZE` | `12.0` | Diff pane font size in logical pixels. |

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,7 +25,7 @@ pub struct UiConfig {
 impl UiConfig {
     pub fn from_env() -> Self {
         let font_family = std::env::var("LOCUS_FONT_FAMILY")
-            .unwrap_or_else(|_| "Menlo, Consolas, monospace".to_string());
+            .unwrap_or_else(|_| default_font_family().to_string());
         let general = std::env::var("LOCUS_FONT_SIZE")
             .ok()
             .and_then(|s| s.parse::<f32>().ok());
@@ -70,6 +70,28 @@ impl UiConfig {
 
     pub fn terminal_cell_h(&self) -> f32 {
         (self.terminal_font_size * 1.45).round().max(8.0)
+    }
+}
+
+/// OS 別の monospace + CJK fallback font family list。Slint Text の
+/// `font-family` は CSS 風のカンマ区切り fallback を解決するため、
+/// 先頭の monospace に CJK glyph がなくても次の候補に倒れる。
+///
+/// terminal pane と diff viewer は `LOCUS_FONT_FAMILY` で同じリストを共有
+/// する (env 未設定時の既定)。LOCUS_FONT_FAMILY が明示指定されていれば
+/// 全面的に上書きする。
+const fn default_font_family() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "Menlo, Hiragino Sans, Consolas, monospace"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Consolas, Yu Gothic, monospace"
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        "DejaVu Sans Mono, Noto Sans CJK JP, monospace"
     }
 }
 


### PR DESCRIPTION
Closes #274

## 背景
実機検証で terminal pane の日本語が全部 □ になっていた。Menlo / Consolas が CJK glyph を持たないが、LOCUS_FONT_FAMILY の既定値に fallback がなかったため。

## 変更
- src/config.rs: `default_font_family()` を OS 別 const fn として追加
  - macOS: `Menlo, Hiragino Sans, Consolas, monospace`
  - Windows: `Consolas, Yu Gothic, monospace`
  - Linux: `DejaVu Sans Mono, Noto Sans CJK JP, monospace`
- README.md / README.ja.md の env 表を更新

LOCUS_FONT_FAMILY を明示指定するケースは挙動変化なし。

## Test plan
- [x] cargo clippy / cargo test (137 passed)
- [x] (実機) cargo run -- github で diff viewer 起動
- [ ] (ユーザー目視) terminal pane で日本語が箱から正しい glyph に切り替わる