### PR TITLE
refactor(main): toast helper を diff_viewer module に分離

### DIFF
--- a/src/app/diff_viewer/mod.rs
+++ b/src/app/diff_viewer/mod.rs
@@ -6,4 +6,5 @@
 pub(crate) mod snapshot;
 pub(crate) mod refresh;
 pub(crate) mod state;
+pub(crate) mod toast;
 pub(crate) mod util;

--- a/src/app/diff_viewer/snapshot.rs
+++ b/src/app/diff_viewer/snapshot.rs
@@ -2,8 +2,8 @@
 //! 純粋ヘルパ群 (#224 step 3)。
 //!
 //! いずれも `&DiffViewerWindow` または slice 引数だけを受け取り、
-//! DIFF_APP_STATE thread_local には触れない。状態を持つ refresh_* / show_toast
-//! は別 step で扱う。
+//! DIFF_APP_STATE thread_local には触れない。状態を持つ UI 更新や副作用は
+//! `refresh` / `toast` module に分離している。
 
 use slint::{ModelRc, SharedString, VecModel};
 

--- a/src/app/diff_viewer/toast.rs
+++ b/src/app/diff_viewer/toast.rs
@@ -1,0 +1,61 @@
+//! Toast 表示の副作用ヘルパ (#224 split)。
+//!
+//! `ACTIVE_DIFF_WINDOW` thread_local には auto-dismiss timer や非同期完了 closure
+//! から `DiffViewerWindow` を取り出すための弱参照を保持する。`run_diff_viewer`
+//! 起動時に `set_active_window` で登録する。
+//!
+//! `show_toast` / `schedule_toast_auto_dismiss` は Slint UI スレッド上で呼ばれる
+//! 想定で、`crate::with_app_state` 経由で `DIFF_APP_STATE` を借用し、
+//! `refresh::refresh_toasts` で UI を再描画する。
+
+use std::cell::RefCell;
+use std::time::Duration;
+
+use slint::{ComponentHandle, Weak};
+
+use super::refresh::refresh_toasts;
+use super::state::ToastKind;
+use crate::DiffViewerWindow;
+
+thread_local! {
+    /// auto-dismiss timer から UI を取り出すための弱参照。
+    /// `set_active_window` で `run_diff_viewer` 起動時に登録する。
+    static ACTIVE_DIFF_WINDOW: RefCell<Option<Weak<DiffViewerWindow>>> = const {
+        RefCell::new(None)
+    };
+}
+
+/// `run_diff_viewer` 起動時に `DiffViewerWindow` の弱参照を登録する。
+pub(crate) fn set_active_window(ui: &DiffViewerWindow) {
+    ACTIVE_DIFF_WINDOW.with(|cell| *cell.borrow_mut() = Some(ui.as_weak()));
+}
+
+/// 5 秒後に該当 toast を自動で dismiss する。
+///
+/// `slint::Timer::single_shot` は内部で self-manage されるため、Timer 自体を
+/// 持ち回ったり leak したりする必要がない。
+pub(crate) fn schedule_toast_auto_dismiss(toast_id: i32) {
+    slint::Timer::single_shot(Duration::from_secs(5), move || {
+        crate::with_app_state(|state| {
+            state.borrow_mut().dismiss_toast(toast_id);
+            if let Some(ui) =
+                ACTIVE_DIFF_WINDOW.with(|w| w.borrow().as_ref().and_then(|w| w.upgrade()))
+            {
+                refresh_toasts(&ui, state);
+            }
+        });
+    });
+}
+
+/// UI イベントループ上で toast を push し、auto-dismiss スケジュールを行う。
+/// 各エラー経路のヘルパとして使う。
+pub(crate) fn show_toast(kind: ToastKind, title: String, message: String) {
+    crate::with_app_state(|state| {
+        let id = state.borrow_mut().push_toast(kind, title, message);
+        if let Some(ui) = ACTIVE_DIFF_WINDOW.with(|w| w.borrow().as_ref().and_then(|w| w.upgrade()))
+        {
+            refresh_toasts(&ui, state);
+        }
+        schedule_toast_auto_dismiss(id);
+    });
+}

--- a/src/app/diff_viewer/util.rs
+++ b/src/app/diff_viewer/util.rs
@@ -1,8 +1,8 @@
 //! Diff viewer 関連の純粋ユーティリティ (#224 step 2)。
 //!
 //! Slint UI / DIFF_APP_STATE thread_local に依存しないものをここに集約する。
