### PR TITLE
refactor(diff-viewer): extract terminal resize wiring

### DIFF
--- a/src/app/diff_viewer/mod.rs
+++ b/src/app/diff_viewer/mod.rs
@@ -8,5 +8,6 @@ pub(crate) mod snapshot;
 pub(crate) mod refresh;
 pub(crate) mod session;
 pub(crate) mod state;
+pub(crate) mod terminal_resize;
 pub(crate) mod toast;
 pub(crate) mod util;

--- a/src/app/diff_viewer/terminal_resize.rs
+++ b/src/app/diff_viewer/terminal_resize.rs
@@ -1,0 +1,86 @@
+//! Diff viewer terminal pane の resize 配線 (#224 split)。
+//!
+//! Slint 側の `terminal-resized` callback を `TerminalPane::resize` に橋渡し
+//! しつつ、cell metric の解決 (override > opt-in probe > fallback) と
+//! window session の保存も同時に行う。`run_diff_viewer` 起動時に一度だけ
+//! 呼ばれる前提。
+
+use std::rc::Rc;
+use std::time::Instant;
+
+use slint::ComponentHandle;
+
+use super::session::save_window_session;
+use crate::config::UiConfig;
+use crate::terminal;
+use crate::DiffViewerWindow;
+
+/// Slint の `terminal-resized` callback を `TerminalPane::resize` に橋渡しする。
+///
+/// Slint 側は terminal-pane Rectangle の `width` / `height` の changed callback
+/// から `terminal-resized(width, height)` を発火する。ここでは:
+///
+/// 1. UI から `measured-terminal-cell-w` / `measured-terminal-cell-h` を読み、
+///    `UiConfig` の優先順位 (override > opt-in probe > fallback) で cell metric を
+///    解決して cell-w / cell-h プロパティに反映する。
+/// 2. (pane size / cell size) を floor して新しい cols / rows を算出する。
+/// 3. `TerminalPane::resize` で PTY + alacritty Term + row model を再構成する。
+pub(crate) fn wire_terminal_resize(
+    ui: &DiffViewerWindow,
+    pane: Rc<terminal::TerminalPane>,
+    ui_cfg: &UiConfig,
+) {
+    let ui_weak = ui.as_weak();
+    let ui_cfg = ui_cfg.clone();
+    ui.on_terminal_resized(move |w_logical: f32, h_logical: f32| {
+        let started = Instant::now();
+        let Some(ui) = ui_weak.upgrade() else {
+            return;
+        };
+        // 初期 layout settling や hidden 中の transient 0x0 では PTY を縮めない。
+        // measured-* も layout 確定前は 0 になるので両条件で skip する。
+        if w_logical <= 0.0 || h_logical <= 0.0 {
+            return;
+        }
+        // 既定では Slint 隠し Text probe (`measured-terminal-cell-w/h`) を信用せず
+        // 比率 fallback (`font_size * 0.6` / `* 1.45`) を採用する。macOS で probe が
+        // SF Mono / Menlo の advance を過大・行高を過小に返し grid と glyph がズレる
+        // #292 / #289 の再現を回避するため。`LOCUS_TERMINAL_CELL_W/H` の手動 override
+        // が最優先、`LOCUS_TERMINAL_PROBE_METRICS=true` で opt-in 時のみ probe 採用。
+        let measured_cell_w = ui.get_measured_terminal_cell_w();
+        let measured_cell_h = ui.get_measured_terminal_cell_h();
+        let cell_w = ui_cfg.terminal_cell_w_from_measurement(measured_cell_w);
+        let cell_h = ui_cfg.terminal_cell_h_from_measurement(measured_cell_h);
+        let cell_w_source = ui_cfg.terminal_cell_w_source(measured_cell_w);
+        let cell_h_source = ui_cfg.terminal_cell_h_source(measured_cell_h);
+        ui.set_terminal_cell_w(cell_w);
+        ui.set_terminal_cell_h(cell_h);
+        let (cols, rows) = terminal::compute_grid_size(w_logical, h_logical, cell_w, cell_h);
+        match pane.resize(cols, rows) {
+            Ok(()) => {
+                let (cols_now, rows_now) = pane.current_size();
+                ui.set_terminal_cols(cols_now as i32);
+                ui.set_terminal_rows_count(rows_now as i32);
+                tracing::debug!(
+                    pane_w = w_logical,
+                    pane_h = h_logical,
+                    cell_w,
+                    cell_h,
+                    cell_w_source,
+                    cell_h_source,
+                    cols = cols_now,
+                    rows = rows_now,
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    "terminal resized"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(%cols, %rows, error = %e, "terminal resize failed");
+            }
+        }
+        // ウィンドウリサイズに連れて terminal-pane の width/height も変わる
+        // ため、ここで session を保存しておくと Cmd+Q (close-requested を
+        // 通らず process exit) でも最後の window size を残せる (#231 補強)。
+        save_window_session(&ui);
+    });
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ use app::diff_viewer::refresh::{
 };
 use app::diff_viewer::session::{save_pr_session, save_window_session};
 use app::diff_viewer::state::{set_app_state, with_app_state, DiffAppState, ToastKind};
+use app::diff_viewer::terminal_resize::wire_terminal_resize;
 use app::diff_viewer::toast::{schedule_toast_auto_dismiss, set_active_window, show_toast};
 use app::diff_viewer::util::resolve_line_number;
 
@@ -964,74 +965,4 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
     drop(position_save_timer);
     drop(terminal_pane);
     Ok(())
-}
-
-/// Slint の `terminal-resized` callback を `TerminalPane::resize` に橋渡しする。
-///
-/// Slint 側は terminal-pane Rectangle の `width` / `height` の changed callback
-/// から `terminal-resized(width, height)` を発火する。ここでは:
-///
-/// 1. UI から `measured-terminal-cell-w` / `measured-terminal-cell-h` を読み、
-///    `UiConfig` の優先順位 (override > opt-in probe > fallback) で cell metric を
-///    解決して cell-w / cell-h プロパティに反映する。
-/// 2. (pane size / cell size) を floor して新しい cols / rows を算出する。
-/// 3. `TerminalPane::resize` で PTY + alacritty Term + row model を再構成する。
-fn wire_terminal_resize(
-    ui: &DiffViewerWindow,
-    pane: Rc<terminal::TerminalPane>,
-    ui_cfg: &config::UiConfig,
-) {
-    let ui_weak = ui.as_weak();
-    let ui_cfg = ui_cfg.clone();
-    ui.on_terminal_resized(move |w_logical: f32, h_logical: f32| {
-        let started = Instant::now();
-        let Some(ui) = ui_weak.upgrade() else {
-            return;
-        };
-        // 初期 layout settling や hidden 中の transient 0x0 では PTY を縮めない。
-        // measured-* も layout 確定前は 0 になるので両条件で skip する。
-        if w_logical <= 0.0 || h_logical <= 0.0 {
-            return;
-        }
-        // 既定では Slint 隠し Text probe (`measured-terminal-cell-w/h`) を信用せず
-        // 比率 fallback (`font_size * 0.6` / `* 1.45`) を採用する。macOS で probe が
-        // SF Mono / Menlo の advance を過大・行高を過小に返し grid と glyph がズレる
-        // #292 / #289 の再現を回避するため。`LOCUS_TERMINAL_CELL_W/H` の手動 override
-        // が最優先、`LOCUS_TERMINAL_PROBE_METRICS=true` で opt-in 時のみ probe 採用。
-        let measured_cell_w = ui.get_measured_terminal_cell_w();
-        let measured_cell_h = ui.get_measured_terminal_cell_h();
-        let cell_w = ui_cfg.terminal_cell_w_from_measurement(measured_cell_w);
-        let cell_h = ui_cfg.terminal_cell_h_from_measurement(measured_cell_h);
-        let cell_w_source = ui_cfg.terminal_cell_w_source(measured_cell_w);
-        let cell_h_source = ui_cfg.terminal_cell_h_source(measured_cell_h);
-        ui.set_terminal_cell_w(cell_w);
-        ui.set_terminal_cell_h(cell_h);
-        let (cols, rows) = terminal::compute_grid_size(w_logical, h_logical, cell_w, cell_h);
-        match pane.resize(cols, rows) {
-            Ok(()) => {
-                let (cols_now, rows_now) = pane.current_size();
-                ui.set_terminal_cols(cols_now as i32);
-                ui.set_terminal_rows_count(rows_now as i32);
-                tracing::debug!(
-                    pane_w = w_logical,
-                    pane_h = h_logical,
-                    cell_w,
-                    cell_h,
-                    cell_w_source,
-                    cell_h_source,
-                    cols = cols_now,
-                    rows = rows_now,
-                    elapsed_ms = started.elapsed().as_millis() as u64,
-                    "terminal resized"
-                );
-            }
-            Err(e) => {
-                tracing::warn!(%cols, %rows, error = %e, "terminal resize failed");
-            }
-        }
-        // ウィンドウリサイズに連れて terminal-pane の width/height も変わる
-        // ため、ここで session を保存しておくと Cmd+Q (close-requested を
-        // 通らず process exit) でも最後の window size を残せる (#231 補強)。
-        save_window_session(&ui);
-    });
 }


### PR DESCRIPTION
## Motivation

#224 の `main.rs` 分割を小さな単位で継続する。

今回は diff viewer 専用の `wire_terminal_resize` helper を `src/app/diff_viewer/` 配下へ移し、`main.rs` を composition root に近づける。機能変更はありません。

Refs #224

## Changes

- `src/app/diff_viewer/terminal_resize.rs` を追加
- `wire_terminal_resize` を `main.rs` 末尾から移設
- `src/app/diff_viewer/mod.rs` に module を追加
- `main.rs` は新 module の `wire_terminal_resize` を呼び出すだけに変更

## Validation

- `rtk cargo test` → 158 passed
- `rtk cargo clippy --all-targets -- -D warnings` → passed
- `rtk cargo build` → passed

## Notes

- `run_terminal` (terminal-only mode) の resize callback は diff viewer 専用ではないため、今回の scope には含めていません。
- `cell_w_source` / `cell_h_source` を含む #305 の診断ログは移設後もそのままです。
