### PR TITLE
feat(ui): terminal debug grid overlay を追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -66,6 +66,7 @@ GitHub アクセス用 token は次の優先順位で解決されます:
 | `LOCUS_FONT_SIZE` | (未設定) | terminal/diff 両方のフォントサイズを一括指定。 |
 | `LOCUS_TERMINAL_FONT_SIZE` | `13.0` | terminal pane のフォントサイズ (logical px)。 |
 | `LOCUS_TERMINAL_CELL_W` / `LOCUS_TERMINAL_CELL_H` | Slint font probe / 比率 fallback | terminal cell の幅/高さを logical px で手動上書きする。glyph と cell metric のズレを診断・強制同期する場合に使う。 |
+| `LOCUS_TERMINAL_DEBUG_GRID` | `false` | `1`/`true`/`on`/`yes` で terminal の各 cell 境界に薄い grid line を描画して cell と glyph のズレを実機で視覚 trace するための debug overlay。レイアウトは変わらない。 |
 | `LOCUS_DIFF_FONT_SIZE` | `12.0` | diff pane のフォントサイズ (logical px)。 |
 | `LOCUS_BRACKETED_PASTE` | `true` | `false`/`0`/`off`/`no` で paste 境界 sequence (`\x1b[200~ ... \x1b[201~`) を使わずに raw 送信。 |
 | `LOCUS_PROMPT_MAX_CHARS` | `32000` | preview 文字数上限。超過時は警告 + override チェックボックス。 |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ For GitHub access, locus reads tokens in this order:
 | `LOCUS_FONT_SIZE` | (unset) | Single override for both terminal and diff font sizes. |
 | `LOCUS_TERMINAL_FONT_SIZE` | `13.0` | Terminal pane font size in logical pixels. |
 | `LOCUS_TERMINAL_CELL_W` / `LOCUS_TERMINAL_CELL_H` | Slint font probe / fallback ratio | Manual terminal cell width/height override in logical pixels. Use for diagnosing glyph/cell metric mismatch. |
