### PR TITLE
feat(session): window position も永続化 (#231 phase 2)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -976,7 +976,28 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
         });
     }
 
+    // セッション位置の定期保存 (#231 Codex MUST 対応):
+    // ウィンドウを移動しただけでは on_close_requested / on_terminal_resized
+    // は発火せず position が stale になるため、1 秒周期で save_window_session
+    // を呼ぶ。session::save() 側の LAST_SAVED キャッシュで実際の disk write は
+    // 値が変化したときのみ。timer は drop されると停止するので、ui.run() の
+    // ライフタイムで保持する。
+    let position_save_timer = slint::Timer::default();
+    {
+        let ui_weak = ui.as_weak();
+        position_save_timer.start(
+            slint::TimerMode::Repeated,
+            std::time::Duration::from_secs(1),
+            move || {
+                if let Some(ui) = ui_weak.upgrade() {
+                    save_window_session(&ui);
+                }
+            },
+        );
+    }
+
     ui.run()?;
+    drop(position_save_timer);
     drop(terminal_pane);
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -353,14 +353,20 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
     ui.set_preview_max_chars(ui_cfg.prompt_max_chars.min(i32::MAX as usize) as i32);
     ui.set_require_send_confirm(ui_cfg.confirm_send);
 
-    // セッション復元 (#231): 前回保存した window size があれば適用する。
-    if let Some(saved) = session::load()
-        && let (Some(w), Some(h)) = (saved.window_width, saved.window_height)
-        && w > 0.0
-        && h > 0.0
-    {
-        ui.window()
-            .set_size(slint::WindowSize::Logical(slint::LogicalSize::new(w, h)));
+    // セッション復元 (#231): 前回保存した window size / position があれば適用する。
+    if let Some(saved) = session::load() {
+        if let (Some(w), Some(h)) = (saved.window_width, saved.window_height)
+            && w > 0.0
+            && h > 0.0
+        {
+            ui.window()
+                .set_size(slint::WindowSize::Logical(slint::LogicalSize::new(w, h)));
+        }
+        if let (Some(x), Some(y)) = (saved.window_x, saved.window_y) {
+            ui.window().set_position(slint::WindowPosition::Logical(
+                slint::LogicalPosition::new(x, y),
+            ));
+        }
     }
     apply_snapshot_to_ui(&ui, &placeholder_snapshot, &[]);
     ui.set_current_pr_number(pr_number as i32);
@@ -1030,14 +1036,17 @@ fn wire_terminal_resize(
     });
 }
 
-/// 現在のウィンドウサイズを logical px にして session.json へ書き出す。
+/// 現在のウィンドウサイズと位置を logical px にして session.json へ書き出す。
 /// 失敗時は session::save 内部で warn ログのみ。
 fn save_window_session(ui: &DiffViewerWindow) {
     let physical = ui.window().size();
+    let pos = ui.window().position();
     let scale = ui.window().scale_factor().max(f32::EPSILON);
     let state = session::SessionState {
         window_width: Some(physical.width as f32 / scale),
         window_height: Some(physical.height as f32 / scale),
+        window_x: Some(pos.x as f32 / scale),
+        window_y: Some(pos.y as f32 / scale),
     };
     session::save(&state);
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 /// ローカル永続化される session 状態。schema が将来増えたら `#[serde(default)]`
 /// で後方互換を取る (古い session.json で新フィールドは default に倒れる)。
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct SessionState {
     /// 最後に閉じた時のウィンドウ幅 (logical px)。
     #[serde(default)]
@@ -23,6 +23,12 @@ pub struct SessionState {
     /// 最後に閉じた時のウィンドウ高さ (logical px)。
     #[serde(default)]
     pub window_height: Option<f32>,
+    /// 最後に閉じた時のウィンドウ X 位置 (logical px、screen 原点)。
+    #[serde(default)]
+    pub window_x: Option<f32>,
+    /// 最後に閉じた時のウィンドウ Y 位置 (logical px、screen 原点)。
+    #[serde(default)]
+    pub window_y: Option<f32>,
 }
 
 /// `directories` crate で OS 固有の config 領域を解決する。
@@ -72,8 +78,7 @@ pub fn save(state: &SessionState) {
 
     if let Ok(guard) = LAST_SAVED.lock()
         && let Some(prev) = guard.as_ref()
-        && prev.window_width == state.window_width
-        && prev.window_height == state.window_height
+        && prev == state
     {
         return;
     }
@@ -120,11 +125,12 @@ mod tests {
         let original = SessionState {
             window_width: Some(1700.0),
             window_height: Some(960.0),
+            window_x: Some(120.0),
+            window_y: Some(48.0),
         };
         let json = serde_json::to_string(&original).unwrap();
         let decoded: SessionState = serde_json::from_str(&json).unwrap();
-        assert_eq!(decoded.window_width, Some(1700.0));
-        assert_eq!(decoded.window_height, Some(960.0));
+        assert_eq!(decoded, original);
     }
 
     #[test]
@@ -133,6 +139,8 @@ mod tests {
         let decoded: SessionState = serde_json::from_str(json).unwrap();
         assert!(decoded.window_width.is_none());
         assert!(decoded.window_height.is_none());
+        assert!(decoded.window_x.is_none());
+        assert!(decoded.window_y.is_none());
     }
 
     #[test]
@@ -141,5 +149,17 @@ mod tests {
         let decoded: SessionState = serde_json::from_str(json).unwrap();
         assert_eq!(decoded.window_width, Some(100.0));
         assert!(decoded.window_height.is_none());
+    }
+
+    #[test]
+    fn old_session_without_position_loads_cleanly() {
+        // 旧 session.json (window_width / window_height のみ) が新 schema で
+        // 読めて、欠落した window_x / window_y が None に倒れる。
+        let json = r#"{"window_width": 1300.0, "window_height": 822.0}"#;
+        let decoded: SessionState = serde_json::from_str(json).unwrap();
+        assert_eq!(decoded.window_width, Some(1300.0));
+        assert_eq!(decoded.window_height, Some(822.0));
+        assert!(decoded.window_x.is_none());
+        assert!(decoded.window_y.is_none());
     }
 }


### PR DESCRIPTION
Refs #231

ウィンドウサイズに加えて X / Y 位置も保存・復元。

- SessionState に window_x / window_y: Option<f32> 追加
- save_window_session で ui.window().position() を logical px に変換
- 起動時 session::load() で set_position 復元
- LAST_SAVED 比較を field-by-field → PartialEq derive ベースに整理
- 旧 session.json での backward-compat unit test 追加

draft entries / per-PR state は #231 follow-up。

## Test plan
- [x] cargo clippy / cargo test (138 passed)
- [x] (実機) 200x150 に移動 → Cmd+Q → 再起動で chrome offset 程度の誤差で復元