### PR TITLE
feat(session): draft entries / selected_file_index の per-PR 永続化 (#231 完了)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -567,6 +567,8 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
     {
         let state = state.clone();
         let ui_weak = ui.as_weak();
+        let owner = owner.clone();
+        let repo = repo.clone();
         ui.on_add_to_draft(move |note: SharedString| {
             let Some(ui) = ui_weak.upgrade() else { return };
             let mut st = state.borrow_mut();
@@ -580,6 +582,8 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
                 Some(note_trimmed.to_string())
             };
             st.draft.push(DraftEntry::new(anchor, note_opt));
+            // ドラフトが変わったので per-PR session を更新する (#231)
+            save_pr_session(&owner, &repo, pr_number, &st, &ui);
             drop(st);
             refresh_draft_panel(&ui, &state);
         });
@@ -589,9 +593,14 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
     {
         let state = state.clone();
         let ui_weak = ui.as_weak();
+        let owner = owner.clone();
+        let repo = repo.clone();
         ui.on_remove_draft_entry(move |index: i32| {
             let Some(ui) = ui_weak.upgrade() else { return };
-            state.borrow_mut().draft.remove(index as usize);
+            let mut st = state.borrow_mut();
+            st.draft.remove(index as usize);
+            save_pr_session(&owner, &repo, pr_number, &st, &ui);
+            drop(st);
             refresh_draft_panel(&ui, &state);
         });
     }
@@ -623,10 +632,13 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
 
     // file-switch-requested (#230): file row click から呼ばれる。
     // 現在の diff-scroll-y を 旧 file index で保存し、selected-file-index を
-    // 切り替えた後に新 index に対する保存値を復元する。
+    // 切り替えた後に新 index に対する保存値を復元する。さらに #231 の per-PR
+    // 永続化として selected_file_index を session.json にも反映する。
     {
         let state = state.clone();
         let ui_weak = ui.as_weak();
+        let owner = owner.clone();
+        let repo = repo.clone();
         ui.on_file_switch_requested(move |new_idx| {
             let Some(ui) = ui_weak.upgrade() else { return };
             let old_idx = ui.get_selected_file_index() as usize;
@@ -642,6 +654,9 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
                 .copied()
                 .unwrap_or(0.0);
             ui.set_diff_scroll_y(restore);
+
+            // per-PR session に selected_file_index を反映
+            save_pr_session(&owner, &repo, pr_number, &state.borrow(), &ui);
 
             ui.invoke_file_switched(new_idx);
         });
@@ -955,7 +970,31 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
                     st.snapshot = snapshot;
                     // snapshot 切替で旧 file index の scroll cache を引きずらない
                     st.scroll_positions.clear();
+
+                    // #231 per-PR 復元: session.json に保存されていた draft /
+                    // selected_file_index を読み戻す。snapshot は再取得した
+                    // ばかりなので anchor の file_id / line がずれていてもまずは
+                    // そのまま復元する (format_prompt 側で snippet が取れない
+                    // ものは最良 effort で出る)。
+                    let key = session::SessionState::pr_key(
+                        &owner_clone, &repo_clone, pr_number,
+                    );
+                    if let Some(saved) = session::load()
+                        && let Some(per_pr) = saved.per_pr.get(&key)
+                    {
+                        for entry in &per_pr.draft {
+                            st.draft.push(entry.clone());
+                        }
+                        if let Some(idx) = per_pr.selected_file_index
+                            && (idx as usize) < st.snapshot.files.len()
+                        {
+                            ui.set_selected_file_index(idx);
+                        }
+                    }
                 });
+                if let Some(ui) = weak_for_task.upgrade() {
+                    with_app_state(|state| refresh_draft_panel(&ui, state));
+                }
             });
         });
     }
@@ -1058,18 +1097,30 @@ fn wire_terminal_resize(
 }
 
 /// 現在のウィンドウサイズと位置を logical px にして session.json へ書き出す。