+| `LOCUS_TERMINAL_DEBUG_GRID` | `false` | `1`/`true`/`on`/`yes` to draw thin grid lines at terminal cell boundaries so cell-vs-glyph mismatches are visible at a glance. Layout is unchanged. |
 | `LOCUS_DIFF_FONT_SIZE` | `12.0` | Diff pane font size in logical pixels. |
 | `LOCUS_BRACKETED_PASTE` | `true` | `false`/`0`/`off`/`no` to send raw bytes when the agent CLI does not understand `\x1b[200~ ... \x1b[201~`. |
 | `LOCUS_PROMPT_MAX_CHARS` | `32000` | Preview is gated above this character count; an override checkbox allows sending anyway. |

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,9 @@ pub struct UiConfig {
     /// Insert+Send 押下前に「送信していい？」と確認 checkbox を要求するかどうか。
     /// `LOCUS_CONFIRM_SEND=true` で有効化、既定 false (毎回の確認はうざいため)。
     pub confirm_send: bool,
+    /// terminal cell metric の崩れを実機で視覚 trace するための debug grid overlay。
+    /// `LOCUS_TERMINAL_DEBUG_GRID=true` で各 cell に薄い border を出す。既定 false。
+    pub terminal_debug_grid: bool,
 }
 
 impl UiConfig {
@@ -63,6 +66,9 @@ impl UiConfig {
             parse_positive_f32_env(std::env::var("LOCUS_TERMINAL_CELL_W").ok().as_deref());
         let terminal_cell_h_override =
             parse_positive_f32_env(std::env::var("LOCUS_TERMINAL_CELL_H").ok().as_deref());
+        let terminal_debug_grid = parse_terminal_debug_grid_env(
+            std::env::var("LOCUS_TERMINAL_DEBUG_GRID").ok().as_deref(),
+        );
         Self {
             font_family,
             terminal_font_family,
@@ -73,6 +79,7 @@ impl UiConfig {
             bracketed_paste,
             prompt_max_chars,
             confirm_send,
+            terminal_debug_grid,
         }
     }
 
@@ -194,6 +201,19 @@ pub fn parse_confirm_send_env(value: Option<&str>) -> bool {
     }
 }
 
+/// `LOCUS_TERMINAL_DEBUG_GRID` で terminal cell metric の debug overlay を出すか。
+///
+/// - 未設定 / 空 / 不明値 / `0` / `false` / `off` / `no` → false (既定)
+/// - `1` / `true` / `on` / `yes` → true
+///
+/// 既定挙動を変えないため fail-closed 側にしている (`confirm_send` と同じ規則)。
+pub fn parse_terminal_debug_grid_env(value: Option<&str>) -> bool {
+    match value.map(|s| s.trim().to_ascii_lowercase()) {
+        Some(v) => matches!(v.as_str(), "1" | "true" | "on" | "yes"),
+        None => false,
+    }
+}
+
 /// 正の有限な f32 だけを受理する環境変数 parser。
 pub fn parse_positive_f32_env(value: Option<&str>) -> Option<f32> {
     value
@@ -228,6 +248,7 @@ mod tests {
             bracketed_paste: true,
             prompt_max_chars: 32_000,
             confirm_send: false,
+            terminal_debug_grid: false,
         };
         assert!(cfg.terminal_cell_w() >= 6.0);
         assert!(cfg.terminal_cell_h() >= 14.0);
@@ -245,6 +266,7 @@ mod tests {
             bracketed_paste: true,
             prompt_max_chars: 32_000,
             confirm_send: false,
+            terminal_debug_grid: false,
         };
         let big = UiConfig {
             font_family: "x".into(),
@@ -256,6 +278,7 @@ mod tests {
             bracketed_paste: true,
             prompt_max_chars: 32_000,
             confirm_send: false,
+            terminal_debug_grid: false,
         };
         assert!(big.terminal_cell_w() > small.terminal_cell_w());
         assert!(big.terminal_cell_h() > small.terminal_cell_h());
@@ -349,11 +372,33 @@ mod tests {
             bracketed_paste: true,
             prompt_max_chars: 32_000,
             confirm_send: false,
+            terminal_debug_grid: false,
         };
         assert_eq!(cfg.terminal_cell_w(), 9.5);
         assert_eq!(cfg.terminal_cell_h(), 18.5);
         assert_eq!(cfg.terminal_cell_w_from_measurement(7.0), 9.5);
         assert_eq!(cfg.terminal_cell_h_from_measurement(15.0), 18.5);
+    }
+
+    #[test]
+    fn terminal_debug_grid_default_off() {
+        assert!(!parse_terminal_debug_grid_env(None));
+        assert!(!parse_terminal_debug_grid_env(Some("")));
+        assert!(!parse_terminal_debug_grid_env(Some("garbage")));
+    }
+
+    #[test]
+    fn terminal_debug_grid_explicit_on() {
+        for v in ["1", "true", "True", "on", "yes", "ON", "  YES  "] {
+            assert!(parse_terminal_debug_grid_env(Some(v)));
+        }
+    }
+
+    #[test]
+    fn terminal_debug_grid_explicit_off() {
+        for v in ["0", "false", "off", "no", "False"] {
+            assert!(!parse_terminal_debug_grid_env(Some(v)));
+        }
     }
 
     #[test]
@@ -368,6 +413,7 @@ mod tests {
             bracketed_paste: true,
             prompt_max_chars: 32_000,
             confirm_send: false,
+            terminal_debug_grid: false,
         };
         assert_eq!(cfg.terminal_cell_w_from_measurement(7.25), 7.25);
         assert_eq!(cfg.terminal_cell_h_from_measurement(15.75), 15.75);

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,11 +95,13 @@ fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
     ui.set_font_size(ui_cfg.terminal_font_size);
     ui.set_cell_w(ui_cfg.terminal_cell_w());
     ui.set_cell_h(ui_cfg.terminal_cell_h());
+    ui.set_terminal_debug_grid(ui_cfg.terminal_debug_grid);
     tracing::debug!(
         terminal_font_family = %ui_cfg.terminal_font_family,
         terminal_font_size = ui_cfg.terminal_font_size,
         terminal_cell_w = ui_cfg.terminal_cell_w(),
         terminal_cell_h = ui_cfg.terminal_cell_h(),
+        terminal_debug_grid = ui_cfg.terminal_debug_grid,
         "terminal typography configured"
     );
     let pane = Rc::new(terminal::launch(&ui, command, ui_cfg.bracketed_paste)?);
@@ -180,6 +182,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
     ui.set_diff_font_size(ui_cfg.diff_font_size);
     ui.set_terminal_cell_w(ui_cfg.terminal_cell_w());
     ui.set_terminal_cell_h(ui_cfg.terminal_cell_h());
+    ui.set_terminal_debug_grid(ui_cfg.terminal_debug_grid);
     ui.set_preview_max_chars(ui_cfg.prompt_max_chars.min(i32::MAX as usize) as i32);
     ui.set_require_send_confirm(ui_cfg.confirm_send);
     tracing::debug!(
@@ -188,6 +191,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
         terminal_font_size = ui_cfg.terminal_font_size,
         terminal_cell_w = ui_cfg.terminal_cell_w(),
         terminal_cell_h = ui_cfg.terminal_cell_h(),
+        terminal_debug_grid = ui_cfg.terminal_debug_grid,
         "diff viewer typography configured"
     );
 

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -24,6 +24,10 @@ export component AppWindow inherits Window {
     in property <int> cursor-row: 0;
     in property <string> font-family: "Menlo, Consolas, monospace";
     in property <length> font-size: 13px;
+    // LOCUS_TERMINAL_DEBUG_GRID=true で各 cell 境界に薄い grid line を出して
+    // glyph と grid のズレを実機で視覚 trace するための debug overlay。
+    // 既定 false。レイアウトは変えない。
+    in property <bool> terminal-debug-grid: false;
 
     // 隠し Text。フォントの実 advance 幅 / 行高を Slint の text shaping
     // 経由で取得する。font-family / font-size を変えると preferred-* も
@@ -93,7 +97,6 @@ export component AppWindow inherits Window {
                     background: cell.bg;
                     visible: cell.span > 0;
                     clip: true;
-
                     Text {
                         width: parent.width;
                         height: parent.height;
@@ -104,6 +107,34 @@ export component AppWindow inherits Window {
                         horizontal-alignment: left;
                         vertical-alignment: center;
                     }
+                }
+            }
+
+            // Debug grid overlay: TerminalCell の span に依存せず、実 cell 境界
+            // そのものを描画する。wide glyph / ZWJ emoji は複数 cell を 1 つの
+            // Text にまとめるため、cell Rectangle の border では内部境界が
+            // 見えない。独立 overlay にして glyph-vs-cell のズレを追跡しやすくする。
+            if root.terminal-debug-grid: Rectangle {
+                x: 0;
+                y: 0;
+                width: root.cols * root.cell-w;
+                height: root.visible-rows * root.cell-h;
+                background: transparent;
+
+                for col in root.cols + 1: Rectangle {
+                    x: col * root.cell-w;
+                    y: 0;
+                    width: 1px;
+                    height: parent.height;
+                    background: #ff00ff80;
+                }
+
+                for row in root.visible-rows + 1: Rectangle {
+                    x: 0;
+                    y: row * root.cell-h;
+                    width: parent.width;
+                    height: 1px;
+                    background: #ff00ff80;
                 }
             }
 
@@ -223,6 +254,10 @@ export component DiffViewerWindow inherits Window {
     in property <int> terminal-cursor-row: 0;
     in property <bool> terminal-available: false;
     in property <string> terminal-status: @tr("not started");
+    // LOCUS_TERMINAL_DEBUG_GRID=true で terminal pane の各 cell 境界に薄い
+    // grid line を出す debug overlay。glyph と cell metric のズレを実機で視覚 trace する。
+    // 既定 false / レイアウトは変えない。
+    in property <bool> terminal-debug-grid: false;
 
     in property <string> font-family: "Menlo, Consolas, monospace";
     in property <length> terminal-font-size: 11px;
@@ -1070,7 +1105,6 @@ export component DiffViewerWindow inherits Window {
                                     background: cell.bg;
                                     visible: cell.span > 0;
                                     clip: true;
-
                                     Text {
                                         width: parent.width;
                                         height: parent.height;
@@ -1081,6 +1115,34 @@ export component DiffViewerWindow inherits Window {
                                         horizontal-alignment: left;
                                         vertical-alignment: center;
                                     }
+                                }
+                            }
+
+                            // Debug grid overlay: TerminalCell の span に依存せず、実 cell
+                            // 境界そのものを描画する。wide glyph / ZWJ emoji は複数 cell を
+                            // 1 つの Text にまとめるため、cell Rectangle の border では
+                            // 内部境界が見えない。
+                            if root.terminal-debug-grid: Rectangle {
+                                x: 0;
+                                y: 0;
+                                width: root.terminal-cols * root.terminal-cell-w;
+                                height: root.terminal-rows-count * root.terminal-cell-h;
+                                background: transparent;
+
+                                for col in root.terminal-cols + 1: Rectangle {
+                                    x: col * root.terminal-cell-w;
+                                    y: 0;
+                                    width: 1px;
+                                    height: parent.height;
+                                    background: #ff00ff80;
+                                }
+
+                                for row in root.terminal-rows-count + 1: Rectangle {
+                                    x: 0;
+                                    y: row * root.terminal-cell-h;
+                                    width: parent.width;
+                                    height: 1px;
+                                    background: #ff00ff80;
                                 }
                             }
 


### PR DESCRIPTION
## Motivation

#292 の terminal pane フォント崩れは実機目視で cell と glyph のズレを切り分ける必要があるため、通常時の挙動を変えずに terminal cell の格子を可視化できる debug overlay を追加します。

## Changes

- `LOCUS_TERMINAL_DEBUG_GRID` を追加し、true 系の値だけ terminal cell border を有効化
- terminal-only / diff viewer の両方へ config を配線
- Slint 側で terminal cell Rectangle に条件付き debug border を描画
- README / README.ja に環境変数を追記

## Validation

- `cargo test` — 149 passed
- `cargo clippy --all-targets -- -D warnings` — no issues
- `cargo build` — passed

Refs: #292
