### PR TITLE
refactor(main): DiffAppState accessor を state module に分離

### DIFF
--- a/src/app/diff_viewer/state.rs
+++ b/src/app/diff_viewer/state.rs
@@ -9,10 +9,35 @@
 //! 一旦 `pub(crate)` で公開し、main.rs / app::diff_viewer 配下の helper から
 //! のみアクセスする想定。
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use crate::github::pull_request::{PullRequestFile, PullRequestSnapshot};
 use crate::review::draft::{PromptDraft, SendMode};
 use crate::review::selection::{Granularity, SelectionAnchor, Side};
 use crate::review::snapshot::FileId;
+
+thread_local! {
+    /// 同期 callback / 非同期 spawn 完了後の invoke_from_event_loop closure
+    /// から共通でアクセスする DiffAppState。Slint イベントループは UI スレッド
+    /// 上で動くため thread_local で十分。Rc<RefCell<>> を closure に capture
+    /// すると非 Send になり spawn できないので、thread_local 経由で
+    /// 取り出す形にして closure を Send に保つ。
+    static DIFF_APP_STATE: RefCell<Option<Rc<RefCell<DiffAppState>>>> = const {
+        RefCell::new(None)
+    };
+}
+
+/// `run_diff_viewer` 起動時に共有 state を thread_local へ登録する。
+/// UI スレッド上で 1 度だけ呼ばれる前提。
+pub(crate) fn set_app_state(state: Rc<RefCell<DiffAppState>>) {
+    DIFF_APP_STATE.with(|cell| *cell.borrow_mut() = Some(state));
+}
+
+/// 登録済みの共有 state へクロージャでアクセスする。未登録なら `None`。
+pub(crate) fn with_app_state<R>(f: impl FnOnce(&Rc<RefCell<DiffAppState>>) -> R) -> Option<R> {
+    DIFF_APP_STATE.with(|cell| cell.borrow().as_ref().map(f))
+}
 
 /// 送信履歴の 1 エントリ。セッション内にのみ保持される。
 #[derive(Debug, Clone)]

--- a/src/app/diff_viewer/toast.rs
+++ b/src/app/diff_viewer/toast.rs
@@ -5,7 +5,7 @@
 //! 起動時に `set_active_window` で登録する。
 //!
 //! `show_toast` / `schedule_toast_auto_dismiss` は Slint UI スレッド上で呼ばれる
-//! 想定で、`crate::with_app_state` 経由で `DIFF_APP_STATE` を借用し、
+//! 想定で、`state::with_app_state` 経由で `DIFF_APP_STATE` を借用し、
 //! `refresh::refresh_toasts` で UI を再描画する。
 
 use std::cell::RefCell;
@@ -14,7 +14,7 @@ use std::time::Duration;
 use slint::{ComponentHandle, Weak};
 
 use super::refresh::refresh_toasts;
-use super::state::ToastKind;
+use super::state::{with_app_state, ToastKind};
 use crate::DiffViewerWindow;
 
 thread_local! {
@@ -36,7 +36,7 @@ pub(crate) fn set_active_window(ui: &DiffViewerWindow) {
 /// 持ち回ったり leak したりする必要がない。
 pub(crate) fn schedule_toast_auto_dismiss(toast_id: i32) {
     slint::Timer::single_shot(Duration::from_secs(5), move || {
-        crate::with_app_state(|state| {
+        with_app_state(|state| {
             state.borrow_mut().dismiss_toast(toast_id);
             if let Some(ui) =
                 ACTIVE_DIFF_WINDOW.with(|w| w.borrow().as_ref().and_then(|w| w.upgrade()))
@@ -50,7 +50,7 @@ pub(crate) fn schedule_toast_auto_dismiss(toast_id: i32) {
 /// UI イベントループ上で toast を push し、auto-dismiss スケジュールを行う。
 /// 各エラー経路のヘルパとして使う。
 pub(crate) fn show_toast(kind: ToastKind, title: String, message: String) {
-    crate::with_app_state(|state| {
+    with_app_state(|state| {
         let id = state.borrow_mut().push_toast(kind, title, message);
         if let Some(ui) = ACTIVE_DIFF_WINDOW.with(|w| w.borrow().as_ref().and_then(|w| w.upgrade()))
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,21 +8,6 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-thread_local! {
-    /// 同期 callback / 非同期 spawn 完了後の invoke_from_event_loop closure
-    /// から共通でアクセスする DiffAppState。Slint イベントループは UI スレッド
-    /// 上で動くため thread_local で十分。Rc<RefCell<>> を closure に capture
-    /// すると非 Send になり spawn できないので、thread_local 経由で
-    /// 取り出す形にして closure を Send に保つ。
-    static DIFF_APP_STATE: RefCell<Option<Rc<RefCell<DiffAppState>>>> = const {
-        RefCell::new(None)
-    };
-}
-
-pub(crate) fn with_app_state<R>(f: impl FnOnce(&Rc<RefCell<DiffAppState>>) -> R) -> Option<R> {
-    DIFF_APP_STATE.with(|cell| cell.borrow().as_ref().map(f))
-}
-
 use slint::{ComponentHandle, SharedString};
 
 slint::include_modules!();
@@ -44,7 +29,7 @@ use app::diff_viewer::refresh::{
     append_history, refresh_current_anchor_label, refresh_draft_panel, refresh_history_panel,
     refresh_preview, refresh_toasts,
 };
-use app::diff_viewer::state::{DiffAppState, ToastKind};
+use app::diff_viewer::state::{set_app_state, with_app_state, DiffAppState, ToastKind};
 use app::diff_viewer::toast::{schedule_toast_auto_dismiss, set_active_window, show_toast};
 use app::diff_viewer::util::resolve_line_number;
 
@@ -243,7 +228,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
         next_toast_id: 0,
         scroll_positions: std::collections::HashMap::new(),
     }));
-    DIFF_APP_STATE.with(|cell| *cell.borrow_mut() = Some(state.clone()));
+    set_app_state(state.clone());
     set_active_window(&ui);
 
     // dismiss-toast コールバック


### PR DESCRIPTION
## Motivation

#224 の `main.rs` 分割を Claude foreground 実装で継続する。前段で toast helper は `src/app/diff_viewer/toast.rs` に分離済みだが、`DIFF_APP_STATE` thread-local と `with_app_state` accessor がまだ `main.rs` 冒頭に残っていた。

## Changes

- `DIFF_APP_STATE` thread-local を `src/app/diff_viewer/state.rs` へ移動
- `with_app_state` を `state.rs` へ移動し `pub(crate)` accessor として維持
- `set_app_state` を追加し、`run_diff_viewer` 起動時の state 登録を module API 経由に変更
- `toast.rs` の `with_app_state` 参照を `state` module 経由に変更
- `main.rs` の state 登録処理を `set_app_state(state.clone())` に置換

## Impact

- 挙動変更なしの refactor
- `Rc<RefCell<DiffAppState>>` の共有構造と登録タイミングは維持
- `main.rs` は 1429 行から 1414 行へ縮小
- 次段階では callback 群 / `run_diff_viewer` 本体の切り出しに進める

## Validation

- `cargo test` — 146 passed
- `cargo clippy --all-targets -- -D warnings` — no issues
- `cargo build` — passed

## Implementation note

- 実装主担当: Claude foreground
- オーケストレーション / 検証: Codex

Refs #224