### PR TITLE
fix(ui): stabilize terminal cell metrics

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -65,7 +65,8 @@ GitHub アクセス用 token は次の優先順位で解決されます:
 | `LOCUS_TERMINAL_FONT_FAMILY` | OS 別 (macOS: `SF Mono, Menlo, Monaco, Osaka-Mono, Hiragino Sans, Apple Symbols, Apple Color Emoji, monospace`) | terminal grid 専用のフォント fallback。等幅候補を優先し、terminal glyph や cell metrics が崩れる場合の切り分けに使う。 |
 | `LOCUS_FONT_SIZE` | (未設定) | terminal/diff 両方のフォントサイズを一括指定。 |
 | `LOCUS_TERMINAL_FONT_SIZE` | `13.0` | terminal pane のフォントサイズ (logical px)。 |
-| `LOCUS_TERMINAL_CELL_W` / `LOCUS_TERMINAL_CELL_H` | Slint font probe / 比率 fallback | terminal cell の幅/高さを logical px で手動上書きする。glyph と cell metric のズレを診断・強制同期する場合に使う。 |
+| `LOCUS_TERMINAL_CELL_W` / `LOCUS_TERMINAL_CELL_H` | 比率 fallback (`font_size * 0.6` / `font_size * 1.45`) | terminal cell の幅/高さを logical px で手動上書きする。probe / fallback のいずれよりも優先。glyph と cell metric のズレを診断・強制同期する場合に使う。 |
+| `LOCUS_TERMINAL_PROBE_METRICS` | `false` | `1`/`true`/`on`/`yes` で Slint 隠し Text probe (`measured-terminal-cell-w/h`) を採用する。既定 false。macOS の SF Mono / Menlo では probe が advance を過大・行高を過小に返し、terminal テキストが崩れる事象 (#292 / #289) があるため、既定では比率 fallback または `LOCUS_TERMINAL_CELL_W/H` による手動 override を採用する。 |
 | `LOCUS_TERMINAL_DEBUG_GRID` | `false` | `1`/`true`/`on`/`yes` で terminal の各 cell 境界に薄い grid line を描画して cell と glyph のズレを実機で視覚 trace するための debug overlay。レイアウトは変わらない。 |
 | `LOCUS_DIFF_FONT_SIZE` | `12.0` | diff pane のフォントサイズ (logical px)。 |
 | `LOCUS_BRACKETED_PASTE` | `true` | `false`/`0`/`off`/`no` で paste 境界 sequence (`\x1b[200~ ... \x1b[201~`) を使わずに raw 送信。 |
@@ -114,6 +115,9 @@ scripts/diagnose_ui.sh terminal \
   --cell-w 8 --cell-h 18 \
   --terminal-font-size 14 \
   --font-family "SF Mono, Menlo, monospace"
+
+# Slint font probe を明示 opt-in して既定 fallback metric と比較
+scripts/diagnose_ui.sh github duck8823/locus#236 --probe-metrics --duration 10
 
 # 既存 build を流用する (cargo build をスキップ)
 scripts/diagnose_ui.sh terminal --no-build --out-dir target/locus-diagnostics/run-A

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ For GitHub access, locus reads tokens in this order:
 | `LOCUS_TERMINAL_FONT_FAMILY` | OS-specific (macOS: `SF Mono, Menlo, Monaco, Osaka-Mono, Hiragino Sans, Apple Symbols, Apple Color Emoji, monospace`) | Terminal-grid-only font fallback chain. Prefer monospace candidates first; useful when terminal glyphs or cell metrics look broken. |
 | `LOCUS_FONT_SIZE` | (unset) | Single override for both terminal and diff font sizes. |
 | `LOCUS_TERMINAL_FONT_SIZE` | `13.0` | Terminal pane font size in logical pixels. |
-| `LOCUS_TERMINAL_CELL_W` / `LOCUS_TERMINAL_CELL_H` | Slint font probe / fallback ratio | Manual terminal cell width/height override in logical pixels. Use for diagnosing glyph/cell metric mismatch. |
+| `LOCUS_TERMINAL_CELL_W` / `LOCUS_TERMINAL_CELL_H` | fallback ratio (`font_size * 0.6` / `font_size * 1.45`) | Manual terminal cell width/height override in logical pixels. Always wins over both probe and fallback. Use for diagnosing glyph/cell metric mismatch. |
+| `LOCUS_TERMINAL_PROBE_METRICS` | `false` | `1`/`true`/`on`/`yes` to opt back into the Slint hidden-Text probe (`measured-terminal-cell-w/h`) for cell metrics. Default is off because the probe overestimates advance and underestimates line-height for SF Mono / Menlo on macOS, garbling terminal text (#292 / #289); the ratio fallback or `LOCUS_TERMINAL_CELL_W/H` override is used instead. |
 | `LOCUS_TERMINAL_DEBUG_GRID` | `false` | `1`/`true`/`on`/`yes` to draw thin grid lines at terminal cell boundaries so cell-vs-glyph mismatches are visible at a glance. Layout is unchanged. |
 | `LOCUS_DIFF_FONT_SIZE` | `12.0` | Diff pane font size in logical pixels. |
 | `LOCUS_BRACKETED_PASTE` | `true` | `false`/`0`/`off`/`no` to send raw bytes when the agent CLI does not understand `\x1b[200~ ... \x1b[201~`. |
@@ -114,6 +115,9 @@ scripts/diagnose_ui.sh terminal \
   --cell-w 8 --cell-h 18 \
   --terminal-font-size 14 \
   --font-family "SF Mono, Menlo, monospace"
+
+# opt into the Slint font probe to compare against the default fallback metrics
+scripts/diagnose_ui.sh github duck8823/locus#236 --probe-metrics --duration 10
 
 # reuse a previous build (skip cargo build)
 scripts/diagnose_ui.sh terminal --no-build --out-dir target/locus-diagnostics/run-A

--- a/scripts/diagnose_ui.sh
+++ b/scripts/diagnose_ui.sh
@@ -35,6 +35,8 @@
 #                             (default ${LOCUS_AGENT_CMD:-sh})
 #   --debug-grid              LOCUS_TERMINAL_DEBUG_GRID=true を注入 (既定 on)
 #   --no-debug-grid           LOCUS_TERMINAL_DEBUG_GRID を注入しない
+#   --probe-metrics           LOCUS_TERMINAL_PROBE_METRICS=true を注入
+#   --no-probe-metrics        LOCUS_TERMINAL_PROBE_METRICS を注入しない (既定)
 #   --cell-w VALUE            LOCUS_TERMINAL_CELL_W override
 #   --cell-h VALUE            LOCUS_TERMINAL_CELL_H override
 #   --font-family VALUE       LOCUS_TERMINAL_FONT_FAMILY override
@@ -70,6 +72,8 @@ options:
                             (default ${LOCUS_AGENT_CMD:-sh})
   --debug-grid              LOCUS_TERMINAL_DEBUG_GRID=true (既定 on)
   --no-debug-grid           LOCUS_TERMINAL_DEBUG_GRID を注入しない
+  --probe-metrics           LOCUS_TERMINAL_PROBE_METRICS=true を注入
+  --no-probe-metrics        LOCUS_TERMINAL_PROBE_METRICS を注入しない (既定)
   --cell-w VALUE            LOCUS_TERMINAL_CELL_W override
   --cell-h VALUE            LOCUS_TERMINAL_CELL_H override
   --font-family VALUE       LOCUS_TERMINAL_FONT_FAMILY override
@@ -108,6 +112,7 @@ write_report_json() {
         REPORT_BUILD_STATUS="$BUILD_STATUS" \
         REPORT_NO_BUILD="$NO_BUILD" \
         REPORT_DEBUG_GRID="$DEBUG_GRID" \
+        REPORT_PROBE_METRICS="$PROBE_METRICS" \
         REPORT_CELL_W="$CELL_W" \
         REPORT_CELL_H="$CELL_H" \
         REPORT_FONT_FAMILY="$FONT_FAMILY" \
@@ -176,6 +181,7 @@ data = {
     },
     "options": {
         "debug_grid": env("REPORT_DEBUG_GRID") == "1",
+        "probe_metrics": env("REPORT_PROBE_METRICS") == "1",
         "cell_w": env("REPORT_CELL_W") or None,
         "cell_h": env("REPORT_CELL_H") or None,
         "font_family": env("REPORT_FONT_FAMILY") or None,
@@ -340,6 +346,7 @@ AGENT_CMD="${LOCUS_AGENT_CMD:-sh}"
 DURATION=8
 OUT_DIR=""
 DEBUG_GRID=1
+PROBE_METRICS=0
 CELL_W=""
 CELL_H=""
 FONT_FAMILY=""
@@ -400,6 +407,14 @@ while [ "$#" -gt 0 ]; do
             ;;
         --no-debug-grid)
             DEBUG_GRID=0
+            shift
+            ;;
+        --probe-metrics)
+            PROBE_METRICS=1
+            shift
+            ;;
+        --no-probe-metrics)
+            PROBE_METRICS=0
             shift
             ;;
         --cell-w)
