### PR TITLE
fix(ui): DiffViewerWindow に min-width / min-height を設定 (#275)

### DIFF
--- a/ui/app.slint
+++ b/ui/app.slint
@@ -287,6 +287,11 @@ export component DiffViewerWindow inherits Window {
     title: @tr("locus — diff viewer");
     preferred-width: 1700px;
     preferred-height: 960px;
+    // 240(PR list) + 240(file list) + 540(diff) + 320(draft/history) = 1340 が
+    // 横方向の最小機能幅。ヘッダー圧縮を避けるため min-width を 1280px と
+    // やや厳しめに、min-height を 720px に設定する。
+    min-width: 1280px;
+    min-height: 720px;
     background: #101014;
 
     // 起動時にグローバル keybinding 用 FocusScope に焦点を渡しておく。


### PR DESCRIPTION
Closes #275

panel 列 (240+240+540+320=1340) より狭い窓では上部 panel タイトルが圧縮されるため、min-width: 1280px / min-height: 720px をかけて最小機能幅を担保する。

実機で 800x500 を要求 → Slint が 1280x748 にクランプすることを確認。

## Test plan
- [x] cargo clippy / cargo test (137 passed)
- [x] (実機) 800x500 を osascript で要求 → 1280x748 にクランプ