### PR TITLE
fix(ui): terminal のフォントと cell metrics を分離

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -61,9 +61,11 @@ GitHub アクセス用 token は次の優先順位で解決されます:
 |---|---|---|
 | `LOCUS_LOCALE` | system / `LANG` | `ja` / `en`。未設定時は `LANG` を見て、未対応値や未設定時は `ja` にフォールバック。 |
 | `LOCUS_AGENT_CMD` | `claude` | 内蔵 terminal pane で起動するコマンド。 |
-| `LOCUS_FONT_FAMILY` | OS 別 (macOS: `Menlo, Hiragino Sans, Consolas, monospace`) | terminal + diff のフォントファミリ。既定で CJK fallback を含むため日本語 / 中国語 / 韓国語の glyph が箱化しない。 |
+| `LOCUS_FONT_FAMILY` | OS 別 (macOS: `Menlo, Hiragino Sans, Apple Symbols, Apple Color Emoji, Consolas, monospace`) | diff / chrome 側のフォントファミリ。`LOCUS_TERMINAL_FONT_FAMILY` が未設定の場合は terminal にも適用される。 |
+| `LOCUS_TERMINAL_FONT_FAMILY` | OS 別 (macOS: `SF Mono, Menlo, Monaco, Osaka-Mono, Hiragino Sans, Apple Symbols, Apple Color Emoji, monospace`) | terminal grid 専用のフォント fallback。等幅候補を優先し、terminal glyph や cell metrics が崩れる場合の切り分けに使う。 |
 | `LOCUS_FONT_SIZE` | (未設定) | terminal/diff 両方のフォントサイズを一括指定。 |
 | `LOCUS_TERMINAL_FONT_SIZE` | `13.0` | terminal pane のフォントサイズ (logical px)。 |
+| `LOCUS_TERMINAL_CELL_W` / `LOCUS_TERMINAL_CELL_H` | Slint font probe / 比率 fallback | terminal cell の幅/高さを logical px で手動上書きする。glyph と cell metric のズレを診断・強制同期する場合に使う。 |
 | `LOCUS_DIFF_FONT_SIZE` | `12.0` | diff pane のフォントサイズ (logical px)。 |
 | `LOCUS_BRACKETED_PASTE` | `true` | `false`/`0`/`off`/`no` で paste 境界 sequence (`\x1b[200~ ... \x1b[201~`) を使わずに raw 送信。 |
 | `LOCUS_PROMPT_MAX_CHARS` | `32000` | preview 文字数上限。超過時は警告 + override チェックボックス。 |

--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ For GitHub access, locus reads tokens in this order:
 |---|---|---|
 | `LOCUS_LOCALE` | system / `LANG` | `ja` or `en`. Reads `LANG` when unset; falls back to `ja` for unsupported values. |
 | `LOCUS_AGENT_CMD` | `claude` | Command launched in the embedded terminal pane. |
-| `LOCUS_FONT_FAMILY` | OS-specific (macOS: `Menlo, Hiragino Sans, Consolas, monospace`) | Font family for terminal + diff. The default already includes a CJK fallback so Japanese / Chinese / Korean glyphs render. |
+| `LOCUS_FONT_FAMILY` | OS-specific (macOS: `Menlo, Hiragino Sans, Apple Symbols, Apple Color Emoji, Consolas, monospace`) | Font family for diff / chrome. If `LOCUS_TERMINAL_FONT_FAMILY` is unset, this also overrides terminal fonts. |
+| `LOCUS_TERMINAL_FONT_FAMILY` | OS-specific (macOS: `SF Mono, Menlo, Monaco, Osaka-Mono, Hiragino Sans, Apple Symbols, Apple Color Emoji, monospace`) | Terminal-grid-only font fallback chain. Prefer monospace candidates first; useful when terminal glyphs or cell metrics look broken. |
 | `LOCUS_FONT_SIZE` | (unset) | Single override for both terminal and diff font sizes. |
 | `LOCUS_TERMINAL_FONT_SIZE` | `13.0` | Terminal pane font size in logical pixels. |
