### PR TITLE
refactor(main): linked issue fetch helper を分離

### DIFF
--- a/src/app/diff_viewer/linked_issues.rs
+++ b/src/app/diff_viewer/linked_issues.rs
@@ -1,0 +1,95 @@
+//! Linked issue を並列 fetch するヘルパ (#224 split)。
+//!
+//! `run_diff_viewer` 起動 hydrate と PR switch callback の双方から呼ばれる
+//! async helper。`fetch_issue_context_async` を `FuturesUnordered` で束ねて
+//! 並列実行し、完了結果を number 順にソートして返す。並列実行中に発生した
+//! エラーがあれば、`slint::invoke_from_event_loop` 経由で要約 toast を 1 つ
+//! だけ表示する (各 issue chip 側でも error 表示するため重複させない)。
+
+use std::time::Instant;
+
+use crate::github::issue_context::fetch_issue_context_async;
+use crate::i18n;
+
+use super::snapshot::LinkedIssueDisplay;
+use super::state::ToastKind;
+use super::toast::show_toast;
+
+/// linked issue 番号一覧を受け取り、各 issue を tokio::spawn 系で並列 fetch
+/// する。`octocrab::Octocrab` は内部で reqwest クライアントを共有しているので
+/// 数件の concurrent 呼び出しは安全。
+pub(crate) async fn fetch_linked_issues_parallel(
+    client: &octocrab::Octocrab,
+    owner: &str,
+    repo: &str,
+    numbers: &[u64],
+) -> Vec<LinkedIssueDisplay> {
+    use futures::stream::{FuturesUnordered, StreamExt};
+
+    let started = Instant::now();
+    let requested = numbers.len();
+    let mut futs: FuturesUnordered<_> = numbers
+        .iter()
+        .copied()
+        .map(|n| {
+            let client = client.clone();
+            let owner = owner.to_string();
+            let repo = repo.to_string();
+            async move {
+                let res = fetch_issue_context_async(&client, &owner, &repo, n).await;
+                (n, res)
+            }
+        })
+        .collect();
+
+    let mut out: Vec<LinkedIssueDisplay> = Vec::new();
+    let mut error_summary: Option<String> = None;
+    let mut error_count: usize = 0;
+    while let Some((n, res)) = futs.next().await {
+        match res {
+            Ok(Some(r)) => out.push(LinkedIssueDisplay::Found(r)),
+            Ok(None) => {}
+            Err(e) => {
+                let message = e.to_string();
+                if error_summary.is_none() {
+                    error_summary = Some(format!("#{n}: {message}"));
+                }
+                error_count += 1;
+                out.push(LinkedIssueDisplay::Failed {
+                    number: n,
+                    message,
+                });
+            }
+        }
+    }
+    // 並列実行の完了順は不定なので number でソートして決定論的にする
+    out.sort_by_key(|d| match d {
+        LinkedIssueDisplay::Found(r) => r.number,
+        LinkedIssueDisplay::Failed { number, .. } => *number,
+    });
+
+    tracing::debug!(
+        requested,
+        returned = out.len(),
+        error_count,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "linked issues fetched"
+    );
+
+    // 1 件以上失敗していたら要約 toast を 1 つだけ出す。
+    // (各 issue chip は別途 error 表示されるため、toast は重複させない)
+    if let Some(first) = error_summary {
+        let count_str = error_count.to_string();
+        let _ = slint::invoke_from_event_loop(move || {
+            show_toast(
+                ToastKind::Warn,
+                i18n::tr_args(
+                    "Failed to fetch {} linked issue(s)",
+                    &[count_str.as_str()],
+                ),
+                first,
+            );
+        });
+    }
+    out
+}

--- a/src/app/diff_viewer/mod.rs
+++ b/src/app/diff_viewer/mod.rs
@@ -3,6 +3,7 @@
 //! main.rs の `run_diff_viewer` は依然として main.rs に残っているが、
 //! 状態 / ヘルパは段階的にここへ移動する (#224 split)。
 
+pub(crate) mod linked_issues;
 pub(crate) mod snapshot;
 pub(crate) mod refresh;
 pub(crate) mod session;

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -126,6 +126,14 @@ fn translate_ja(key: &str) -> Option<&'static str> {
         "(edited preview)" => "(編集済みプレビュー)",
         "+{} more" => "+{} 件",
         "(failed to fetch)" => "(取得失敗)",
+        "(loading…)" => "(読み込み中…)",
+        // runtime error / toast messages
+        "Terminal pane failed to start" => "ターミナルペインの起動に失敗しました",
+        "{}: {}" => "{}: {}",
+        "Failed to fetch PR #{}" => "PR #{} の取得に失敗しました",
+        "Failed to load PR #{}" => "PR #{} の読み込みに失敗しました",
+        "Failed to load PR list" => "PR 一覧の取得に失敗しました",
+        "Failed to fetch {} linked issue(s)" => "{} 件の関連 issue の取得に失敗しました",
         // terminal status
         "{} (running)" => "{} (起動中)",
         "{}: failed to start ({})" => "{}: 起動失敗 ({})",