+/// 既存の per_pr などは preserve したいので、session::mutate で部分更新する。
 /// 失敗時は session::save 内部で warn ログのみ。
 fn save_window_session(ui: &DiffViewerWindow) {
     let physical = ui.window().size();
     let pos = ui.window().position();
     let scale = ui.window().scale_factor().max(f32::EPSILON);
-    let state = session::SessionState {
-        window_width: Some(physical.width as f32 / scale),
-        window_height: Some(physical.height as f32 / scale),
-        window_x: Some(pos.x as f32 / scale),
-        window_y: Some(pos.y as f32 / scale),
+    session::mutate(|state| {
+        state.window_width = Some(physical.width as f32 / scale);
+        state.window_height = Some(physical.height as f32 / scale);
+        state.window_x = Some(pos.x as f32 / scale);
+        state.window_y = Some(pos.y as f32 / scale);
+    });
+}
+
+/// PR 単位の draft / file index を session.json の per_pr table に書き出す。
+fn save_pr_session(owner: &str, repo: &str, pr_number: u64, state: &DiffAppState, ui: &DiffViewerWindow) {
+    let key = session::SessionState::pr_key(owner, repo, pr_number);
+    let pr_state = session::PerPrState {
+        selected_file_index: Some(ui.get_selected_file_index()),
+        draft: state.draft.entries().to_vec(),
     };
-    session::save(&state);
+    session::mutate(|s| {
+        s.per_pr.insert(key, pr_state);
+    });
 }
 
 fn apply_snapshot_to_ui(

--- a/src/main.rs
+++ b/src/main.rs
@@ -583,7 +583,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
             };
             st.draft.push(DraftEntry::new(anchor, note_opt));
             // ドラフトが変わったので per-PR session を更新する (#231)
-            save_pr_session(&owner, &repo, pr_number, &st, &ui);
+            save_pr_session(&owner, &repo, &st, &ui);
             drop(st);
             refresh_draft_panel(&ui, &state);
         });
@@ -599,7 +599,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
             let Some(ui) = ui_weak.upgrade() else { return };
             let mut st = state.borrow_mut();
             st.draft.remove(index as usize);
-            save_pr_session(&owner, &repo, pr_number, &st, &ui);
+            save_pr_session(&owner, &repo, &st, &ui);
             drop(st);
             refresh_draft_panel(&ui, &state);
         });
@@ -656,7 +656,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
             ui.set_diff_scroll_y(restore);
 
             // per-PR session に selected_file_index を反映
-            save_pr_session(&owner, &repo, pr_number, &state.borrow(), &ui);
+            save_pr_session(&owner, &repo, &state.borrow(), &ui);
 
             ui.invoke_file_switched(new_idx);
         });
@@ -803,6 +803,25 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
                             st.pending_range = false;
                             // snapshot 切替で旧 PR の scroll cache を引きずらない (#230)
                             st.scroll_positions.clear();
+
+                            // #231 PR 切替後の per-PR draft / file index 復元
+                            let key = session::SessionState::pr_key(
+                                &owner,
+                                &repo,
+                                new_pr_number as u64,
+                            );
+                            if let Some(saved) = session::load()
+                                && let Some(per_pr) = saved.per_pr.get(&key)
+                            {
+                                for entry in &per_pr.draft {
+                                    st.draft.push(entry.clone());
+                                }
+                                if let Some(idx) = per_pr.selected_file_index
+                                    && (idx as usize) < st.snapshot.files.len()
+                                {
+                                    ui.set_selected_file_index(idx);
+                                }
+                            }
                         }
                         refresh_current_anchor_label(&ui, state);
                         refresh_draft_panel(&ui, state);
@@ -993,7 +1012,10 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
                     }
                 });
                 if let Some(ui) = weak_for_task.upgrade() {
-                    with_app_state(|state| refresh_draft_panel(&ui, state));
+                    with_app_state(|state| {
+                        refresh_draft_panel(&ui, state);
+                        refresh_preview(&ui, state);
+                    });
                 }
             });
         });
@@ -1112,8 +1134,15 @@ fn save_window_session(ui: &DiffViewerWindow) {
 }
 
 /// PR 単位の draft / file index を session.json の per_pr table に書き出す。