+| `LOCUS_TERMINAL_CELL_W` / `LOCUS_TERMINAL_CELL_H` | Slint font probe / fallback ratio | Manual terminal cell width/height override in logical pixels. Use for diagnosing glyph/cell metric mismatch. |
 | `LOCUS_DIFF_FONT_SIZE` | `12.0` | Diff pane font size in logical pixels. |
 | `LOCUS_BRACKETED_PASTE` | `true` | `false`/`0`/`off`/`no` to send raw bytes when the agent CLI does not understand `\x1b[200~ ... \x1b[201~`. |
 | `LOCUS_PROMPT_MAX_CHARS` | `32000` | Preview is gated above this character count; an override checkbox allows sending anyway. |

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,9 +6,17 @@
 
 #[derive(Debug, Clone)]
 pub struct UiConfig {
+    /// Diff / chrome 側で使う既定フォント。
     pub font_family: String,
+    /// Terminal grid 専用フォント。`LOCUS_TERMINAL_FONT_FAMILY` があれば
+    /// `LOCUS_FONT_FAMILY` より優先する。
+    pub terminal_font_family: String,
     pub terminal_font_size: f32,
     pub diff_font_size: f32,
+    /// Terminal cell の手動 override。Slint の font metric probe が実機で
+    /// 崩れる場合に `LOCUS_TERMINAL_CELL_W/H` で grid と glyph を強制同期する。
+    pub terminal_cell_w_override: Option<f32>,
+    pub terminal_cell_h_override: Option<f32>,
     /// PromptDraft を PTY に流し込む際に bracketed paste mode で囲うかどうか。
     /// 非対応 shell / agent CLI では `\x1b[200~` 等が文字としてそのまま表示
     /// されるため、`LOCUS_BRACKETED_PASTE=false` で raw 送信に切り替えられる。
@@ -24,8 +32,14 @@ pub struct UiConfig {
 
 impl UiConfig {
     pub fn from_env() -> Self {
-        let font_family = std::env::var("LOCUS_FONT_FAMILY")
-            .unwrap_or_else(|_| default_font_family().to_string());
+        let font_family_env = std::env::var("LOCUS_FONT_FAMILY").ok();
+        let font_family = font_family_env
+            .clone()
+            .unwrap_or_else(|| default_font_family().to_string());
+        let terminal_font_family = std::env::var("LOCUS_TERMINAL_FONT_FAMILY")
+            .ok()
+            .or(font_family_env)
+            .unwrap_or_else(|| default_terminal_font_family().to_string());
         let general = std::env::var("LOCUS_FONT_SIZE")
             .ok()
             .and_then(|s| s.parse::<f32>().ok());
@@ -41,16 +55,21 @@ impl UiConfig {
             .unwrap_or(12.0);
         let bracketed_paste =
             parse_bracketed_paste_env(std::env::var("LOCUS_BRACKETED_PASTE").ok().as_deref());
-        let prompt_max_chars = parse_prompt_max_chars_env(
-            std::env::var("LOCUS_PROMPT_MAX_CHARS").ok().as_deref(),
-        );
-        let confirm_send = parse_confirm_send_env(
-            std::env::var("LOCUS_CONFIRM_SEND").ok().as_deref(),
-        );
+        let prompt_max_chars =
+            parse_prompt_max_chars_env(std::env::var("LOCUS_PROMPT_MAX_CHARS").ok().as_deref());
+        let confirm_send =
+            parse_confirm_send_env(std::env::var("LOCUS_CONFIRM_SEND").ok().as_deref());
+        let terminal_cell_w_override =
+            parse_positive_f32_env(std::env::var("LOCUS_TERMINAL_CELL_W").ok().as_deref());
+        let terminal_cell_h_override =
+            parse_positive_f32_env(std::env::var("LOCUS_TERMINAL_CELL_H").ok().as_deref());
         Self {
             font_family,
+            terminal_font_family,
             terminal_font_size,
             diff_font_size,
+            terminal_cell_w_override,
+            terminal_cell_h_override,
             bracketed_paste,
             prompt_max_chars,
             confirm_send,
@@ -65,33 +84,81 @@ impl UiConfig {
     /// 使われる。実 glyph metric は `terminal-resized` callback 経由で
     /// `measured-terminal-cell-w` / `measured-terminal-cell-h` から取得する。
     pub fn terminal_cell_w(&self) -> f32 {
-        (self.terminal_font_size * 0.6).round().max(4.0)
+        self.terminal_cell_w_override
+            .unwrap_or_else(|| (self.terminal_font_size * 0.6).round().max(4.0))
     }
 
     pub fn terminal_cell_h(&self) -> f32 {
-        (self.terminal_font_size * 1.45).round().max(8.0)
+        self.terminal_cell_h_override
+            .unwrap_or_else(|| (self.terminal_font_size * 1.45).round().max(8.0))
+    }
+
+    /// Slint の probe から得た cell metric を実際に採用する値へ解決する。
+    ///
+    /// 手動 override がある場合は実測値より優先する。override が無い場合は
+    /// 正の有限な実測値を使い、未測定 / 異常値なら従来の比率 fallback を使う。
+    pub fn terminal_cell_w_from_measurement(&self, measured: f32) -> f32 {
+        if let Some(cell_w) = self.terminal_cell_w_override {
+            cell_w
+        } else if measured.is_finite() && measured > 0.0 {
+            measured
+        } else {
+            self.terminal_cell_w()
+        }
+    }
+
+    pub fn terminal_cell_h_from_measurement(&self, measured: f32) -> f32 {
+        if let Some(cell_h) = self.terminal_cell_h_override {
+            cell_h
+        } else if measured.is_finite() && measured > 0.0 {
+            measured
+        } else {
+            self.terminal_cell_h()
+        }
     }
 }
 
-/// OS 別の monospace + CJK fallback font family list。Slint Text の
+/// OS 別の monospace + CJK/symbol/emoji fallback font family list。Slint Text の
 /// `font-family` は CSS 風のカンマ区切り fallback を解決するため、
 /// 先頭の monospace に CJK glyph がなくても次の候補に倒れる。
 ///
-/// terminal pane と diff viewer は `LOCUS_FONT_FAMILY` で同じリストを共有
-/// する (env 未設定時の既定)。LOCUS_FONT_FAMILY が明示指定されていれば
-/// 全面的に上書きする。
+/// diff / chrome 側の既定。terminal pane は grid 幅を安定させるため
+/// `default_terminal_font_family()` を別に持つ。`LOCUS_FONT_FAMILY` が明示
+/// 指定されていれば terminal 側にも引き継がれるが、
+/// `LOCUS_TERMINAL_FONT_FAMILY` があればそちらを優先する。
 const fn default_font_family() -> &'static str {
     #[cfg(target_os = "macos")]
     {
-        "Menlo, Hiragino Sans, Consolas, monospace"
+        "Menlo, Hiragino Sans, Apple Symbols, Apple Color Emoji, Consolas, monospace"
     }
     #[cfg(target_os = "windows")]
     {
-        "Consolas, Yu Gothic, monospace"
+        "Consolas, Yu Gothic, Segoe UI Symbol, Segoe UI Emoji, monospace"
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        "DejaVu Sans Mono, Noto Sans CJK JP, monospace"
+        "DejaVu Sans Mono, Noto Sans CJK JP, Noto Sans Symbols 2, Noto Color Emoji, monospace"
+    }
+}
+
+/// Terminal grid 専用の monospace 寄り fallback。
+///
+/// `default_font_family()` は diff/chrome の可読性を優先して CJK UI フォントを
+/// 含むが、terminal grid で proportional fallback が先に選ばれると cell 幅と
+/// glyph advance がズレる。Terminal だけは monospace 候補を前段に分離し、
+/// CJK / symbol / emoji は最後の fallback として扱う。
+const fn default_terminal_font_family() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "SF Mono, Menlo, Monaco, Osaka-Mono, Hiragino Sans, Apple Symbols, Apple Color Emoji, monospace"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Cascadia Mono, Consolas, MS Gothic, Yu Gothic UI, Segoe UI Symbol, Segoe UI Emoji, monospace"
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        "DejaVu Sans Mono, Noto Sans Mono CJK JP, Noto Sans Symbols 2, Noto Color Emoji, Noto Sans CJK JP, monospace"
     }
 }
 
@@ -109,7 +176,10 @@ const fn default_font_family() -> &'static str {
 pub fn parse_bracketed_paste_env(value: Option<&str>) -> bool {
     match value.map(str::trim) {
         None | Some("") => true,
-        Some(v) => !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "off" | "no"),
+        Some(v) => !matches!(
+            v.to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "no"
+        ),
     }
 }
 
@@ -122,6 +192,13 @@ pub fn parse_confirm_send_env(value: Option<&str>) -> bool {
         Some(v) => matches!(v.as_str(), "1" | "true" | "on" | "yes"),
         None => false,
     }
+}
+
+/// 正の有限な f32 だけを受理する環境変数 parser。
+pub fn parse_positive_f32_env(value: Option<&str>) -> Option<f32> {
+    value
+        .and_then(|v| v.trim().parse::<f32>().ok())
+        .filter(|v| v.is_finite() && *v > 0.0)
 }
 
 /// `LOCUS_PROMPT_MAX_CHARS` を usize にパースする。
@@ -143,8 +220,11 @@ mod tests {
     fn default_metrics_are_reasonable() {
         let cfg = UiConfig {
             font_family: "test".into(),
+            terminal_font_family: "test-mono".into(),
             terminal_font_size: 12.0,
             diff_font_size: 12.0,
+            terminal_cell_w_override: None,
+            terminal_cell_h_override: None,
             bracketed_paste: true,
             prompt_max_chars: 32_000,
             confirm_send: false,
@@ -157,16 +237,22 @@ mod tests {
     fn cell_metrics_scale_with_font_size() {
         let small = UiConfig {
             font_family: "x".into(),
+            terminal_font_family: "x-mono".into(),
             terminal_font_size: 10.0,
             diff_font_size: 10.0,
+            terminal_cell_w_override: None,
+            terminal_cell_h_override: None,
             bracketed_paste: true,
             prompt_max_chars: 32_000,
             confirm_send: false,
         };
         let big = UiConfig {
             font_family: "x".into(),
+            terminal_font_family: "x-mono".into(),
             terminal_font_size: 20.0,
             diff_font_size: 20.0,
+            terminal_cell_w_override: None,
+            terminal_cell_h_override: None,
             bracketed_paste: true,
             prompt_max_chars: 32_000,
             confirm_send: false,
@@ -236,5 +322,62 @@ mod tests {
         // fail-open: paste 機能を不用意に殺さないため未知値は true
         assert!(parse_bracketed_paste_env(Some("garbage")));
         assert!(parse_bracketed_paste_env(Some("auto"))); // 旧 auto モードも fail-open
+    }
+
+    #[test]
+    fn positive_f32_env_accepts_only_positive_finite_values() {
+        assert_eq!(parse_positive_f32_env(Some("8.5")), Some(8.5));
+        assert_eq!(parse_positive_f32_env(Some("  16  ")), Some(16.0));
+        assert_eq!(parse_positive_f32_env(None), None);
+        assert_eq!(parse_positive_f32_env(Some("")), None);
+        assert_eq!(parse_positive_f32_env(Some("0")), None);
+        assert_eq!(parse_positive_f32_env(Some("-1")), None);
+        assert_eq!(parse_positive_f32_env(Some("NaN")), None);
+        assert_eq!(parse_positive_f32_env(Some("inf")), None);
+        assert_eq!(parse_positive_f32_env(Some("garbage")), None);
+    }
+
+    #[test]
+    fn manual_terminal_cell_metrics_override_probe_values() {
+        let cfg = UiConfig {
+            font_family: "x".into(),
+            terminal_font_family: "x-mono".into(),
+            terminal_font_size: 13.0,
+            diff_font_size: 12.0,
+            terminal_cell_w_override: Some(9.5),
+            terminal_cell_h_override: Some(18.5),
+            bracketed_paste: true,
+            prompt_max_chars: 32_000,
+            confirm_send: false,
+        };
+        assert_eq!(cfg.terminal_cell_w(), 9.5);
+        assert_eq!(cfg.terminal_cell_h(), 18.5);
+        assert_eq!(cfg.terminal_cell_w_from_measurement(7.0), 9.5);
+        assert_eq!(cfg.terminal_cell_h_from_measurement(15.0), 18.5);
+    }
+
+    #[test]
+    fn measured_terminal_cell_metrics_win_without_manual_override() {
+        let cfg = UiConfig {
+            font_family: "x".into(),
+            terminal_font_family: "x-mono".into(),
+            terminal_font_size: 13.0,
+            diff_font_size: 12.0,
+            terminal_cell_w_override: None,
+            terminal_cell_h_override: None,
+            bracketed_paste: true,
+            prompt_max_chars: 32_000,
+            confirm_send: false,
+        };
+        assert_eq!(cfg.terminal_cell_w_from_measurement(7.25), 7.25);
+        assert_eq!(cfg.terminal_cell_h_from_measurement(15.75), 15.75);
+        assert_eq!(
+            cfg.terminal_cell_w_from_measurement(0.0),
+            cfg.terminal_cell_w()
+        );
+        assert_eq!(
+            cfg.terminal_cell_h_from_measurement(f32::NAN),
+            cfg.terminal_cell_h()
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,16 +102,22 @@ fn init_logging() {
 fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
     let ui_cfg = config::UiConfig::from_env();
     let ui = AppWindow::new()?;
-    ui.set_font_family(SharedString::from(ui_cfg.font_family.as_str()));
+    ui.set_font_family(SharedString::from(ui_cfg.terminal_font_family.as_str()));
     ui.set_font_size(ui_cfg.terminal_font_size);
     ui.set_cell_w(ui_cfg.terminal_cell_w());
     ui.set_cell_h(ui_cfg.terminal_cell_h());
+    tracing::debug!(
+        terminal_font_family = %ui_cfg.terminal_font_family,
+        terminal_font_size = ui_cfg.terminal_font_size,
+        terminal_cell_w = ui_cfg.terminal_cell_w(),
+        terminal_cell_h = ui_cfg.terminal_cell_h(),
+        "terminal typography configured"
+    );
     let pane = Rc::new(terminal::launch(&ui, command, ui_cfg.bracketed_paste)?);
     {
         let pane = pane.clone();
         let ui_weak = ui.as_weak();
-        let fallback_cell_w = ui_cfg.terminal_cell_w();
-        let fallback_cell_h = ui_cfg.terminal_cell_h();
+        let ui_cfg = ui_cfg.clone();
         ui.on_resized(move |w_logical: f32, h_logical: f32| {
             let Some(ui) = ui_weak.upgrade() else {
                 return;
@@ -121,14 +127,8 @@ fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
             if w_logical <= 0.0 || h_logical <= 0.0 {
                 return;
             }
-            let mut cell_w = ui.get_measured_cell_w();
-            let mut cell_h = ui.get_measured_cell_h();
-            if cell_w <= 0.0 {
-                cell_w = fallback_cell_w;
-            }
-            if cell_h <= 0.0 {
-                cell_h = fallback_cell_h;
-            }
+            let cell_w = ui_cfg.terminal_cell_w_from_measurement(ui.get_measured_cell_w());
+            let cell_h = ui_cfg.terminal_cell_h_from_measurement(ui.get_measured_cell_h());
             ui.set_cell_w(cell_w);
             ui.set_cell_h(cell_h);
             let (cols, rows) = terminal::compute_grid_size(w_logical, h_logical, cell_w, cell_h);
@@ -186,12 +186,21 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
     let ui_cfg = config::UiConfig::from_env();
     let ui = DiffViewerWindow::new()?;
     ui.set_font_family(SharedString::from(ui_cfg.font_family.as_str()));
+    ui.set_terminal_font_family(SharedString::from(ui_cfg.terminal_font_family.as_str()));
     ui.set_terminal_font_size(ui_cfg.terminal_font_size);
     ui.set_diff_font_size(ui_cfg.diff_font_size);
     ui.set_terminal_cell_w(ui_cfg.terminal_cell_w());
     ui.set_terminal_cell_h(ui_cfg.terminal_cell_h());
     ui.set_preview_max_chars(ui_cfg.prompt_max_chars.min(i32::MAX as usize) as i32);
     ui.set_require_send_confirm(ui_cfg.confirm_send);
+    tracing::debug!(
+        font_family = %ui_cfg.font_family,
+        terminal_font_family = %ui_cfg.terminal_font_family,
+        terminal_font_size = ui_cfg.terminal_font_size,
+        terminal_cell_w = ui_cfg.terminal_cell_w(),
+        terminal_cell_h = ui_cfg.terminal_cell_h(),
+        "diff viewer typography configured"
+    );
 
     // セッション復元 (#231): 前回保存した window size / position があれば適用する。
     if let Some(saved) = session::load() {
@@ -918,8 +927,7 @@ fn wire_terminal_resize(
     fallback: &config::UiConfig,
 ) {
     let ui_weak = ui.as_weak();
-    let fallback_cell_w = fallback.terminal_cell_w();
-    let fallback_cell_h = fallback.terminal_cell_h();
+    let fallback = fallback.clone();
     ui.on_terminal_resized(move |w_logical: f32, h_logical: f32| {
         let Some(ui) = ui_weak.upgrade() else {
             return;
@@ -930,14 +938,10 @@ fn wire_terminal_resize(
             return;
         }
         // 実 glyph metric が未測定 (= 0) の間は従来の比率近似を使う。
-        let mut cell_w = ui.get_measured_terminal_cell_w();
-        let mut cell_h = ui.get_measured_terminal_cell_h();
-        if cell_w <= 0.0 {
-            cell_w = fallback_cell_w;
-        }
-        if cell_h <= 0.0 {
-            cell_h = fallback_cell_h;
-        }
+        // `LOCUS_TERMINAL_CELL_W/H` が指定されている場合は、実測値より
+        // 手動 override を優先して grid と glyph のズレを切り分けられる。
+        let cell_w = fallback.terminal_cell_w_from_measurement(ui.get_measured_terminal_cell_w());
+        let cell_h = fallback.terminal_cell_h_from_measurement(ui.get_measured_terminal_cell_h());
         ui.set_terminal_cell_w(cell_w);
         ui.set_terminal_cell_h(cell_h);
         let (cols, rows) = terminal::compute_grid_size(w_logical, h_logical, cell_w, cell_h);

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -92,8 +92,11 @@ export component AppWindow inherits Window {
                     height: root.cell-h;
                     background: cell.bg;
                     visible: cell.span > 0;
+                    clip: true;
 
                     Text {
+                        width: parent.width;
+                        height: parent.height;
                         text: cell.ch;
                         color: cell.fg;
                         font-family: root.font-family;
@@ -215,6 +218,7 @@ export component DiffViewerWindow inherits Window {
     in property <int> terminal-rows-count: 30;
     in property <length> terminal-cell-w: 8px;
     in property <length> terminal-cell-h: 16px;
+    in property <string> terminal-font-family: "Menlo, Consolas, monospace";
     in property <int> terminal-cursor-col: 0;
     in property <int> terminal-cursor-row: 0;
     in property <bool> terminal-available: false;
@@ -266,7 +270,7 @@ export component DiffViewerWindow inherits Window {
 
     terminal-monospace-probe := Text {
         text: "MMMMMMMMMM";
-        font-family: root.font-family;
+        font-family: root.terminal-font-family;
         font-size: root.terminal-font-size;
         visible: false;
         x: -10000px;
@@ -1065,11 +1069,14 @@ export component DiffViewerWindow inherits Window {
                                     height: root.terminal-cell-h;
                                     background: cell.bg;
                                     visible: cell.span > 0;
+                                    clip: true;
 
                                     Text {
+                                        width: parent.width;
+                                        height: parent.height;
                                         text: cell.ch;
                                         color: cell.fg;
-                                        font-family: root.font-family;
+                                        font-family: root.terminal-font-family;
                                         font-size: root.terminal-font-size;
                                         horizontal-alignment: left;
                                         vertical-alignment: center;


### PR DESCRIPTION
## Motivation

実機検証で terminal pane の文字化け / フォント崩れが残っており、diff/chrome と同じ `LOCUS_FONT_FAMILY` を terminal grid に流用すると proportional fallback や Slint の font metric probe の揺れで cell 幅と glyph 描画がズレやすい。#289 / #292 / #277 の切り分けを進めるため、terminal 専用の typography 設定と手動 cell metrics override を追加する。

## Changes

- `LOCUS_TERMINAL_FONT_FAMILY` を追加し、terminal pane の font fallback を diff/chrome から分離
- default fallback に symbol / emoji 候補を追加
- `LOCUS_TERMINAL_CELL_W` / `LOCUS_TERMINAL_CELL_H` を追加し、Slint probe より優先できるようにした
- terminal cell の `Text` に cell rectangle の width/height を与え、cell 内で clip するようにした
- terminal typography 設定を `LOCUS_LOG=debug` で確認できるようにした
- README の環境変数表を更新

## Validation

- `cargo test` — 146 passed
- `cargo clippy --all-targets -- -D warnings` — no issues
- `cargo build` — passed

## Notes

実機の目視確認は未実施。PR 後に macOS 実機で #289 / #292 の再現条件を確認し、必要なら `LOCUS_TERMINAL_CELL_W/H` の推奨値や bundled monospace font の追加を別PRで詰める。