@@ -170,6 +178,31 @@ mod tests {
         assert_eq!(
             translate_ja("{}: not found in PATH (set LOCUS_AGENT_CMD)"),
             Some("{}: PATH に見つかりません (LOCUS_AGENT_CMD を設定してください)")
+        );
+    }
+
+    #[test]
+    fn translate_ja_covers_runtime_error_keys() {
+        assert_eq!(translate_ja("(loading…)"), Some("(読み込み中…)"));
+        assert_eq!(
+            translate_ja("Terminal pane failed to start"),
+            Some("ターミナルペインの起動に失敗しました")
+        );
+        assert_eq!(
+            translate_ja("Failed to fetch PR #{}"),
+            Some("PR #{} の取得に失敗しました")
+        );
+        assert_eq!(
+            translate_ja("Failed to load PR #{}"),
+            Some("PR #{} の読み込みに失敗しました")
+        );
+        assert_eq!(
+            translate_ja("Failed to load PR list"),
+            Some("PR 一覧の取得に失敗しました")
+        );
+        assert_eq!(
+            translate_ja("Failed to fetch {} linked issue(s)"),
+            Some("{} 件の関連 issue の取得に失敗しました")
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,8 @@ mod session;
 mod terminal;
 mod ui_state;
 
-use app::diff_viewer::snapshot::{
-    apply_snapshot_to_ui, build_pr_list_model, LinkedIssueDisplay,
-};
+use app::diff_viewer::linked_issues::fetch_linked_issues_parallel;
+use app::diff_viewer::snapshot::{apply_snapshot_to_ui, build_pr_list_model};
 use app::diff_viewer::refresh::{
     append_history, refresh_current_anchor_label, refresh_draft_panel, refresh_history_panel,
     refresh_preview, refresh_toasts,
@@ -35,9 +34,7 @@ use app::diff_viewer::state::{set_app_state, with_app_state, DiffAppState, Toast
 use app::diff_viewer::toast::{schedule_toast_auto_dismiss, set_active_window, show_toast};
 use app::diff_viewer::util::resolve_line_number;
 
-use github::issue_context::{
-    extract_linked_issue_numbers, fetch_issue_context_async,
-};
+use github::issue_context::extract_linked_issue_numbers;
 use github::pull_request::{
     build_client, fetch_pr_snapshot, fetch_pull_requests, parse_pr_spec, PrListFilter,
     PullRequestSnapshot,
@@ -1009,83 +1006,4 @@ fn wire_terminal_resize(
         // 通らず process exit) でも最後の window size を残せる (#231 補強)。
         save_window_session(&ui);
     });
-}
-
-/// linked issue 番号一覧を受け取り、各 issue を tokio::spawn 系で並列 fetch
-/// する。`octocrab::Octocrab` は内部で reqwest クライアントを共有しているので
-/// 数件の concurrent 呼び出しは安全。
-async fn fetch_linked_issues_parallel(
-    client: &octocrab::Octocrab,
-    owner: &str,
-    repo: &str,
-    numbers: &[u64],
-) -> Vec<LinkedIssueDisplay> {
-    use futures::stream::{FuturesUnordered, StreamExt};
-
-    let started = Instant::now();
-    let requested = numbers.len();
-    let mut futs: FuturesUnordered<_> = numbers
-        .iter()
-        .copied()
-        .map(|n| {
-            let client = client.clone();
-            let owner = owner.to_string();
-            let repo = repo.to_string();
-            async move {
-                let res = fetch_issue_context_async(&client, &owner, &repo, n).await;
-                (n, res)
-            }
-        })
-        .collect();
-
-    let mut out: Vec<LinkedIssueDisplay> = Vec::new();
-    let mut error_summary: Option<String> = None;
-    let mut error_count: usize = 0;
-    while let Some((n, res)) = futs.next().await {
-        match res {
-            Ok(Some(r)) => out.push(LinkedIssueDisplay::Found(r)),
-            Ok(None) => {}
-            Err(e) => {
-                let message = e.to_string();
-                if error_summary.is_none() {
-                    error_summary = Some(format!("#{n}: {message}"));
-                }
-                error_count += 1;
-                out.push(LinkedIssueDisplay::Failed {
-                    number: n,
-                    message,
-                });
-            }
-        }
-    }
-    // 並列実行の完了順は不定なので number でソートして決定論的にする
-    out.sort_by_key(|d| match d {
-        LinkedIssueDisplay::Found(r) => r.number,
-        LinkedIssueDisplay::Failed { number, .. } => *number,
-    });
-
-    tracing::debug!(
-        requested,
-        returned = out.len(),
-        error_count,
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "linked issues fetched"
-    );
-
-    // 1 件以上失敗していたら要約 toast を 1 つだけ出す。
-    // (各 issue chip は別途 error 表示されるため、toast は重複させない)
-    if let Some(first) = error_summary {
-        let count_str = error_count.to_string();
-        let _ = slint::invoke_from_event_loop(move || {
-            show_toast(
-                ToastKind::Warn,
-                i18n::tr_args(
-                    "Failed to fetch {} linked issue(s)",
-                    &[count_str.as_str()],
-                ),
-                first,
-            );
-        });
-    }
-    out
 }


### PR DESCRIPTION
## Motivation

#224 の main.rs 分割を継続します。今回は initial hydrate と PR switch callback で共有している linked issue 並列 fetch を `src/app/diff_viewer/linked_issues.rs` へ移し、main.rs から async helper 実装を減らします。

Gemini scout で指摘された Rust 側 i18n の runtime error key 登録漏れも併せて補完しました。

## Changes

- `src/app/diff_viewer/linked_issues.rs` を追加
- `fetch_linked_issues_parallel` を main.rs から移動
- toast / sort / debug trace / FuturesUnordered の挙動は維持
- main.rs の import を整理
- `src/i18n.rs` に runtime error / loading keys の ja translation とテストを追加
- main.rs: 1091 → 1009 lines

## Validation

- `cargo test` — 150 passed
- `cargo clippy --all-targets -- -D warnings` — no issues
- `cargo build` — passed

Refs: #224