-//! callback 経由でしか呼ばれない refresh_* / show_toast 等は thread_local に
-//! 触れるため main.rs に留め、別 step で追加移動する。
+//! UI model への反映や toast など状態・副作用を持つ helper は
+//! `refresh` / `toast` module に分離している。
 
 use crate::review::draft::SendMode;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ thread_local! {
     };
 }
 
-fn with_app_state<R>(f: impl FnOnce(&Rc<RefCell<DiffAppState>>) -> R) -> Option<R> {
+pub(crate) fn with_app_state<R>(f: impl FnOnce(&Rc<RefCell<DiffAppState>>) -> R) -> Option<R> {
     DIFF_APP_STATE.with(|cell| cell.borrow().as_ref().map(f))
 }
 
@@ -45,6 +45,7 @@ use app::diff_viewer::refresh::{
     refresh_preview, refresh_toasts,
 };
 use app::diff_viewer::state::{DiffAppState, ToastKind};
+use app::diff_viewer::toast::{schedule_toast_auto_dismiss, set_active_window, show_toast};
 use app::diff_viewer::util::resolve_line_number;
 
 use github::issue_context::{
@@ -243,7 +244,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
         scroll_positions: std::collections::HashMap::new(),
     }));
     DIFF_APP_STATE.with(|cell| *cell.borrow_mut() = Some(state.clone()));
-    ACTIVE_DIFF_WINDOW.with(|cell| *cell.borrow_mut() = Some(ui.as_weak()));
+    set_active_window(&ui);
 
     // dismiss-toast コールバック
     {
@@ -997,45 +998,6 @@ fn save_pr_session(owner: &str, repo: &str, state: &DiffAppState, ui: &DiffViewe
     session::mutate(|s| {
         s.per_pr.insert(key, pr_state);
     });
-}
-
-/// 5 秒後に該当 toast を自動で dismiss する。
-///
-/// `slint::Timer::single_shot` は内部で self-manage されるため、Timer 自体を
-/// 持ち回ったり leak したりする必要がない。
-fn schedule_toast_auto_dismiss(toast_id: i32) {
-    use std::time::Duration;
-    slint::Timer::single_shot(Duration::from_secs(5), move || {
-        with_app_state(|state| {
-            state.borrow_mut().dismiss_toast(toast_id);
-            if let Some(ui) =
-                ACTIVE_DIFF_WINDOW.with(|w| w.borrow().as_ref().and_then(|w| w.upgrade()))
-            {
-                refresh_toasts(&ui, state);
-            }
-        });
-    });
-}
-
-/// UI イベントループ上で toast を push し、auto-dismiss スケジュールを行う。
-/// 各エラー経路のヘルパとして使う。
-fn show_toast(kind: ToastKind, title: String, message: String) {
-    with_app_state(|state| {
-        let id = state.borrow_mut().push_toast(kind, title, message);
-        if let Some(ui) =
-            ACTIVE_DIFF_WINDOW.with(|w| w.borrow().as_ref().and_then(|w| w.upgrade()))
-        {
-            refresh_toasts(&ui, state);
-        }
-        schedule_toast_auto_dismiss(id);
-    });
-}
-
-thread_local! {
-    /// auto-dismiss timer から UI を取り出すための弱参照。run_diff_viewer 起動時に登録。
-    static ACTIVE_DIFF_WINDOW: RefCell<Option<slint::Weak<DiffViewerWindow>>> = const {
-        RefCell::new(None)
-    };
 }
 
 /// linked issue 番号一覧を受け取り、各 issue を tokio::spawn 系で並列 fetch


### PR DESCRIPTION
## Motivation

#224 の `main.rs` 分割を Claude foreground 実装で継続する。前段で refresh / preview / history helper は `src/app/diff_viewer/refresh.rs` に分離済みだが、toast の auto-dismiss と active window 弱参照がまだ `main.rs` に残っており、composition root と UI 副作用が混在していた。

## Changes

- `src/app/diff_viewer/toast.rs` を追加
- `ACTIVE_DIFF_WINDOW` thread-local を toast module へ移動
- `set_active_window` / `schedule_toast_auto_dismiss` / `show_toast` を toast module へ移動
- `main.rs` は toast helper を import して既存 callback / async completion から呼ぶ形に変更
- `with_app_state` を `pub(crate)` にして toast module から既存 state accessor を再利用

## Impact

- 挙動変更なしの refactor
- `main.rs` は 1465 行から 1429 行へ縮小
- 次段階では `DIFF_APP_STATE` accessor または callback 群の切り出しに進める

## Validation

- `cargo test` — 146 passed
- `cargo clippy --all-targets -- -D warnings` — no issues
- `cargo build` — passed

## Implementation note

- 実装主担当: Claude foreground
- オーケストレーション / 検証: Codex

Refs #224