@@ -486,6 +501,7 @@ command -v cargo >/dev/null 2>&1 && HAS_CARGO=1
     esac
     printf '\n# duration: %s seconds\n' "$DURATION"
     printf '# debug_grid: %s\n' "$DEBUG_GRID"
+    printf '# probe_metrics: %s\n' "$PROBE_METRICS"
     printf '# cell_w: %s\n' "$CELL_W"
     printf '# cell_h: %s\n' "$CELL_H"
     printf '# font_family: %s\n' "$FONT_FAMILY"
@@ -534,6 +550,9 @@ fi
 ENV_VARS=("LOCUS_LOG=debug")
 if [ "$DEBUG_GRID" -eq 1 ]; then
     ENV_VARS+=("LOCUS_TERMINAL_DEBUG_GRID=true")
+fi
+if [ "$PROBE_METRICS" -eq 1 ]; then
+    ENV_VARS+=("LOCUS_TERMINAL_PROBE_METRICS=true")
 fi
 [ -n "$CELL_W" ]              && ENV_VARS+=("LOCUS_TERMINAL_CELL_W=$CELL_W")
 [ -n "$CELL_H" ]              && ENV_VARS+=("LOCUS_TERMINAL_CELL_H=$CELL_H")

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,13 @@ pub struct UiConfig {
     /// 崩れる場合に `LOCUS_TERMINAL_CELL_W/H` で grid と glyph を強制同期する。
     pub terminal_cell_w_override: Option<f32>,
     pub terminal_cell_h_override: Option<f32>,
+    /// Slint 隠し Text probe (`measured-terminal-cell-w/h`) の値を採用するか。
+    /// 既定 false: 比率 fallback (`terminal_cell_w()` / `terminal_cell_h()`) を
+    /// 優先する。macOS の SF Mono / Menlo では probe が advance を過大、行高を
+    /// 過小に返し、結果として grid と glyph がズレる事象 (#292 / #289) を観測
+    /// したため、`LOCUS_TERMINAL_PROBE_METRICS=true` を明示しない限り probe を
+    /// 信用しない。手動 override (`LOCUS_TERMINAL_CELL_W/H`) は常に最優先。
+    pub terminal_probe_metrics: bool,
     /// PromptDraft を PTY に流し込む際に bracketed paste mode で囲うかどうか。
     /// 非対応 shell / agent CLI では `\x1b[200~` 等が文字としてそのまま表示
     /// されるため、`LOCUS_BRACKETED_PASTE=false` で raw 送信に切り替えられる。
@@ -61,14 +68,15 @@ impl UiConfig {
         let prompt_max_chars =
             parse_prompt_max_chars_env(std::env::var("LOCUS_PROMPT_MAX_CHARS").ok().as_deref());
         let confirm_send =
-            parse_confirm_send_env(std::env::var("LOCUS_CONFIRM_SEND").ok().as_deref());
+            parse_bool_env(std::env::var("LOCUS_CONFIRM_SEND").ok().as_deref());
         let terminal_cell_w_override =
             parse_positive_f32_env(std::env::var("LOCUS_TERMINAL_CELL_W").ok().as_deref());
         let terminal_cell_h_override =
             parse_positive_f32_env(std::env::var("LOCUS_TERMINAL_CELL_H").ok().as_deref());
-        let terminal_debug_grid = parse_terminal_debug_grid_env(
-            std::env::var("LOCUS_TERMINAL_DEBUG_GRID").ok().as_deref(),
-        );
+        let terminal_debug_grid =
+            parse_bool_env(std::env::var("LOCUS_TERMINAL_DEBUG_GRID").ok().as_deref());
+        let terminal_probe_metrics =
+            parse_bool_env(std::env::var("LOCUS_TERMINAL_PROBE_METRICS").ok().as_deref());
         Self {
             font_family,
             terminal_font_family,
@@ -76,6 +84,7 @@ impl UiConfig {
             diff_font_size,
             terminal_cell_w_override,
             terminal_cell_h_override,
+            terminal_probe_metrics,
             bracketed_paste,
             prompt_max_chars,
             confirm_send,
@@ -84,12 +93,13 @@ impl UiConfig {
     }
 
     /// monospace の典型的な比率 (advance ≈ 0.6 em, line height ≈ 1.45 em)
-    /// から cell width/height をピクセルに変換する暫定値。
+    /// から cell width/height をピクセルに変換する既定値。
     ///
-    /// 起動直後の Slint layout が settling していない短時間 (probe Text の
-    /// `preferred-width` / `preferred-height` がまだ 0) に fallback として
-    /// 使われる。実 glyph metric は `terminal-resized` callback 経由で
-    /// `measured-terminal-cell-w` / `measured-terminal-cell-h` から取得する。
+    /// 既定では `terminal_cell_w_from_measurement` 経由でこの比率値が採用される
+    /// (Slint 側 `measured-terminal-cell-w/h` probe は #292 / #289 の再現を
+    /// 避けるため既定 off)。`LOCUS_TERMINAL_CELL_W/H` の手動 override がある
+    /// 場合はそちらが優先され、`LOCUS_TERMINAL_PROBE_METRICS=true` を opt-in
+    /// したときだけ probe 値が採用される。
     pub fn terminal_cell_w(&self) -> f32 {
         self.terminal_cell_w_override
             .unwrap_or_else(|| (self.terminal_font_size * 0.6).round().max(4.0))
@@ -102,25 +112,49 @@ impl UiConfig {
 
     /// Slint の probe から得た cell metric を実際に採用する値へ解決する。
     ///
-    /// 手動 override がある場合は実測値より優先する。override が無い場合は
-    /// 正の有限な実測値を使い、未測定 / 異常値なら従来の比率 fallback を使う。
+    /// 優先順位は: 手動 override (`LOCUS_TERMINAL_CELL_W/H`) > probe (有効時のみ) >
+    /// 比率 fallback。probe は既定で無効化されており、`terminal_probe_metrics`
+    /// が true で、かつ実測値が正の有限値の場合だけ採用する。macOS では
+    /// `MMMMMMMMMM` の `preferred-width` が advance を過大、`preferred-height`
+    /// が行高を過小に返すケース (#292 / #289) があり、既定で信用すると grid と
+    /// glyph がズレるため。
     pub fn terminal_cell_w_from_measurement(&self, measured: f32) -> f32 {
         if let Some(cell_w) = self.terminal_cell_w_override {
-            cell_w
-        } else if measured.is_finite() && measured > 0.0 {
-            measured
-        } else {
-            self.terminal_cell_w()
+            return cell_w;
         }
+        if self.terminal_probe_metrics && measured.is_finite() && measured > 0.0 {
+            return measured;
+        }
+        self.terminal_cell_w()
     }
 
     pub fn terminal_cell_h_from_measurement(&self, measured: f32) -> f32 {
         if let Some(cell_h) = self.terminal_cell_h_override {
-            cell_h
-        } else if measured.is_finite() && measured > 0.0 {
-            measured
+            return cell_h;
+        }
+        if self.terminal_probe_metrics && measured.is_finite() && measured > 0.0 {
+            return measured;
+        }
+        self.terminal_cell_h()
+    }
+
+    pub fn terminal_cell_w_source(&self, measured: f32) -> &'static str {
+        if self.terminal_cell_w_override.is_some() {
+            "override"
+        } else if self.terminal_probe_metrics && measured.is_finite() && measured > 0.0 {
+            "probe"
         } else {
-            self.terminal_cell_h()
+            "fallback"
+        }
+    }
+
+    pub fn terminal_cell_h_source(&self, measured: f32) -> &'static str {
+        if self.terminal_cell_h_override.is_some() {
+            "override"
+        } else if self.terminal_probe_metrics && measured.is_finite() && measured > 0.0 {
+            "probe"
+        } else {
+            "fallback"
         }
     }
 }
@@ -190,24 +224,20 @@ pub fn parse_bracketed_paste_env(value: Option<&str>) -> bool {
     }
 }
 
-/// `LOCUS_CONFIRM_SEND` の値で Insert+Send 確認 checkbox を要求するかどうか。
-///
-/// - 未設定 / 空 / 不明値 / `0` / `false` / `off` / `no` → false (既定)
-/// - `1` / `true` / `on` / `yes` → true
-pub fn parse_confirm_send_env(value: Option<&str>) -> bool {
-    match value.map(|s| s.trim().to_ascii_lowercase()) {
-        Some(v) => matches!(v.as_str(), "1" | "true" | "on" | "yes"),
-        None => false,
-    }
-}
-
-/// `LOCUS_TERMINAL_DEBUG_GRID` で terminal cell metric の debug overlay を出すか。
+/// fail-closed な真偽値環境変数の共通 parser。
 ///
 /// - 未設定 / 空 / 不明値 / `0` / `false` / `off` / `no` → false (既定)
 /// - `1` / `true` / `on` / `yes` → true
 ///
-/// 既定挙動を変えないため fail-closed 側にしている (`confirm_send` と同じ規則)。
-pub fn parse_terminal_debug_grid_env(value: Option<&str>) -> bool {
+/// `LOCUS_CONFIRM_SEND` (Insert+Send 確認 checkbox の opt-in)、
+/// `LOCUS_TERMINAL_DEBUG_GRID` (terminal cell metric の debug overlay)、
+/// `LOCUS_TERMINAL_PROBE_METRICS` (Slint 隠し Text probe の opt-in) など、
+/// 「明示的に有効化されたときだけ既定挙動を変える」フラグで使う。
+/// `LOCUS_TERMINAL_PROBE_METRICS` は macOS で probe (`preferred-width` /
+/// `preferred-height`) が SF Mono / Menlo 系の幅を過大・行高を過小に返し
+/// cell と glyph がズレる #292 / #289 を避けるため、既定 false で比率
+/// fallback を信用する設計になっている。
+pub fn parse_bool_env(value: Option<&str>) -> bool {
     match value.map(|s| s.trim().to_ascii_lowercase()) {
         Some(v) => matches!(v.as_str(), "1" | "true" | "on" | "yes"),
         None => false,
@@ -236,50 +266,33 @@ pub fn parse_prompt_max_chars_env(value: Option<&str>) -> usize {
 mod tests {
     use super::*;
 
-    #[test]
-    fn default_metrics_are_reasonable() {
-        let cfg = UiConfig {
+    fn fixture(font_size: f32) -> UiConfig {
+        UiConfig {
             font_family: "test".into(),
             terminal_font_family: "test-mono".into(),
-            terminal_font_size: 12.0,
-            diff_font_size: 12.0,
+            terminal_font_size: font_size,
+            diff_font_size: font_size,
             terminal_cell_w_override: None,
             terminal_cell_h_override: None,
+            terminal_probe_metrics: false,
             bracketed_paste: true,
             prompt_max_chars: 32_000,
             confirm_send: false,
             terminal_debug_grid: false,
-        };
+        }
+    }
+
+    #[test]
+    fn default_metrics_are_reasonable() {
+        let cfg = fixture(12.0);
         assert!(cfg.terminal_cell_w() >= 6.0);
         assert!(cfg.terminal_cell_h() >= 14.0);
     }
 
     #[test]
     fn cell_metrics_scale_with_font_size() {
-        let small = UiConfig {
-            font_family: "x".into(),
-            terminal_font_family: "x-mono".into(),
-            terminal_font_size: 10.0,
-            diff_font_size: 10.0,
-            terminal_cell_w_override: None,
-            terminal_cell_h_override: None,
-            bracketed_paste: true,
-            prompt_max_chars: 32_000,
-            confirm_send: false,
-            terminal_debug_grid: false,
-        };
-        let big = UiConfig {
-            font_family: "x".into(),
-            terminal_font_family: "x-mono".into(),
-            terminal_font_size: 20.0,
-            diff_font_size: 20.0,
-            terminal_cell_w_override: None,
-            terminal_cell_h_override: None,
-            bracketed_paste: true,
-            prompt_max_chars: 32_000,
-            confirm_send: false,
-            terminal_debug_grid: false,
-        };
+        let small = fixture(10.0);
+        let big = fixture(20.0);
         assert!(big.terminal_cell_w() > small.terminal_cell_w());
         assert!(big.terminal_cell_h() > small.terminal_cell_h());
     }
@@ -302,27 +315,6 @@ mod tests {
     fn bracketed_paste_explicit_on() {
         for v in ["1", "true", "True", "on", "yes"] {
             assert!(parse_bracketed_paste_env(Some(v)));
-        }
-    }
-
-    #[test]
-    fn confirm_send_default_off() {
-        assert!(!parse_confirm_send_env(None));
-        assert!(!parse_confirm_send_env(Some("")));
-        assert!(!parse_confirm_send_env(Some("garbage")));
-    }
-
-    #[test]
-    fn confirm_send_explicit_on() {
-        for v in ["1", "true", "True", "on", "yes", "ON"] {
-            assert!(parse_confirm_send_env(Some(v)));
-        }
-    }
-
-    #[test]
-    fn confirm_send_explicit_off() {
-        for v in ["0", "false", "off", "no"] {
-            assert!(!parse_confirm_send_env(Some(v)));
         }
     }
 
@@ -362,18 +354,10 @@ mod tests {
 
     #[test]
     fn manual_terminal_cell_metrics_override_probe_values() {
-        let cfg = UiConfig {
-            font_family: "x".into(),
-            terminal_font_family: "x-mono".into(),
-            terminal_font_size: 13.0,
-            diff_font_size: 12.0,
-            terminal_cell_w_override: Some(9.5),
-            terminal_cell_h_override: Some(18.5),
-            bracketed_paste: true,
-            prompt_max_chars: 32_000,
-            confirm_send: false,
-            terminal_debug_grid: false,
-        };
+        let mut cfg = fixture(13.0);
+        cfg.terminal_cell_w_override = Some(9.5);
+        cfg.terminal_cell_h_override = Some(18.5);
+        cfg.terminal_probe_metrics = true; // probe 有効でも override が最優先
         assert_eq!(cfg.terminal_cell_w(), 9.5);
         assert_eq!(cfg.terminal_cell_h(), 18.5);
         assert_eq!(cfg.terminal_cell_w_from_measurement(7.0), 9.5);
@@ -381,42 +365,76 @@ mod tests {
     }
 
     #[test]
-    fn terminal_debug_grid_default_off() {
-        assert!(!parse_terminal_debug_grid_env(None));
-        assert!(!parse_terminal_debug_grid_env(Some("")));
-        assert!(!parse_terminal_debug_grid_env(Some("garbage")));
+    fn bool_env_default_off() {
+        assert!(!parse_bool_env(None));
+        assert!(!parse_bool_env(Some("")));
+        assert!(!parse_bool_env(Some("garbage")));
     }
 
     #[test]
-    fn terminal_debug_grid_explicit_on() {
+    fn bool_env_explicit_on() {
         for v in ["1", "true", "True", "on", "yes", "ON", "  YES  "] {
-            assert!(parse_terminal_debug_grid_env(Some(v)));
+            assert!(parse_bool_env(Some(v)));
         }
     }
 
     #[test]
-    fn terminal_debug_grid_explicit_off() {
+    fn bool_env_explicit_off() {
         for v in ["0", "false", "off", "no", "False"] {
-            assert!(!parse_terminal_debug_grid_env(Some(v)));
+            assert!(!parse_bool_env(Some(v)));
         }
     }
 
     #[test]
-    fn measured_terminal_cell_metrics_win_without_manual_override() {
-        let cfg = UiConfig {
-            font_family: "x".into(),
-            terminal_font_family: "x-mono".into(),
-            terminal_font_size: 13.0,
-            diff_font_size: 12.0,
-            terminal_cell_w_override: None,
-            terminal_cell_h_override: None,
-            bracketed_paste: true,
-            prompt_max_chars: 32_000,
-            confirm_send: false,
-            terminal_debug_grid: false,
-        };
+    fn default_ignores_probe_metrics_and_uses_ratio_fallback() {
+        // 既定 (probe 無効) では実測値が「妥当そう」でも採用しない。これは macOS で
+        // probe 値が glyph と grid をズラす #292 / #289 の再現を回避するため。
+        let cfg = fixture(13.0);
+        assert!(!cfg.terminal_probe_metrics);
+
+        // 同じ font_size で probe が advance を過大 (10.9) 行高を過小 (13.0) に
+        // 返した実機ログ (#292 baseline) を入れても fallback ratio で解決される。
+        assert_eq!(
+            cfg.terminal_cell_w_from_measurement(10.9),
+            cfg.terminal_cell_w()
+        );
+        assert_eq!(
+            cfg.terminal_cell_h_from_measurement(13.0),
+            cfg.terminal_cell_h()
+        );
+        // 一見妥当そうな値も既定では信用しない
+        assert_eq!(
+            cfg.terminal_cell_w_from_measurement(7.25),
+            cfg.terminal_cell_w()
+        );
+        assert_eq!(
+            cfg.terminal_cell_h_from_measurement(18.5),
+            cfg.terminal_cell_h()
+        );
+        // pathological も従来同様 fallback
+        assert_eq!(
+            cfg.terminal_cell_w_from_measurement(0.0),
+            cfg.terminal_cell_w()
+        );
+        assert_eq!(
+            cfg.terminal_cell_h_from_measurement(f32::NAN),
+            cfg.terminal_cell_h()
+        );
+        assert_eq!(cfg.terminal_cell_w_source(10.9), "fallback");
+        assert_eq!(cfg.terminal_cell_h_source(13.0), "fallback");
+    }
+
+    #[test]
+    fn opt_in_probe_metrics_use_measured_values() {
+        // `LOCUS_TERMINAL_PROBE_METRICS=true` 相当: 旧挙動を opt-in できる。
+        let mut cfg = fixture(13.0);
+        cfg.terminal_probe_metrics = true;
+
         assert_eq!(cfg.terminal_cell_w_from_measurement(7.25), 7.25);
         assert_eq!(cfg.terminal_cell_h_from_measurement(15.75), 15.75);
+        assert_eq!(cfg.terminal_cell_w_source(7.25), "probe");
+        assert_eq!(cfg.terminal_cell_h_source(15.75), "probe");
+        // 異常値 (0 / NaN) は probe 有効でも fallback に倒す
         assert_eq!(
             cfg.terminal_cell_w_from_measurement(0.0),
             cfg.terminal_cell_w()
@@ -426,4 +444,20 @@ mod tests {
             cfg.terminal_cell_h()
         );
     }
+
+    #[test]
+    fn manual_override_beats_probe_opt_in() {
+        // override + probe 有効 でも override が最優先。診断時に
+        // `LOCUS_TERMINAL_CELL_W/H` を強制値として使う運用を保証する。
+        let mut cfg = fixture(13.0);
+        cfg.terminal_cell_w_override = Some(8.0);
+        cfg.terminal_cell_h_override = Some(19.0);
+        cfg.terminal_probe_metrics = true;
+
+        assert_eq!(cfg.terminal_cell_w_from_measurement(10.9), 8.0);
+        assert_eq!(cfg.terminal_cell_h_from_measurement(13.0), 19.0);
+        assert_eq!(cfg.terminal_cell_w_source(10.9), "override");
+        assert_eq!(cfg.terminal_cell_h_source(13.0), "override");
+    }
+
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,7 @@ fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
         terminal_font_size = ui_cfg.terminal_font_size,
         terminal_cell_w = ui_cfg.terminal_cell_w(),
         terminal_cell_h = ui_cfg.terminal_cell_h(),
+        terminal_probe_metrics = ui_cfg.terminal_probe_metrics,
         terminal_debug_grid = ui_cfg.terminal_debug_grid,
         "terminal typography configured"
     );
@@ -107,6 +108,7 @@ fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
         let ui_weak = ui.as_weak();
         let ui_cfg = ui_cfg.clone();
         ui.on_resized(move |w_logical: f32, h_logical: f32| {
+            let started = Instant::now();
             let Some(ui) = ui_weak.upgrade() else {
                 return;
             };
@@ -115,8 +117,12 @@ fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
             if w_logical <= 0.0 || h_logical <= 0.0 {
                 return;
             }
-            let cell_w = ui_cfg.terminal_cell_w_from_measurement(ui.get_measured_cell_w());
-            let cell_h = ui_cfg.terminal_cell_h_from_measurement(ui.get_measured_cell_h());
+            let measured_cell_w = ui.get_measured_cell_w();
+            let measured_cell_h = ui.get_measured_cell_h();
+            let cell_w = ui_cfg.terminal_cell_w_from_measurement(measured_cell_w);
+            let cell_h = ui_cfg.terminal_cell_h_from_measurement(measured_cell_h);
+            let cell_w_source = ui_cfg.terminal_cell_w_source(measured_cell_w);
+            let cell_h_source = ui_cfg.terminal_cell_h_source(measured_cell_h);
             ui.set_cell_w(cell_w);
             ui.set_cell_h(cell_h);
             let (cols, rows) = terminal::compute_grid_size(w_logical, h_logical, cell_w, cell_h);
@@ -125,6 +131,18 @@ fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
                     let (cols_now, rows_now) = pane.current_size();
                     ui.set_cols(cols_now as i32);
                     ui.set_visible_rows(rows_now as i32);
+                    tracing::debug!(
+                        pane_w = w_logical,
+                        pane_h = h_logical,
+                        cell_w,
+                        cell_h,
+                        cell_w_source,
+                        cell_h_source,
+                        cols = cols_now,
+                        rows = rows_now,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "terminal resized"
+                    );
                 }
                 Err(e) => {
                     tracing::warn!(%cols, %rows, error = %e, "terminal resize failed");
@@ -188,6 +206,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
         terminal_font_size = ui_cfg.terminal_font_size,
         terminal_cell_w = ui_cfg.terminal_cell_w(),
         terminal_cell_h = ui_cfg.terminal_cell_h(),
+        terminal_probe_metrics = ui_cfg.terminal_probe_metrics,
         terminal_debug_grid = ui_cfg.terminal_debug_grid,
         "diff viewer typography configured"
     );
@@ -953,16 +972,17 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
 /// から `terminal-resized(width, height)` を発火する。ここでは:
 ///
 /// 1. UI から `measured-terminal-cell-w` / `measured-terminal-cell-h` を読み、
-///    cell-w / cell-h プロパティに反映する（render と PTY の grid を一致させる）。
+///    `UiConfig` の優先順位 (override > opt-in probe > fallback) で cell metric を
+///    解決して cell-w / cell-h プロパティに反映する。
 /// 2. (pane size / cell size) を floor して新しい cols / rows を算出する。
 /// 3. `TerminalPane::resize` で PTY + alacritty Term + row model を再構成する。
 fn wire_terminal_resize(
     ui: &DiffViewerWindow,
     pane: Rc<terminal::TerminalPane>,
-    fallback: &config::UiConfig,
+    ui_cfg: &config::UiConfig,
 ) {
     let ui_weak = ui.as_weak();
-    let fallback = fallback.clone();
+    let ui_cfg = ui_cfg.clone();
     ui.on_terminal_resized(move |w_logical: f32, h_logical: f32| {
         let started = Instant::now();
         let Some(ui) = ui_weak.upgrade() else {
@@ -973,11 +993,17 @@ fn wire_terminal_resize(
         if w_logical <= 0.0 || h_logical <= 0.0 {
             return;
         }
-        // 実 glyph metric が未測定 (= 0) の間は従来の比率近似を使う。
-        // `LOCUS_TERMINAL_CELL_W/H` が指定されている場合は、実測値より
-        // 手動 override を優先して grid と glyph のズレを切り分けられる。
-        let cell_w = fallback.terminal_cell_w_from_measurement(ui.get_measured_terminal_cell_w());
-        let cell_h = fallback.terminal_cell_h_from_measurement(ui.get_measured_terminal_cell_h());
+        // 既定では Slint 隠し Text probe (`measured-terminal-cell-w/h`) を信用せず
+        // 比率 fallback (`font_size * 0.6` / `* 1.45`) を採用する。macOS で probe が
+        // SF Mono / Menlo の advance を過大・行高を過小に返し grid と glyph がズレる
+        // #292 / #289 の再現を回避するため。`LOCUS_TERMINAL_CELL_W/H` の手動 override
+        // が最優先、`LOCUS_TERMINAL_PROBE_METRICS=true` で opt-in 時のみ probe 採用。
+        let measured_cell_w = ui.get_measured_terminal_cell_w();
+        let measured_cell_h = ui.get_measured_terminal_cell_h();
+        let cell_w = ui_cfg.terminal_cell_w_from_measurement(measured_cell_w);
+        let cell_h = ui_cfg.terminal_cell_h_from_measurement(measured_cell_h);
+        let cell_w_source = ui_cfg.terminal_cell_w_source(measured_cell_w);
+        let cell_h_source = ui_cfg.terminal_cell_h_source(measured_cell_h);
         ui.set_terminal_cell_w(cell_w);
         ui.set_terminal_cell_h(cell_h);
         let (cols, rows) = terminal::compute_grid_size(w_logical, h_logical, cell_w, cell_h);
@@ -991,6 +1017,8 @@ fn wire_terminal_resize(
                     pane_h = h_logical,
                     cell_w,
                     cell_h,
+                    cell_w_source,
+                    cell_h_source,
                     cols = cols_now,
                     rows = rows_now,
                     elapsed_ms = started.elapsed().as_millis() as u64,


### PR DESCRIPTION
## Motivation

#292 / #289 の実機診断で、terminal pane の cell metric が Slint probe によって `10.9 x 13.0` に上書きされ、glyph に対して cell が広すぎ・行高が低すぎる状態になっていました。

#304 で追加した診断ハーネスで確認したところ、手動で fallback 値 `8 x 19` を指定すると terminal ASCII / 日本語の可読性が大きく改善しました。probe は macOS の SF Mono / Menlo で advance を過大・行高を過小に返しているため、既定では信用しないようにします。

## Changes

- `UiConfig` に `terminal_probe_metrics` を追加
- `LOCUS_TERMINAL_PROBE_METRICS=true` の明示 opt-in 時のみ Slint hidden Text probe を採用
- 既定は fallback ratio (`font_size * 0.6`, `font_size * 1.45`) を採用
- `LOCUS_TERMINAL_CELL_W/H` の手動 override は引き続き最優先
- typography debug log に `terminal_probe_metrics` を追加
- README / README.ja に新 env と metric 優先順位を記載
- config tests を追加・更新

## Validation

- `cargo test` — 164 passed
- `cargo clippy --all-targets -- -D warnings` — no issues
- `cargo build` — passed
- default diagnostic after fix:
  - `scripts/diagnose_ui.sh github duck8823/locus#304 --no-build --duration 4 --out-dir target/locus-diagnostics/issue-ui-default-after-probe-log`
  - `terminal_probe_metrics=false`
  - `terminal resized ... cell_w=8.0 cell_h=19.0 cols=89 rows=13`
  - screenshot confirmed terminal text is no longer extremely spaced/compressed
- opt-in diagnostic:
  - `LOCUS_TERMINAL_PROBE_METRICS=true scripts/diagnose_ui.sh github duck8823/locus#304 --no-build --duration 3 --out-dir target/locus-diagnostics/issue-ui-probe-opt-in`
  - `terminal_probe_metrics=true`
  - `terminal resized ... cell_w=10.899999618530273 cell_h=13.0 cols=65 rows=19` (old behavior preserved behind opt-in)
- Japanese terminal smoke:
  - `/tmp/locus-terminal-jp-smoke.sh` via terminal mode
  - ASCII / 日本語 text is readable; remaining decorative/symbol tofu is left to #277

Refs #292, #289