-fn save_pr_session(owner: &str, repo: &str, pr_number: u64, state: &DiffAppState, ui: &DiffViewerWindow) {
-    let key = session::SessionState::pr_key(owner, repo, pr_number);
+///
+/// PR 番号は UI の current-pr-number を読む (PR 切替後も正しい key に書く)。
+/// owner/repo は同じ window の中では不変なので closure capture でよい。
+fn save_pr_session(owner: &str, repo: &str, state: &DiffAppState, ui: &DiffViewerWindow) {
+    let pr_number = ui.get_current_pr_number();
+    if pr_number <= 0 {
+        return;
+    }
+    let key = session::SessionState::pr_key(owner, repo, pr_number as u64);
     let pr_state = session::PerPrState {
         selected_file_index: Some(ui.get_selected_file_index()),
         draft: state.draft.entries().to_vec(),

--- a/src/review/draft.rs
+++ b/src/review/draft.rs
@@ -1,7 +1,7 @@
 use super::selection::SelectionAnchor;
 
 /// PromptDraft の 1 エントリ。選択 + 任意の note。
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct DraftEntry {
     pub anchor: SelectionAnchor,
     pub note: Option<String>,

--- a/src/review/selection.rs
+++ b/src/review/selection.rs
@@ -1,7 +1,7 @@
 use super::snapshot::FileId;
 
 /// 選択時にどちら側の行番号を指しているか。
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum Side {
     Before,
     After,
@@ -11,7 +11,7 @@ pub enum Side {
 ///
 /// line-based な固定を避けるため、line 以上の粒度（range/hunk/file）を
 /// 型レベルで用意する。
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum Granularity {
     File,
     Hunk { hunk_index: usize },
@@ -24,7 +24,7 @@ pub enum Granularity {
 /// PromptDraft はこれを複数束ねて整形する。Comment ではなく Selection と
 /// 呼ぶのは、送り先が GitHub ではなく AI Agent CLI であり、「書き戻し前提の
 /// レビューコメント」という体験を避けるため。
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SelectionAnchor {
     pub file_id: FileId,
     pub file_path: String,

--- a/src/review/snapshot.rs
+++ b/src/review/snapshot.rs
@@ -2,7 +2,7 @@
 ///
 /// GitHub ではリネームがあっても同じ file として扱いたいので、path ではなく
 /// 別の識別を持たせる余地を残す。v0.1 では単純に path ベースで発行する想定。
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct FileId(pub String);
 
 impl FileId {

--- a/src/session.rs
+++ b/src/session.rs
@@ -8,10 +8,29 @@
 //! アプリは続行する (起動時に corrupt JSON / permission denied / disk full
 //! などで止めない方針)。
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
+
+use crate::review::draft::DraftEntry;
+
+/// PR 単位の永続化状態。
+///
+/// 同じ owner/repo#pr を再度開いたとき、draft entries を復元する。snapshot
+/// は再取得するので、anchor の file_id / line が現在の diff とずれている場合
+/// は そのまま表示される (label は描画できる、snippet は format_prompt が
+/// 旧 anchor を参照したときに `(missing)` 等になる)。
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct PerPrState {
+    /// 直近に選択していた file index。0 始まり。
+    #[serde(default)]
+    pub selected_file_index: Option<i32>,
+    /// 蓄積中の draft entries。
+    #[serde(default)]
+    pub draft: Vec<DraftEntry>,
+}
 
 /// ローカル永続化される session 状態。schema が将来増えたら `#[serde(default)]`
 /// で後方互換を取る (古い session.json で新フィールドは default に倒れる)。
@@ -29,6 +48,16 @@ pub struct SessionState {
     /// 最後に閉じた時のウィンドウ Y 位置 (logical px、screen 原点)。
     #[serde(default)]
     pub window_y: Option<f32>,
+    /// PR 単位の状態。key は "owner/repo#pr" 形式の文字列。
+    #[serde(default)]
+    pub per_pr: HashMap<String, PerPrState>,
+}
+
+impl SessionState {
+    /// "owner/repo#pr" key を作る。
+    pub fn pr_key(owner: &str, repo: &str, pr: u64) -> String {
+        format!("{owner}/{repo}#{pr}")
+    }
 }
 
 /// `directories` crate で OS 固有の config 領域を解決する。
@@ -66,21 +95,45 @@ pub fn load() -> Option<SessionState> {
     }
 }
 
+use std::sync::Mutex;
+
+/// プロセス内 cache。disk write を「値が変化したときだけ」に絞るのと、
+/// `mutate` で 「現在の state を partial update して save」するときの
+/// ベースとして使う。プロセス起動直後は None。
+static LAST_SAVED: Mutex<Option<SessionState>> = Mutex::new(None);
+
+/// 現在の cached state を取り出す。cache が空なら disk から load、それも
+/// 失敗すれば SessionState::default()。
+fn current_or_default() -> SessionState {
+    if let Ok(guard) = LAST_SAVED.lock()
+        && let Some(prev) = guard.as_ref()
+    {
+        return prev.clone();
+    }
+    load().unwrap_or_default()
+}
+
+/// 現在の state を closure で書き換えて save する。window / per_pr など
+/// 部分的に変えたい side からの単一エントリポイント。
+pub fn mutate(updater: impl FnOnce(&mut SessionState)) {
+    let mut state = current_or_default();
+    updater(&mut state);
+    save(&state);
+}
+
 /// セッションを書き出す。失敗時は warn ログのみで panic しない。
 ///
 /// ライブリサイズ中の連続呼び出しでも実 I/O は最小限に抑えるため、
 /// 直前に書いた SessionState と同じなら早期 return する (in-process cache)。
 /// プロセス再起動の境界では cache が空なので必ず最初の 1 回は書く。
 pub fn save(state: &SessionState) {
-    use std::sync::Mutex;
-
-    static LAST_SAVED: Mutex<Option<SessionState>> = Mutex::new(None);
-
-    if let Ok(guard) = LAST_SAVED.lock()
-        && let Some(prev) = guard.as_ref()
-        && prev == state
     {
-        return;
+        if let Ok(guard) = LAST_SAVED.lock()
+            && let Some(prev) = guard.as_ref()
+            && prev == state
+        {
+            return;
+        }
     }
 
     let Some(path) = session_path() else {
@@ -127,10 +180,51 @@ mod tests {
             window_height: Some(960.0),
             window_x: Some(120.0),
             window_y: Some(48.0),
+            per_pr: HashMap::new(),
         };
         let json = serde_json::to_string(&original).unwrap();
         let decoded: SessionState = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn pr_key_format_is_stable() {
+        assert_eq!(
+            SessionState::pr_key("duck8823", "locus", 282),
+            "duck8823/locus#282"
+        );
+    }
+
+    #[test]
+    fn per_pr_round_trip_with_draft_entry() {
+        use crate::review::draft::DraftEntry;
+        use crate::review::selection::{Granularity, SelectionAnchor, Side};
+        use crate::review::snapshot::FileId;
+
+        let mut original = SessionState::default();
+        let key = SessionState::pr_key("o", "r", 1);
+        original.per_pr.insert(
+            key.clone(),
+            PerPrState {
+                selected_file_index: Some(2),
+                draft: vec![DraftEntry::new(
+                    SelectionAnchor {
+                        file_id: FileId::new("a.rs"),
+                        file_path: "a.rs".into(),
+                        granularity: Granularity::Line {
+                            line: 42,
+                            side: Side::After,
+                        },
+                    },
+                    Some("note".into()),
+                )],
+            },
+        );
+
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: SessionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.per_pr.get(&key).unwrap().selected_file_index, Some(2));
+        assert_eq!(decoded.per_pr.get(&key).unwrap().draft.len(), 1);
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -97,69 +97,44 @@ pub fn load() -> Option<SessionState> {
 
 use std::sync::Mutex;
 
-/// プロセス内 cache。disk write を「値が変化したときだけ」に絞るのと、
-/// `mutate` で 「現在の state を partial update して save」するときの
-/// ベースとして使う。プロセス起動直後は None。
+/// プロセス内 cache。`mutate` の read-modify-write を 1 つの critical section
+/// で守るために単一 Mutex で持つ。`save()` も同じ lock を使うので、
+/// 並行な mutate / save が混在しても後勝ち上書きで partial update を失わない。
 static LAST_SAVED: Mutex<Option<SessionState>> = Mutex::new(None);
 
-/// 現在の cached state を取り出す。cache が空なら disk から load、それも
-/// 失敗すれば SessionState::default()。
-fn current_or_default() -> SessionState {
-    if let Ok(guard) = LAST_SAVED.lock()
-        && let Some(prev) = guard.as_ref()
-    {
-        return prev.clone();
-    }
-    load().unwrap_or_default()
-}
-
-/// 現在の state を closure で書き換えて save する。window / per_pr など
-/// 部分的に変えたい side からの単一エントリポイント。
+/// LAST_SAVED の lock 配下で current state を取り出して closure で書き換え、
+/// disk へ flush するまでを 1 つの critical section で行う。
 pub fn mutate(updater: impl FnOnce(&mut SessionState)) {
-    let mut state = current_or_default();
+    let mut guard = match LAST_SAVED.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    let mut state = guard.clone().unwrap_or_else(|| load().unwrap_or_default());
     updater(&mut state);
-    save(&state);
+    if let Some(prev) = guard.as_ref()
+        && prev == &state
+    {
+        return;
+    }
+    if let Err(e) = write_state_to_disk(&state) {
+        tracing::warn!(error = %e, "failed to persist session state");
+        return;
+    }
+    *guard = Some(state);
 }
 
-/// セッションを書き出す。失敗時は warn ログのみで panic しない。
-///
-/// ライブリサイズ中の連続呼び出しでも実 I/O は最小限に抑えるため、
-/// 直前に書いた SessionState と同じなら早期 return する (in-process cache)。
-/// プロセス再起動の境界では cache が空なので必ず最初の 1 回は書く。
-pub fn save(state: &SessionState) {
-    {
-        if let Ok(guard) = LAST_SAVED.lock()
-            && let Some(prev) = guard.as_ref()
-            && prev == state
-        {
-            return;
-        }
+/// 純粋な write 経路 (lock を持たない、エラーは Err で返す)。`mutate` から
+/// 呼ばれる。
+fn write_state_to_disk(state: &SessionState) -> Result<(), String> {
+    let path = session_path().ok_or_else(|| "could not resolve session.json path".to_string())?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create_dir_all {}: {}", parent.display(), e))?;
     }
-
-    let Some(path) = session_path() else {
-        tracing::warn!("could not resolve session.json path");
-        return;
-    };
-    if let Some(parent) = path.parent()
-        && let Err(e) = std::fs::create_dir_all(parent)
-    {
-        tracing::warn!(path = %parent.display(), error = %e, "failed to create config dir");
-        return;
-    }
-    let json = match serde_json::to_string_pretty(state) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!(error = %e, "failed to serialize session state");
-            return;
-        }
-    };
-    if let Err(e) = std::fs::write(&path, json) {
-        tracing::warn!(path = %path.display(), error = %e, "failed to write session.json");
-        return;
-    }
-    if let Ok(mut guard) = LAST_SAVED.lock() {
-        *guard = Some(state.clone());
-    }
+    let json = serde_json::to_string_pretty(state)
+        .map_err(|e| format!("serialize: {e}"))?;
+    std::fs::write(&path, json).map_err(|e| format!("write {}: {}", path.display(), e))?;
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #231

#231 の残スコープ (draft entries + selected_file_index) を per-PR で永続化。

## 設計
- `PerPrState { selected_file_index, draft }` を `SessionState.per_pr: HashMap<String, ...>` で持つ
- key は `owner/repo#pr` 形式
- DraftEntry / SelectionAnchor / Granularity / Side / FileId に serde derive 追加
- session::mutate(closure) で window_* / per_pr をそれぞれ部分更新

## 保存トリガー
- on_add_to_draft / on_remove_draft_entry → save_pr_session
- on_file_switch_requested → save_pr_session (selected_file_index 反映)

## 復元
- 起動時 snapshot hydrate 完了直後に per_pr[key] を load
- snapshot が再取得後のファイルセットに対し index が範囲内のときだけ復元

## Test plan
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test (140 passed; per_pr_round_trip / pr_key_format 新規)
- [ ] (実機) PR を draft 蓄積 → Cmd+Q → 再起動で draft 復元