### PR TITLE
feat(dx): add scripted interaction diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ scripts/diagnose_ui.sh terminal --interaction terminal-type --interaction termin
 scripts/diagnose_ui.sh github duck8823/locus#302 --interaction file-switch-next --duration 8
 ```
 
-出力先は既定で `target/locus-diagnostics/<timestamp>/`。`report.json` / `app.log` / `perf_summary.txt` / `screenshot.png` を確認し、必要なら `view_image` で screenshot を目視確認する。`--interaction` 指定時は `interaction_events.jsonl` / `interaction_summary.json` も確認し、注入 event と app log の突合 latency を見る。`env.txt` は filtered snapshot で credential らしい値は redacted される。
+出力先は既定で `target/locus-diagnostics/<timestamp>/`。`report.json` / `app.log` / `perf_summary.txt` / `screenshot.png` を確認し、必要なら `view_image` で screenshot を目視確認する。`--interaction` 指定時は `interaction_events.jsonl` / `interaction_summary.json` も確認し、注入 event と app log の突合 latency を見る。`observed=false` / `unobserved` の場合は、操作注入は走ったが app log 上の反応を確認できていないため、操作遅延の測定値として扱わない。`env.txt` は filtered snapshot で credential らしい値は redacted される。
 
 ## AI レビュー設定 (`/review-and-merge` で使用)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,11 @@ Web SaaS 時代 (Next.js) からの転換が完了済み (ADR 0005)。
 ```sh
 scripts/diagnose_ui.sh terminal --duration 6
 scripts/diagnose_ui.sh github duck8823/locus#302 --duration 8
+scripts/diagnose_ui.sh terminal --interaction terminal-type --interaction terminal-scroll --duration 4
+scripts/diagnose_ui.sh github duck8823/locus#302 --interaction file-switch-next --duration 8
 ```
 
-出力先は既定で `target/locus-diagnostics/<timestamp>/`。`report.json` / `app.log` / `perf_summary.txt` / `screenshot.png` を確認し、必要なら `view_image` で screenshot を目視確認する。`env.txt` は filtered snapshot で credential らしい値は redacted される。
+出力先は既定で `target/locus-diagnostics/<timestamp>/`。`report.json` / `app.log` / `perf_summary.txt` / `screenshot.png` を確認し、必要なら `view_image` で screenshot を目視確認する。`--interaction` 指定時は `interaction_events.jsonl` / `interaction_summary.json` も確認し、注入 event と app log の突合 latency を見る。`env.txt` は filtered snapshot で credential らしい値は redacted される。
 
 ## AI レビュー設定 (`/review-and-merge` で使用)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ scripts/diagnose_ui.sh terminal --interaction terminal-type --interaction termin
 scripts/diagnose_ui.sh github duck8823/locus#302 --interaction file-switch-next --duration 8
 ```
 
-出力先は既定で `target/locus-diagnostics/<timestamp>/`。`report.json` / `app.log` / `perf_summary.txt` / `screenshot.png` を確認し、必要なら `view_image` で screenshot を目視確認する。`--interaction` 指定時は `interaction_events.jsonl` / `interaction_summary.json` も確認し、注入 event と app log の突合 latency と `latency_stats` (p50/p95/max) を見る。`observed=false` / `unobserved` の場合は、操作注入は走ったが app log 上の反応を確認できていないため、操作遅延の測定値として扱わない。`file-switch-next` は app-side single-shot なので 1 run 1 回・単独指定のみ。`--interaction-delay` は `--duration` 以下にする。`env.txt` は filtered snapshot で credential らしい値は redacted される。
+出力先は既定で `target/locus-diagnostics/<timestamp>/`。`report.json` / `app.log` / `perf_summary.txt` / `screenshot.png` を確認し、必要なら `view_image` で screenshot を目視確認する。`--interaction` 指定時は `interaction_events.jsonl` / `interaction_summary.json` も確認し、注入 event と app log の突合 latency と `latency_stats` (p50/p95/max) を見る。`terminal-scroll` は `terminal scroll event` log と突合する。`observed=false` / `unobserved` の場合は、操作注入は走ったが app log 上の反応を確認できていないため、操作遅延の測定値として扱わない。`file-switch-next` は app-side single-shot なので 1 run 1 回・単独指定のみ。`--interaction-delay` は `--duration` 以下にする。`env.txt` は filtered snapshot で credential らしい値は redacted される。
 
 ## AI レビュー設定 (`/review-and-merge` で使用)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ scripts/diagnose_ui.sh terminal --interaction terminal-type --interaction termin
 scripts/diagnose_ui.sh github duck8823/locus#302 --interaction file-switch-next --duration 8
 ```
 
-出力先は既定で `target/locus-diagnostics/<timestamp>/`。`report.json` / `app.log` / `perf_summary.txt` / `screenshot.png` を確認し、必要なら `view_image` で screenshot を目視確認する。`--interaction` 指定時は `interaction_events.jsonl` / `interaction_summary.json` も確認し、注入 event と app log の突合 latency と `latency_stats` (p50/p95/max) を見る。`observed=false` / `unobserved` の場合は、操作注入は走ったが app log 上の反応を確認できていないため、操作遅延の測定値として扱わない。`file-switch-next` は app-side single-shot なので 1 run 1 回まで。`--interaction-delay` は `--duration` 以下にする。`env.txt` は filtered snapshot で credential らしい値は redacted される。
+出力先は既定で `target/locus-diagnostics/<timestamp>/`。`report.json` / `app.log` / `perf_summary.txt` / `screenshot.png` を確認し、必要なら `view_image` で screenshot を目視確認する。`--interaction` 指定時は `interaction_events.jsonl` / `interaction_summary.json` も確認し、注入 event と app log の突合 latency と `latency_stats` (p50/p95/max) を見る。`observed=false` / `unobserved` の場合は、操作注入は走ったが app log 上の反応を確認できていないため、操作遅延の測定値として扱わない。`file-switch-next` は app-side single-shot なので 1 run 1 回・単独指定のみ。`--interaction-delay` は `--duration` 以下にする。`env.txt` は filtered snapshot で credential らしい値は redacted される。
 
 ## AI レビュー設定 (`/review-and-merge` で使用)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ scripts/diagnose_ui.sh terminal --interaction terminal-type --interaction termin
 scripts/diagnose_ui.sh github duck8823/locus#302 --interaction file-switch-next --duration 8
 ```
 
-出力先は既定で `target/locus-diagnostics/<timestamp>/`。`report.json` / `app.log` / `perf_summary.txt` / `screenshot.png` を確認し、必要なら `view_image` で screenshot を目視確認する。`--interaction` 指定時は `interaction_events.jsonl` / `interaction_summary.json` も確認し、注入 event と app log の突合 latency を見る。`observed=false` / `unobserved` の場合は、操作注入は走ったが app log 上の反応を確認できていないため、操作遅延の測定値として扱わない。`env.txt` は filtered snapshot で credential らしい値は redacted される。
+出力先は既定で `target/locus-diagnostics/<timestamp>/`。`report.json` / `app.log` / `perf_summary.txt` / `screenshot.png` を確認し、必要なら `view_image` で screenshot を目視確認する。`--interaction` 指定時は `interaction_events.jsonl` / `interaction_summary.json` も確認し、注入 event と app log の突合 latency と `latency_stats` (p50/p95/max) を見る。`observed=false` / `unobserved` の場合は、操作注入は走ったが app log 上の反応を確認できていないため、操作遅延の測定値として扱わない。`env.txt` は filtered snapshot で credential らしい値は redacted される。
 
 ## AI レビュー設定 (`/review-and-merge` で使用)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ scripts/diagnose_ui.sh terminal --interaction terminal-type --interaction termin
 scripts/diagnose_ui.sh github duck8823/locus#302 --interaction file-switch-next --duration 8
 ```
 
-出力先は既定で `target/locus-diagnostics/<timestamp>/`。`report.json` / `app.log` / `perf_summary.txt` / `screenshot.png` を確認し、必要なら `view_image` で screenshot を目視確認する。`--interaction` 指定時は `interaction_events.jsonl` / `interaction_summary.json` も確認し、注入 event と app log の突合 latency と `latency_stats` (p50/p95/max) を見る。`observed=false` / `unobserved` の場合は、操作注入は走ったが app log 上の反応を確認できていないため、操作遅延の測定値として扱わない。`env.txt` は filtered snapshot で credential らしい値は redacted される。
+出力先は既定で `target/locus-diagnostics/<timestamp>/`。`report.json` / `app.log` / `perf_summary.txt` / `screenshot.png` を確認し、必要なら `view_image` で screenshot を目視確認する。`--interaction` 指定時は `interaction_events.jsonl` / `interaction_summary.json` も確認し、注入 event と app log の突合 latency と `latency_stats` (p50/p95/max) を見る。`observed=false` / `unobserved` の場合は、操作注入は走ったが app log 上の反応を確認できていないため、操作遅延の測定値として扱わない。`file-switch-next` は app-side single-shot なので 1 run 1 回まで。`--interaction-delay` は `--duration` 以下にする。`env.txt` は filtered snapshot で credential らしい値は redacted される。
 
 ## AI レビュー設定 (`/review-and-merge` で使用)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -129,13 +129,20 @@ scripts/diagnose_ui.sh terminal \
   --interaction-delay 1 \
   --duration 4
 
+# diff-viewer の file switch interaction (github mode が必要)
+scripts/diagnose_ui.sh github duck8823/locus#236 \
+  --interaction file-switch-next \
+  --interaction-delay 2 \
+  --duration 6
+
 # 既存 build を流用する (cargo build をスキップ)
 scripts/diagnose_ui.sh terminal --no-build --out-dir target/locus-diagnostics/run-A
 ```
 
 `terminal-type` は macOS System Events (`osascript`) を使います。
 `terminal-scroll` は Python の Quartz (`pyobjc-framework-Quartz`) を使います。
-これらの tool / 権限が無い場合でも harness 全体は失敗させず、
+`file-switch-next` は `github` mode で app 側の診断 timer を arm します。
+必要な tool / mode / 権限が無い場合でも harness 全体は失敗させず、
 interaction artifact に skipped / failed として記録します。
 
 各実行は次のファイルを `--out-dir` (既定 `target/locus-diagnostics/<timestamp>/`) に書き出します:

--- a/README.ja.md
+++ b/README.ja.md
@@ -157,7 +157,7 @@ interaction artifact に skipped / failed として記録します。
 | `build.log` | `cargo build` の出力 (`--no-build` の場合は出ない) |
 | `command.txt` | 起動した argv と子プロセスに注入した環境変数 |
 | `env.txt` | 再現に必要な環境変数の filtered snapshot。credential らしい変数は redacted |
-| `perf_summary.txt` | `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal input forward failed` / `terminal render tick` / `terminal render idle flush` / `file switch requested` / `diagnostic file switch` / `window session saved` / `pr session saved` / `linked issues fetched` / `initial hydrate ...` の grep カウントとマッチ行、加えて WARN/ERROR/panic の tail |
+| `perf_summary.txt` | `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal input forward failed` / `terminal scroll event` / `terminal render tick` / `terminal render idle flush` / `file switch requested` / `diagnostic file switch` / `window session saved` / `pr session saved` / `linked issues fetched` / `initial hydrate ...` の grep カウントとマッチ行、加えて WARN/ERROR/panic の tail |
 | `screenshot.png` | 起動 N 秒後のデスクトップ (`screencapture` がある環境のみ) |
 | `interaction_events.jsonl` | scripted interaction の start/done/skipped/failed event、timestamp、status (`--interaction` 指定時のみ) |
 | `interaction_summary.json` | `interaction_events.jsonl` と `app.log` を突き合わせた interaction count と best-effort latency summary/statistics。`observed=false` / `unobserved` は注入は完了したが対応する app log が見つからなかった状態 |

--- a/README.ja.md
+++ b/README.ja.md
@@ -158,7 +158,7 @@ interaction artifact に skipped / failed として記録します。
 | `perf_summary.txt` | `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal input forward failed` / `terminal render tick` / `pr session saved` / `linked issues fetched` / `initial hydrate ...` の grep カウントとマッチ行、加えて WARN/ERROR/panic の tail |
 | `screenshot.png` | 起動 N 秒後のデスクトップ (`screencapture` がある環境のみ) |
 | `interaction_events.jsonl` | scripted interaction の start/done/skipped/failed event、timestamp、status (`--interaction` 指定時のみ) |
-| `interaction_summary.json` | `interaction_events.jsonl` と `app.log` を突き合わせた interaction count と best-effort latency summary。`observed=false` / `unobserved` は注入は完了したが対応する app log が見つからなかった状態 |
+| `interaction_summary.json` | `interaction_events.jsonl` と `app.log` を突き合わせた interaction count と best-effort latency summary/statistics。`observed=false` / `unobserved` は注入は完了したが対応する app log が見つからなかった状態 |
 | `report.json` | mode / command / env override / duration / exit status / screenshot/focus status / artifact paths / tool availability / notes |
 
 `cargo build` 失敗・binary 不在・locus が harness 停止より前に死んだ場合のいずれでも `report.json` を必ず書き出し、non-zero exit します (子プロセスの exit status が分かる場合はそれを伝播)。`--duration` 経過後に harness が TERM で停止させた正常 run のみ exit 0 です。

--- a/README.ja.md
+++ b/README.ja.md
@@ -142,7 +142,7 @@ scripts/diagnose_ui.sh terminal --no-build --out-dir target/locus-diagnostics/ru
 `terminal-type` は macOS System Events (`osascript`) を使います。
 `terminal-scroll` は Python の Quartz (`pyobjc-framework-Quartz`) を使います。
 `file-switch-next` は `github` mode で app 側の single-shot 診断 timer を arm するため、
-1 run につき 1 回だけ指定できます。interaction 指定時の `--interaction-delay` は
+1 run につき 1 回だけ、かつ単独で指定します。interaction 指定時の `--interaction-delay` は
 短時間 smoke 診断が指定時間を超えて待ち続けないよう `--duration` 以下に制限します。
 必要な tool / mode / 権限が無い場合でも harness 全体は失敗させず、
 interaction artifact に skipped / failed として記録します。

--- a/README.ja.md
+++ b/README.ja.md
@@ -155,10 +155,10 @@ interaction artifact に skipped / failed として記録します。
 | `build.log` | `cargo build` の出力 (`--no-build` の場合は出ない) |
 | `command.txt` | 起動した argv と子プロセスに注入した環境変数 |
 | `env.txt` | 再現に必要な環境変数の filtered snapshot。credential らしい変数は redacted |
-| `perf_summary.txt` | `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal render tick` / `pr session saved` / `linked issues fetched` / `initial hydrate ...` の grep カウントとマッチ行、加えて WARN/ERROR/panic の tail |
+| `perf_summary.txt` | `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal input forward failed` / `terminal render tick` / `pr session saved` / `linked issues fetched` / `initial hydrate ...` の grep カウントとマッチ行、加えて WARN/ERROR/panic の tail |
 | `screenshot.png` | 起動 N 秒後のデスクトップ (`screencapture` がある環境のみ) |
 | `interaction_events.jsonl` | scripted interaction の start/done/skipped/failed event、timestamp、status (`--interaction` 指定時のみ) |
-| `interaction_summary.json` | `interaction_events.jsonl` と `app.log` を突き合わせた interaction count と best-effort latency summary |
+| `interaction_summary.json` | `interaction_events.jsonl` と `app.log` を突き合わせた interaction count と best-effort latency summary。`observed=false` / `unobserved` は注入は完了したが対応する app log が見つからなかった状態 |
 | `report.json` | mode / command / env override / duration / exit status / screenshot/focus status / artifact paths / tool availability / notes |
 
 `cargo build` 失敗・binary 不在・locus が harness 停止より前に死んだ場合のいずれでも `report.json` を必ず書き出し、non-zero exit します (子プロセスの exit status が分かる場合はそれを伝播)。`--duration` 経過後に harness が TERM で停止させた正常 run のみ exit 0 です。

--- a/README.ja.md
+++ b/README.ja.md
@@ -146,6 +146,8 @@ scripts/diagnose_ui.sh terminal --no-build --out-dir target/locus-diagnostics/ru
 interaction artifact に skipped / failed として記録します。
 
 各実行は次のファイルを `--out-dir` (既定 `target/locus-diagnostics/<timestamp>/`) に書き出します:
+既定の出力先は `target/` 配下なので、明示的に working tree 内の別ディレクトリを
+指定しない限り git には含まれません。
 
 | ファイル | 内容 |
 |---|---|

--- a/README.ja.md
+++ b/README.ja.md
@@ -141,7 +141,9 @@ scripts/diagnose_ui.sh terminal --no-build --out-dir target/locus-diagnostics/ru
 
 `terminal-type` は macOS System Events (`osascript`) を使います。
 `terminal-scroll` は Python の Quartz (`pyobjc-framework-Quartz`) を使います。
-`file-switch-next` は `github` mode で app 側の診断 timer を arm します。
+`file-switch-next` は `github` mode で app 側の single-shot 診断 timer を arm するため、
+1 run につき 1 回だけ指定できます。interaction 指定時の `--interaction-delay` は
+短時間 smoke 診断が指定時間を超えて待ち続けないよう `--duration` 以下に制限します。
 必要な tool / mode / 権限が無い場合でも harness 全体は失敗させず、
 interaction artifact に skipped / failed として記録します。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -122,9 +122,21 @@ scripts/diagnose_ui.sh github duck8823/locus#236 --probe-metrics --duration 10
 # front window を固定サイズに resize して min-size 目視診断のスクショを再現する (macOS)
 scripts/diagnose_ui.sh terminal --window-size 1280x720 --duration 6
 
+# scripted input / scroll を注入して latency artifact を作る (macOS)
+scripts/diagnose_ui.sh terminal \
+  --interaction terminal-type \
+  --interaction terminal-scroll \
+  --interaction-delay 1 \
+  --duration 4
+
 # 既存 build を流用する (cargo build をスキップ)
 scripts/diagnose_ui.sh terminal --no-build --out-dir target/locus-diagnostics/run-A
 ```
+
+`terminal-type` は macOS System Events (`osascript`) を使います。
+`terminal-scroll` は Python の Quartz (`pyobjc-framework-Quartz`) を使います。
+これらの tool / 権限が無い場合でも harness 全体は失敗させず、
+interaction artifact に skipped / failed として記録します。
 
 各実行は次のファイルを `--out-dir` (既定 `target/locus-diagnostics/<timestamp>/`) に書き出します:
 
@@ -134,8 +146,10 @@ scripts/diagnose_ui.sh terminal --no-build --out-dir target/locus-diagnostics/ru
 | `build.log` | `cargo build` の出力 (`--no-build` の場合は出ない) |
 | `command.txt` | 起動した argv と子プロセスに注入した環境変数 |
 | `env.txt` | 再現に必要な環境変数の filtered snapshot。credential らしい変数は redacted |
-| `perf_summary.txt` | `preview refreshed` / `terminal resized` / `pr session saved` / `linked issues fetched` / `initial hydrate ...` の grep カウントとマッチ行、加えて WARN/ERROR/panic の tail |
+| `perf_summary.txt` | `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal render tick` / `pr session saved` / `linked issues fetched` / `initial hydrate ...` の grep カウントとマッチ行、加えて WARN/ERROR/panic の tail |
 | `screenshot.png` | 起動 N 秒後のデスクトップ (`screencapture` がある環境のみ) |
+| `interaction_events.jsonl` | scripted interaction の start/done/skipped/failed event、timestamp、status (`--interaction` 指定時のみ) |
+| `interaction_summary.json` | `interaction_events.jsonl` と `app.log` を突き合わせた interaction count と best-effort latency summary |
 | `report.json` | mode / command / env override / duration / exit status / screenshot/focus status / artifact paths / tool availability / notes |
 
 `cargo build` 失敗・binary 不在・locus が harness 停止より前に死んだ場合のいずれでも `report.json` を必ず書き出し、non-zero exit します (子プロセスの exit status が分かる場合はそれを伝播)。`--duration` 経過後に harness が TERM で停止させた正常 run のみ exit 0 です。

--- a/README.ja.md
+++ b/README.ja.md
@@ -157,7 +157,7 @@ interaction artifact に skipped / failed として記録します。
 | `build.log` | `cargo build` の出力 (`--no-build` の場合は出ない) |
 | `command.txt` | 起動した argv と子プロセスに注入した環境変数 |
 | `env.txt` | 再現に必要な環境変数の filtered snapshot。credential らしい変数は redacted |
-| `perf_summary.txt` | `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal input forward failed` / `terminal render tick` / `pr session saved` / `linked issues fetched` / `initial hydrate ...` の grep カウントとマッチ行、加えて WARN/ERROR/panic の tail |
+| `perf_summary.txt` | `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal input forward failed` / `terminal render tick` / `terminal render idle flush` / `file switch requested` / `diagnostic file switch` / `window session saved` / `pr session saved` / `linked issues fetched` / `initial hydrate ...` の grep カウントとマッチ行、加えて WARN/ERROR/panic の tail |
 | `screenshot.png` | 起動 N 秒後のデスクトップ (`screencapture` がある環境のみ) |
 | `interaction_events.jsonl` | scripted interaction の start/done/skipped/failed event、timestamp、status (`--interaction` 指定時のみ) |
 | `interaction_summary.json` | `interaction_events.jsonl` と `app.log` を突き合わせた interaction count と best-effort latency summary/statistics。`observed=false` / `unobserved` は注入は完了したが対応する app log が見つからなかった状態 |

--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ unless you explicitly choose an output directory inside the working tree.
 | `build.log` | `cargo build` output (omitted with `--no-build`) |
 | `command.txt` | resolved argv and the exact env vars injected into the child |
 | `env.txt` | filtered environment snapshot for reproduction; credential-like variables are redacted |
-| `perf_summary.txt` | grep counts and matched lines for `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal render tick` / `pr session saved` / `linked issues fetched` / `initial hydrate ...`, plus a tail of WARN/ERROR/panic lines |
+| `perf_summary.txt` | grep counts and matched lines for `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal input forward failed` / `terminal render tick` / `pr session saved` / `linked issues fetched` / `initial hydrate ...`, plus a tail of WARN/ERROR/panic lines |
 | `screenshot.png` | desktop screenshot taken mid-run (only when `screencapture` is available and succeeds) |
 | `interaction_events.jsonl` | scripted interaction start/done/skipped/failed events with timestamps and status (only when `--interaction` is used) |
-| `interaction_summary.json` | interaction counts plus best-effort latency summaries by matching `interaction_events.jsonl` with `app.log` |
+| `interaction_summary.json` | interaction counts plus best-effort latency summaries by matching `interaction_events.jsonl` with `app.log`; `observed=false` / `unobserved` means the input was injected but no matching app log was seen |
 | `report.json` | mode, command, env overrides, duration, exit status, screenshot/focus status, artifact paths, tool availability, free-form notes |
 
 When `cargo build` fails, the binary is missing, or locus exits before the harness terminates it, the script still writes `report.json` and exits non-zero (propagating the child's exit status when available) so an LLM caller can read the failure mode programmatically instead of inferring it from missing files. A clean run (locus is still alive after `--duration` and shuts down on TERM) exits 0.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ unless you explicitly choose an output directory inside the working tree.
 | `perf_summary.txt` | grep counts and matched lines for `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal input forward failed` / `terminal render tick` / `pr session saved` / `linked issues fetched` / `initial hydrate ...`, plus a tail of WARN/ERROR/panic lines |
 | `screenshot.png` | desktop screenshot taken mid-run (only when `screencapture` is available and succeeds) |
 | `interaction_events.jsonl` | scripted interaction start/done/skipped/failed events with timestamps and status (only when `--interaction` is used) |
-| `interaction_summary.json` | interaction counts plus best-effort latency summaries by matching `interaction_events.jsonl` with `app.log`; `observed=false` / `unobserved` means the input was injected but no matching app log was seen |
+| `interaction_summary.json` | interaction counts plus best-effort latency summaries/statistics by matching `interaction_events.jsonl` with `app.log`; `observed=false` / `unobserved` means the input was injected but no matching app log was seen |
 | `report.json` | mode, command, env overrides, duration, exit status, screenshot/focus status, artifact paths, tool availability, free-form notes |
 
 When `cargo build` fails, the binary is missing, or locus exits before the harness terminates it, the script still writes `report.json` and exits non-zero (propagating the child's exit status when available) so an LLM caller can read the failure mode programmatically instead of inferring it from missing files. A clean run (locus is still alive after `--duration` and shuts down on TERM) exits 0.

--- a/README.md
+++ b/README.md
@@ -141,9 +141,12 @@ scripts/diagnose_ui.sh terminal --no-build --out-dir target/locus-diagnostics/ru
 
 `terminal-type` uses macOS System Events via `osascript`. `terminal-scroll`
 uses Quartz through Python (`pyobjc-framework-Quartz`). `file-switch-next`
-arms an app-side diagnostic timer in `github` mode. When the required tools,
-mode, or permissions are missing, the harness records a skipped/failed
-interaction in the artifacts instead of failing the whole run.
+arms a single app-side diagnostic timer in `github` mode and can be specified
+at most once per run. When interactions are requested, `--interaction-delay`
+must be less than or equal to `--duration` so short smoke diagnostics do not
+wait longer than their requested run time. When the required tools, mode, or
+permissions are missing, the harness records a skipped/failed interaction in
+the artifacts instead of failing the whole run.
 
 Every run drops these files into `--out-dir` (default `target/locus-diagnostics/<timestamp>/`):
 the default location is under `target/`, so these artifacts are ignored by git

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ unless you explicitly choose an output directory inside the working tree.
 | `build.log` | `cargo build` output (omitted with `--no-build`) |
 | `command.txt` | resolved argv and the exact env vars injected into the child |
 | `env.txt` | filtered environment snapshot for reproduction; credential-like variables are redacted |
-| `perf_summary.txt` | grep counts and matched lines for `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal input forward failed` / `terminal render tick` / `pr session saved` / `linked issues fetched` / `initial hydrate ...`, plus a tail of WARN/ERROR/panic lines |
+| `perf_summary.txt` | grep counts and matched lines for `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal input forward failed` / `terminal render tick` / `terminal render idle flush` / `file switch requested` / `diagnostic file switch` / `window session saved` / `pr session saved` / `linked issues fetched` / `initial hydrate ...`, plus a tail of WARN/ERROR/panic lines |
 | `screenshot.png` | desktop screenshot taken mid-run (only when `screencapture` is available and succeeds) |
 | `interaction_events.jsonl` | scripted interaction start/done/skipped/failed events with timestamps and status (only when `--interaction` is used) |
 | `interaction_summary.json` | interaction counts plus best-effort latency summaries/statistics by matching `interaction_events.jsonl` with `app.log`; `observed=false` / `unobserved` means the input was injected but no matching app log was seen |

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ unless you explicitly choose an output directory inside the working tree.
 | `build.log` | `cargo build` output (omitted with `--no-build`) |
 | `command.txt` | resolved argv and the exact env vars injected into the child |
 | `env.txt` | filtered environment snapshot for reproduction; credential-like variables are redacted |
-| `perf_summary.txt` | grep counts and matched lines for `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal input forward failed` / `terminal render tick` / `terminal render idle flush` / `file switch requested` / `diagnostic file switch` / `window session saved` / `pr session saved` / `linked issues fetched` / `initial hydrate ...`, plus a tail of WARN/ERROR/panic lines |
+| `perf_summary.txt` | grep counts and matched lines for `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal input forward failed` / `terminal scroll event` / `terminal render tick` / `terminal render idle flush` / `file switch requested` / `diagnostic file switch` / `window session saved` / `pr session saved` / `linked issues fetched` / `initial hydrate ...`, plus a tail of WARN/ERROR/panic lines |
 | `screenshot.png` | desktop screenshot taken mid-run (only when `screencapture` is available and succeeds) |
 | `interaction_events.jsonl` | scripted interaction start/done/skipped/failed events with timestamps and status (only when `--interaction` is used) |
 | `interaction_summary.json` | interaction counts plus best-effort latency summaries/statistics by matching `interaction_events.jsonl` with `app.log`; `observed=false` / `unobserved` means the input was injected but no matching app log was seen |

--- a/README.md
+++ b/README.md
@@ -129,14 +129,21 @@ scripts/diagnose_ui.sh terminal \
   --interaction-delay 1 \
   --duration 4
 
+# diff-viewer file switch interaction (requires github mode)
+scripts/diagnose_ui.sh github duck8823/locus#236 \
+  --interaction file-switch-next \
+  --interaction-delay 2 \
+  --duration 6
+
 # reuse a previous build (skip cargo build)
 scripts/diagnose_ui.sh terminal --no-build --out-dir target/locus-diagnostics/run-A
 ```
 
 `terminal-type` uses macOS System Events via `osascript`. `terminal-scroll`
-uses Quartz through Python (`pyobjc-framework-Quartz`); when those tools are
-missing or not permitted, the harness records a skipped/failed interaction in
-the artifacts instead of failing the whole run.
+uses Quartz through Python (`pyobjc-framework-Quartz`). `file-switch-next`
+arms an app-side diagnostic timer in `github` mode. When the required tools,
+mode, or permissions are missing, the harness records a skipped/failed
+interaction in the artifacts instead of failing the whole run.
 
 Every run drops these files into `--out-dir` (default `target/locus-diagnostics/<timestamp>/`):
 

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ scripts/diagnose_ui.sh terminal --no-build --out-dir target/locus-diagnostics/ru
 
 `terminal-type` uses macOS System Events via `osascript`. `terminal-scroll`
 uses Quartz through Python (`pyobjc-framework-Quartz`). `file-switch-next`
-arms a single app-side diagnostic timer in `github` mode and can be specified
-at most once per run. When interactions are requested, `--interaction-delay`
+arms a single app-side diagnostic timer in `github` mode and must be the only
+interaction in that run. When interactions are requested, `--interaction-delay`
 must be less than or equal to `--duration` so short smoke diagnostics do not
 wait longer than their requested run time. When the required tools, mode, or
 permissions are missing, the harness records a skipped/failed interaction in

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ mode, or permissions are missing, the harness records a skipped/failed
 interaction in the artifacts instead of failing the whole run.
 
 Every run drops these files into `--out-dir` (default `target/locus-diagnostics/<timestamp>/`):
+the default location is under `target/`, so these artifacts are ignored by git
+unless you explicitly choose an output directory inside the working tree.
 
 | File | Contents |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -122,9 +122,21 @@ scripts/diagnose_ui.sh github duck8823/locus#236 --probe-metrics --duration 10
 # pin the front window to a known size for reproducible min-size screenshots (macOS)
 scripts/diagnose_ui.sh terminal --window-size 1280x720 --duration 6
 
+# inject scripted input/scroll interactions and summarize latency artifacts (macOS)
+scripts/diagnose_ui.sh terminal \
+  --interaction terminal-type \
+  --interaction terminal-scroll \
+  --interaction-delay 1 \
+  --duration 4
+
 # reuse a previous build (skip cargo build)
 scripts/diagnose_ui.sh terminal --no-build --out-dir target/locus-diagnostics/run-A
 ```
+
+`terminal-type` uses macOS System Events via `osascript`. `terminal-scroll`
+uses Quartz through Python (`pyobjc-framework-Quartz`); when those tools are
+missing or not permitted, the harness records a skipped/failed interaction in
+the artifacts instead of failing the whole run.
 
 Every run drops these files into `--out-dir` (default `target/locus-diagnostics/<timestamp>/`):
 
@@ -134,8 +146,10 @@ Every run drops these files into `--out-dir` (default `target/locus-diagnostics/
 | `build.log` | `cargo build` output (omitted with `--no-build`) |
 | `command.txt` | resolved argv and the exact env vars injected into the child |
 | `env.txt` | filtered environment snapshot for reproduction; credential-like variables are redacted |
-| `perf_summary.txt` | grep counts and matched lines for `preview refreshed` / `terminal resized` / `pr session saved` / `linked issues fetched` / `initial hydrate ...`, plus a tail of WARN/ERROR/panic lines |
+| `perf_summary.txt` | grep counts and matched lines for `preview refreshed` / `terminal resized` / `terminal input forwarded` / `terminal render tick` / `pr session saved` / `linked issues fetched` / `initial hydrate ...`, plus a tail of WARN/ERROR/panic lines |
 | `screenshot.png` | desktop screenshot taken mid-run (only when `screencapture` is available and succeeds) |
+| `interaction_events.jsonl` | scripted interaction start/done/skipped/failed events with timestamps and status (only when `--interaction` is used) |
+| `interaction_summary.json` | interaction counts plus best-effort latency summaries by matching `interaction_events.jsonl` with `app.log` |
 | `report.json` | mode, command, env overrides, duration, exit status, screenshot/focus status, artifact paths, tool availability, free-form notes |
 
 When `cargo build` fails, the binary is missing, or locus exits before the harness terminates it, the script still writes `report.json` and exits non-zero (propagating the child's exit status when available) so an LLM caller can read the failure mode programmatically instead of inferring it from missing files. A clean run (locus is still alive after `--duration` and shuts down on TERM) exits 0.

--- a/scripts/diagnose_ui.sh
+++ b/scripts/diagnose_ui.sh
@@ -781,6 +781,7 @@ def parse_ts(ts):
 
 forwarded = []
 render_hits = []
+scroll_hits = []
 file_switch_hits = []
 if app_log and os.path.exists(app_log):
     with open(app_log, "r", encoding="utf-8", errors="replace") as f:
@@ -795,6 +796,8 @@ if app_log and os.path.exists(app_log):
                 forwarded.append(ums)
             if "terminal render tick" in line or "terminal render idle flush" in line:
                 render_hits.append(ums)
+            if "terminal scroll event" in line:
+                scroll_hits.append(ums)
             if "file switch requested" in line:
                 file_switch_hits.append(ums)
 
@@ -876,13 +879,13 @@ for a in agg.values():
             a["observation_status"] = "unmatched"
             a["observation_reason"] = "no terminal input forwarded log after injection"
     elif a["name"] == "terminal-scroll":
-        hit = first_after(render_hits, start)
+        hit = first_after(scroll_hits, start)
         if hit is not None:
             a["latency_ms"] = hit - start
-            a["match_keyword"] = "terminal render tick|terminal render idle flush"
+            a["match_keyword"] = "terminal scroll event"
         else:
             a["observation_status"] = "unmatched"
-            a["observation_reason"] = "no terminal render tick/idle flush log after injection"
+            a["observation_reason"] = "no terminal scroll event log after injection"
     elif a["name"] == "file-switch-next":
         hit = first_after(file_switch_hits, start)
         if hit is not None:
@@ -1443,6 +1446,7 @@ esac
         "terminal resize failed" \
         "terminal input forwarded" \
         "terminal input forward failed" \
+        "terminal scroll event" \
         "terminal render tick" \
         "terminal render idle flush" \
         "file switch requested" \
@@ -1465,7 +1469,7 @@ esac
     printf '\n'
     printf '== matched lines ==\n'
     if [ -f "$APP_LOG" ]; then
-        grep -E -- 'typography configured|preview refreshed|terminal resized|terminal resize failed|terminal input forwarded|terminal input forward failed|terminal render tick|terminal render idle flush|file switch requested|diagnostic file switch|window session saved|pr session saved|pr switch fetch completed|linked issues fetched|initial hydrate snapshot\+list fetched|initial hydrate completed|initial hydrate snapshot failed' \
+        grep -E -- 'typography configured|preview refreshed|terminal resized|terminal resize failed|terminal input forwarded|terminal input forward failed|terminal scroll event|terminal render tick|terminal render idle flush|file switch requested|diagnostic file switch|window session saved|pr session saved|pr switch fetch completed|linked issues fetched|initial hydrate snapshot\+list fetched|initial hydrate completed|initial hydrate snapshot failed' \
             "$APP_LOG" 2>/dev/null \
             | head -n 200 \
             || printf '  (no matching debug lines found)\n'

--- a/scripts/diagnose_ui.sh
+++ b/scripts/diagnose_ui.sh
@@ -661,14 +661,71 @@ inject_terminal_scroll() {
 
     start_ms="$(unix_ms)"
     emit_event "start" "terminal-scroll" "$idx" \
-        "start_unix_ms=$start_ms" "detail=post 6 scroll wheel events (line, dy=-3)"
+        "start_unix_ms=$start_ms" "detail=move pointer to terminal area; post 6 scroll wheel events (line, dy=-3)"
 
-    "$HAS_PYTHON3_BIN" - >/dev/null 2>&1 <<'PY'
+    APP_PID="$APP_PID" MODE="$MODE" "$HAS_PYTHON3_BIN" - >/dev/null 2>&1 <<'PY'
+import os
 import sys, time
 try:
     import Quartz
 except ImportError:
     sys.exit(11)
+
+try:
+    pid = int(os.environ.get("APP_PID", "0"))
+except ValueError:
+    sys.exit(12)
+if pid <= 0:
+    sys.exit(12)
+
+options = (
+    Quartz.kCGWindowListOptionOnScreenOnly
+    | Quartz.kCGWindowListExcludeDesktopElements
+)
+windows = Quartz.CGWindowListCopyWindowInfo(options, Quartz.kCGNullWindowID) or []
+candidates = []
+for w in windows:
+    if w.get("kCGWindowOwnerPID") != pid:
+        continue
+    if w.get("kCGWindowLayer", 0) != 0:
+        continue
+    bounds = w.get("kCGWindowBounds") or {}
+    width = float(bounds.get("Width", 0) or 0)
+    height = float(bounds.get("Height", 0) or 0)
+    if width <= 0 or height <= 0:
+        continue
+    x = float(bounds.get("X", 0) or 0)
+    y = float(bounds.get("Y", 0) or 0)
+    candidates.append((width * height, x, y, width, height))
+if not candidates:
+    sys.exit(13)
+
+_, x, y, width, height = sorted(candidates, reverse=True)[0]
+mode = os.environ.get("MODE") or "terminal"
+if mode == "github":
+    # Diff viewer: terminal pane is the bottom part of the left content area.
+    content_width = max(1.0, width - 320.0)
+    target = (x + min(content_width, width) * 0.5, y + max(24.0, height - 129.0))
+else:
+    # Terminal-only window: the terminal fills the window.
+    target = (x + width * 0.5, y + height * 0.5)
+
+move = Quartz.CGEventCreateMouseEvent(
+    None, Quartz.kCGEventMouseMoved, target, Quartz.kCGMouseButtonLeft
+)
+if move is None:
+    sys.exit(21)
+Quartz.CGEventPost(Quartz.kCGHIDEventTap, move)
+time.sleep(0.05)
+for event_type in (Quartz.kCGEventLeftMouseDown, Quartz.kCGEventLeftMouseUp):
+    click = Quartz.CGEventCreateMouseEvent(
+        None, event_type, target, Quartz.kCGMouseButtonLeft
+    )
+    if click is None:
+        sys.exit(22)
+    Quartz.CGEventPost(Quartz.kCGHIDEventTap, click)
+    time.sleep(0.03)
+
 for _ in range(6):
     e = Quartz.CGEventCreateScrollWheelEvent(
         None, Quartz.kCGScrollEventUnitLine, 1, -3
@@ -689,6 +746,14 @@ PY
         11)
             emit_event "skipped" "terminal-scroll" "$idx" \
                 "start_unix_ms=$start_ms" "reason=no_quartz"
+            ;;
+        12)
+            emit_event "skipped" "terminal-scroll" "$idx" \
+                "start_unix_ms=$start_ms" "reason=no_pid_for_scroll"
+            ;;
+        13)
+            emit_event "skipped" "terminal-scroll" "$idx" \
+                "start_unix_ms=$start_ms" "reason=no_window_for_scroll"
             ;;
         *)
             emit_event "failed" "terminal-scroll" "$idx" \

--- a/scripts/diagnose_ui.sh
+++ b/scripts/diagnose_ui.sh
@@ -94,7 +94,9 @@ options:
                             NAME: terminal-type | terminal-scroll | file-switch-next
                             terminal-scroll requires Python Quartz
                             (pyobjc-framework-Quartz) on macOS; otherwise skipped.
-  --interaction-delay SEC   launch から interactions 開始までの待ち秒数 (default 1)
+                            file-switch-next は app-side single-shot のため 1 回のみ指定可。
+  --interaction-delay SEC   launch から interactions 開始までの待ち秒数 (default 1)。
+                            --interaction 指定時は --duration 以下であること。
   --no-build                cargo build をスキップ
   -h, --help                ヘルプ
 USAGE
@@ -1130,13 +1132,23 @@ case "$INTERACTION_DELAY" in
 esac
 
 if [ "${#INTERACTIONS[@]}" -gt 0 ]; then
+    if [ "$INTERACTION_DELAY" -gt "$DURATION" ]; then
+        die "--interaction-delay must be less than or equal to --duration when --interaction is used (delay=$INTERACTION_DELAY duration=$DURATION)"
+    fi
+    _file_switch_count=0
     for _name in "${INTERACTIONS[@]}"; do
         case "$_name" in
-            terminal-type|terminal-scroll|file-switch-next) ;;
+            terminal-type|terminal-scroll) ;;
+            file-switch-next)
+                _file_switch_count=$((_file_switch_count + 1))
+                if [ "$_file_switch_count" -gt 1 ]; then
+                    die "--interaction file-switch-next can be specified at most once (app-side single-shot diagnostic)"
+                fi
+                ;;
             *) die "--interaction must be one of: terminal-type, terminal-scroll, file-switch-next (got: $_name)" ;;
         esac
     done
-    unset _name
+    unset _name _file_switch_count
 fi
 
 if [ -n "$WINDOW_SIZE" ]; then

--- a/scripts/diagnose_ui.sh
+++ b/scripts/diagnose_ui.sh
@@ -741,7 +741,7 @@ write_interaction_summary() {
         REQUESTED_INTERACTIONS_JSON="${INTERACTIONS_JSON:-[]}" \
         INTERACTION_DELAY_SEC="$INTERACTION_DELAY" \
             "$HAS_PYTHON3_BIN" - <<'PY'
-import json, os, re
+import json, math, os, re
 from datetime import datetime
 
 app_log = os.environ.get("APP_LOG") or ""
@@ -907,6 +907,39 @@ unobserved = sum(
     if a["status"] in ("ok", "started") and not a["observed"]
 )
 
+def percentile(values, p):
+    if not values:
+        return None
+    sorted_values = sorted(values)
+    index = max(0, math.ceil((p / 100.0) * len(sorted_values)) - 1)
+    return sorted_values[min(index, len(sorted_values) - 1)]
+
+def latency_stats(values):
+    if not values:
+        return {
+            "count": 0,
+            "min_ms": None,
+            "p50_ms": None,
+            "p95_ms": None,
+            "max_ms": None,
+        }
+    return {
+        "count": len(values),
+        "min_ms": min(values),
+        "p50_ms": percentile(values, 50),
+        "p95_ms": percentile(values, 95),
+        "max_ms": max(values),
+    }
+
+latencies_by_name = {}
+all_latencies = []
+for a in ordered:
+    latency = a.get("latency_ms")
+    if latency is None:
+        continue
+    all_latencies.append(latency)
+    latencies_by_name.setdefault(a.get("name") or "unknown", []).append(latency)
+
 out = {
     "schema_version": 1,
     "requested": requested,
@@ -918,6 +951,13 @@ out = {
         "failed": failed,
         "observed": observed,
         "unobserved": unobserved,
+    },
+    "latency_stats": {
+        "overall": latency_stats(all_latencies),
+        "by_interaction": {
+            name: latency_stats(values)
+            for name, values in sorted(latencies_by_name.items())
+        },
     },
 }
 

--- a/scripts/diagnose_ui.sh
+++ b/scripts/diagnose_ui.sh
@@ -47,7 +47,7 @@
 #                             リサイズして再現スクショを撮る (#290 等の min-size
 #                             目視診断向け)
 #   --interaction NAME        起動後に注入する操作。複数回指定可。対応 NAME:
-#                             terminal-type / terminal-scroll
+#                             terminal-type / terminal-scroll / file-switch-next
 #                             terminal-scroll は Python Quartz
 #                             (pyobjc-framework-Quartz) がある macOS で有効
 #   --interaction-delay SEC   launch から interactions 開始までの待ち秒数 (default 1)
@@ -91,7 +91,7 @@ options:
   --window-size WxH         macOS で起動後に front window を WIDTHxHEIGHT に
                             リサイズ (例: 1280x720)
   --interaction NAME        起動後に注入する操作。複数回指定可。
-                            NAME: terminal-type | terminal-scroll
+                            NAME: terminal-type | terminal-scroll | file-switch-next
                             terminal-scroll requires Python Quartz
                             (pyobjc-framework-Quartz) on macOS; otherwise skipped.
   --interaction-delay SEC   launch から interactions 開始までの待ち秒数 (default 1)
@@ -566,14 +566,15 @@ emit_event() {
 inject_terminal_type() {
     local idx="$1"
     local start_ms
-    start_ms="$(unix_ms)"
 
     if [ -z "${APP_PID:-}" ] || ! kill -0 "$APP_PID" 2>/dev/null; then
+        start_ms="$(unix_ms)"
         emit_event "skipped" "terminal-type" "$idx" \
             "start_unix_ms=$start_ms" "reason=app_not_running"
         return
     fi
     if [ "${HAS_OSASCRIPT:-0}" -ne 1 ]; then
+        start_ms="$(unix_ms)"
         emit_event "skipped" "terminal-type" "$idx" \
             "start_unix_ms=$start_ms" "reason=no_osascript"
         return
@@ -583,15 +584,26 @@ inject_terminal_type() {
     # 出す。注入文字列そのものは ここの interaction_events にだけ書き、app.log
     # には keystroke の結果として bytes_len のみが流れる。
     local payload="locus-diagnostic-input"
+
+    if ! osascript \
+        -e "tell application \"System Events\"" \
+        -e "    tell (first application process whose unix id is $APP_PID)" \
+        -e "        set frontmost to true" \
+        -e "    end tell" \
+        -e "end tell" >/dev/null 2>&1; then
+        start_ms="$(unix_ms)"
+        emit_event "failed" "terminal-type" "$idx" \
+            "start_unix_ms=$start_ms" "reason=osascript_focus_failed"
+        return
+    fi
+    sleep 0.2
+
+    start_ms="$(unix_ms)"
     emit_event "start" "terminal-type" "$idx" \
         "start_unix_ms=$start_ms" "detail=type '$payload' + return"
 
     if osascript \
         -e "tell application \"System Events\"" \
-        -e "    tell (first application process whose unix id is $APP_PID)" \
-        -e "        set frontmost to true" \
-        -e "    end tell" \
-        -e "    delay 0.2" \
         -e "    keystroke \"$payload\"" \
         -e "    key code 36" \
         -e "end tell" >/dev/null 2>&1; then
@@ -609,14 +621,15 @@ inject_terminal_type() {
 inject_terminal_scroll() {
     local idx="$1"
     local start_ms
-    start_ms="$(unix_ms)"
 
     if [ -z "${APP_PID:-}" ] || ! kill -0 "$APP_PID" 2>/dev/null; then
+        start_ms="$(unix_ms)"
         emit_event "skipped" "terminal-scroll" "$idx" \
             "start_unix_ms=$start_ms" "reason=app_not_running"
         return
     fi
     if [ -z "${HAS_PYTHON3_BIN:-}" ]; then
+        start_ms="$(unix_ms)"
         emit_event "skipped" "terminal-scroll" "$idx" \
             "start_unix_ms=$start_ms" "reason=no_python3"
         return
@@ -631,6 +644,7 @@ inject_terminal_scroll() {
         sleep 0.2
     fi
 
+    start_ms="$(unix_ms)"
     emit_event "start" "terminal-scroll" "$idx" \
         "start_unix_ms=$start_ms" "detail=post 6 scroll wheel events (line, dy=-3)"
 
@@ -668,6 +682,29 @@ PY
     esac
 }
 
+inject_file_switch_next() {
+    local idx="$1"
+    local start_ms
+    start_ms="$(unix_ms)"
+
+    if [ "$MODE" != "github" ]; then
+        emit_event "skipped" "file-switch-next" "$idx" \
+            "start_unix_ms=$start_ms" "reason=requires_github_mode"
+        return
+    fi
+    if [ -z "${APP_PID:-}" ] || ! kill -0 "$APP_PID" 2>/dev/null; then
+        emit_event "skipped" "file-switch-next" "$idx" \
+            "start_unix_ms=$start_ms" "reason=app_not_running"
+        return
+    fi
+
+    emit_event "start" "file-switch-next" "$idx" \
+        "start_unix_ms=$start_ms" "detail=app-side diagnostic timer requests next file"
+    emit_event "done" "file-switch-next" "$idx" \
+        "start_unix_ms=$start_ms" "end_unix_ms=$(unix_ms)" \
+        "detail=armed via LOCUS_DIAG_FILE_SWITCH_AFTER_MS"
+}
+
 run_interactions() {
     [ "${#INTERACTIONS[@]}" -gt 0 ] || return
     local i=0 name
@@ -675,6 +712,7 @@ run_interactions() {
         case "$name" in
             terminal-type)   inject_terminal_type "$i" ;;
             terminal-scroll) inject_terminal_scroll "$i" ;;
+            file-switch-next) inject_file_switch_next "$i" ;;
             *)
                 # 未対応 NAME は parse 段階で die しているため到達しないが
                 # 防衛的に残す。
@@ -737,6 +775,7 @@ def parse_ts(ts):
 
 forwarded = []
 render_hits = []
+file_switch_hits = []
 if app_log and os.path.exists(app_log):
     with open(app_log, "r", encoding="utf-8", errors="replace") as f:
         for line in f:
@@ -750,6 +789,8 @@ if app_log and os.path.exists(app_log):
                 forwarded.append(ums)
             if "terminal render tick" in line or "terminal render idle flush" in line:
                 render_hits.append(ums)
+            if "file switch requested" in line:
+                file_switch_hits.append(ums)
 
 def first_after(items, threshold):
     for ums in items:
@@ -816,6 +857,11 @@ for a in agg.values():
         if hit is not None:
             a["latency_ms"] = hit - start
             a["match_keyword"] = "terminal render tick|terminal render idle flush"
+    elif a["name"] == "file-switch-next":
+        hit = first_after(file_switch_hits, start)
+        if hit is not None:
+            a["latency_ms"] = hit - start
+            a["match_keyword"] = "file switch requested"
 
 ordered = [agg[k] for k in sorted(agg.keys())]
 events_total = len(ordered)
@@ -970,7 +1016,7 @@ while [ "$#" -gt 0 ]; do
             ;;
         --interaction)
             shift
-            [ "$#" -gt 0 ] || die "--interaction requires a value (terminal-type | terminal-scroll)"
+            [ "$#" -gt 0 ] || die "--interaction requires a value (terminal-type | terminal-scroll | file-switch-next)"
             INTERACTIONS+=("$1")
             shift
             ;;
@@ -1005,8 +1051,8 @@ esac
 if [ "${#INTERACTIONS[@]}" -gt 0 ]; then
     for _name in "${INTERACTIONS[@]}"; do
         case "$_name" in
-            terminal-type|terminal-scroll) ;;
-            *) die "--interaction must be one of: terminal-type, terminal-scroll (got: $_name)" ;;
+            terminal-type|terminal-scroll|file-switch-next) ;;
+            *) die "--interaction must be one of: terminal-type, terminal-scroll, file-switch-next (got: $_name)" ;;
         esac
     done
     unset _name
@@ -1142,6 +1188,19 @@ fi
 [ -n "$CELL_H" ]              && ENV_VARS+=("LOCUS_TERMINAL_CELL_H=$CELL_H")
 [ -n "$FONT_FAMILY" ]         && ENV_VARS+=("LOCUS_TERMINAL_FONT_FAMILY=$FONT_FAMILY")
 [ -n "$TERMINAL_FONT_SIZE" ]  && ENV_VARS+=("LOCUS_TERMINAL_FONT_SIZE=$TERMINAL_FONT_SIZE")
+if [ "${#INTERACTIONS[@]}" -gt 0 ]; then
+    # interaction latency を app.log と突き合わせられるよう、高速 render tick も
+    # 診断時だけ出す。通常 run では従来通り slow/budget-hit のみ。
+    ENV_VARS+=("LOCUS_DIAG_TRACE_RENDER_TICKS=true")
+fi
+for _interaction in "${INTERACTIONS[@]}"; do
+    if [ "$_interaction" = "file-switch-next" ]; then
+        # app 側 single-shot timer が file-switch-requested callback を発火する。
+        # script 側 event start よりわずかに後に出るよう +250ms しておく。
+        ENV_VARS+=("LOCUS_DIAG_FILE_SWITCH_AFTER_MS=$((INTERACTION_DELAY * 1000 + 250))")
+    fi
+done
+unset _interaction
 
 case "$MODE" in
     terminal) CMD_ARGS=("$BIN" "$AGENT_CMD") ;;
@@ -1288,6 +1347,8 @@ esac
         "terminal input forwarded" \
         "terminal render tick" \
         "terminal render idle flush" \
+        "file switch requested" \
+        "diagnostic file switch" \
         "window session saved" \
         "pr session saved" \
         "pr switch fetch completed" \
@@ -1306,7 +1367,7 @@ esac
     printf '\n'
     printf '== matched lines ==\n'
     if [ -f "$APP_LOG" ]; then
-        grep -E -- 'typography configured|preview refreshed|terminal resized|terminal resize failed|terminal input forwarded|terminal render tick|terminal render idle flush|window session saved|pr session saved|pr switch fetch completed|linked issues fetched|initial hydrate snapshot\+list fetched|initial hydrate completed|initial hydrate snapshot failed' \
+        grep -E -- 'typography configured|preview refreshed|terminal resized|terminal resize failed|terminal input forwarded|terminal render tick|terminal render idle flush|file switch requested|diagnostic file switch|window session saved|pr session saved|pr switch fetch completed|linked issues fetched|initial hydrate snapshot\+list fetched|initial hydrate completed|initial hydrate snapshot failed' \
             "$APP_LOG" 2>/dev/null \
             | head -n 200 \
             || printf '  (no matching debug lines found)\n'

--- a/scripts/diagnose_ui.sh
+++ b/scripts/diagnose_ui.sh
@@ -5,13 +5,15 @@
 # LLM / オペレータが locus の terminal-only mode と diff viewer mode を
 # 実機で起動し、以下のアーティファクトを out-dir に書き出すための入口。
 #
-#   app.log         child process (cargo build した debug binary) の stdout/stderr
-#   build.log       cargo build の stdout/stderr (--no-build 時は省略)
-#   command.txt     起動した argv と注入した環境変数
-#   env.txt         スクリプト時点の環境変数 dump
-#   perf_summary.txt LOCUS_LOG=debug が吐く主要 perf 行の grep カウント
-#   screenshot.png  screencapture が使える環境では起動 N 秒後の画面
-#   report.json     mode / command / env / duration / exit_status / paths / tools
+#   app.log                    child process (cargo build した debug binary) の stdout/stderr
+#   build.log                  cargo build の stdout/stderr (--no-build 時は省略)
+#   command.txt                起動した argv と注入した環境変数
+#   env.txt                    スクリプト時点の環境変数 dump
+#   perf_summary.txt           LOCUS_LOG=debug が吐く主要 perf 行の grep カウント
+#   screenshot.png             screencapture が使える環境では起動 N 秒後の画面
+#   interaction_events.jsonl   --interaction で注入した操作の start/done/skipped/failed イベント
+#   interaction_summary.json   イベントと app.log を突き合わせた latency_ms / counts サマリ
+#   report.json                mode / command / env / duration / exit_status / paths / tools
 #
 # ふるまい:
 #   - 既定で `cargo build` 実行 → `target/debug/locus ...` を子プロセスで起動。
@@ -44,6 +46,9 @@
 #   --window-size WxH         macOS で起動後に front window を WIDTHxHEIGHT に
 #                             リサイズして再現スクショを撮る (#290 等の min-size
 #                             目視診断向け)
+#   --interaction NAME        起動後に注入する操作。複数回指定可。対応 NAME:
+#                             terminal-type / terminal-scroll
+#   --interaction-delay SEC   launch から interactions 開始までの待ち秒数 (default 1)
 #   --no-build                cargo build をスキップ (target/debug/locus 既存前提)
 #   -h, --help                このヘルプ
 #
@@ -83,6 +88,9 @@ options:
   --terminal-font-size VAL  LOCUS_TERMINAL_FONT_SIZE override
   --window-size WxH         macOS で起動後に front window を WIDTHxHEIGHT に
                             リサイズ (例: 1280x720)
+  --interaction NAME        起動後に注入する操作。複数回指定可。
+                            NAME: terminal-type | terminal-scroll
+  --interaction-delay SEC   launch から interactions 開始までの待ち秒数 (default 1)
   --no-build                cargo build をスキップ
   -h, --help                ヘルプ
 USAGE
@@ -143,6 +151,8 @@ write_report_json() {
         REPORT_TIMESTAMP="$TS" \
         REPORT_CMD_JSON="$CMD_ARGS_JSON" \
         REPORT_ENV_JSON="$ENV_VARS_JSON" \
+        REPORT_INTERACTIONS_JSON="${INTERACTIONS_JSON:-[]}" \
+        REPORT_INTERACTION_DELAY="$INTERACTION_DELAY" \
             "$HAS_PYTHON3_BIN" - <<'PY'
 import json, os
 
@@ -169,7 +179,8 @@ def loads_or_none(s):
 out_dir = env("REPORT_OUT_DIR")
 artifacts = {}
 for name in ("app.log", "build.log", "command.txt", "env.txt",
-             "perf_summary.txt", "screenshot.png"):
+             "perf_summary.txt", "screenshot.png",
+             "interaction_events.jsonl", "interaction_summary.json"):
     p = os.path.join(out_dir, name)
     artifacts[name] = {
         "path": p,
@@ -202,6 +213,10 @@ data = {
     },
     "command": loads_or_none(env("REPORT_CMD_JSON")) or [],
     "env_overrides": loads_or_none(env("REPORT_ENV_JSON")) or [],
+    "interactions": {
+        "requested": loads_or_none(env("REPORT_INTERACTIONS_JSON")) or [],
+        "delay_seconds": maybe_int(env("REPORT_INTERACTION_DELAY")),
+    },
     "process": {
         "pid": maybe_int(env("REPORT_APP_PID")),
         "exit_status": maybe_int(env("REPORT_APP_EXIT")),
@@ -270,6 +285,7 @@ PY
             "$([ "${HAS_SCREENCAPTURE:-0}" = 1 ] && echo true || echo false)" \
             "$([ "${HAS_OSASCRIPT:-0}" = 1 ] && echo true || echo false)" \
             "$([ "${HAS_CARGO:-0}" = 1 ] && echo true || echo false)"
+        printf '  "interactions": { "requested": [], "delay_seconds": %s },\n' "$INTERACTION_DELAY"
         printf '  "notes": %s\n' "$(json_escape_fallback "$REPORT_NOTES")"
         printf '}\n'
     } > "$report_path"
@@ -481,6 +497,359 @@ focus_app_for_screenshot() {
     fi
 }
 
+# ---- interaction injection -------------------------------------------------
+
+# 現在時刻を Unix epoch ms で返す。tracing_subscriber の RFC3339 timestamp と
+# 突き合わせるため、Python があれば time.time() で ms 精度を得る。bash 3 の
+# date には %N が無いので fallback は秒精度 (× 1000)。
+unix_ms() {
+    if [ -n "${HAS_PYTHON3_BIN:-}" ]; then
+        "$HAS_PYTHON3_BIN" -c 'import time; print(int(time.time() * 1000))' 2>/dev/null \
+            || printf '%s000' "$(date +%s)"
+    else
+        printf '%s000' "$(date +%s)"
+    fi
+}
+
+# JSONL に 1 行追記する。固定フィールド (event/name/index) と任意の
+# key=value ペアを取る。数値キー (start_unix_ms / end_unix_ms / latency_ms)
+# はそのまま number として出力し、それ以外は string として escape する。
+emit_event() {
+    local event="$1" iname="$2" iindex="$3"
+    shift 3
+    local line emitted_ms default_status
+    emitted_ms="$(unix_ms)"
+    case "$event" in
+        start) default_status="started" ;;
+        done) default_status="ok" ;;
+        skipped) default_status="skipped" ;;
+        failed) default_status="failed" ;;
+        *) default_status="$event" ;;
+    esac
+    line='{"event":'
+    line+="$(json_escape_fallback "$event")"
+    line+=',"phase":'
+    line+="$(json_escape_fallback "$event")"
+    line+=',"name":'
+    line+="$(json_escape_fallback "$iname")"
+    line+=",\"index\":$iindex"
+    line+=",\"timestamp_unix_ms\":$emitted_ms"
+    line+=',"status":'
+    line+="$(json_escape_fallback "$default_status")"
+    while [ "$#" -gt 0 ]; do
+        local pair="$1" key val
+        key="${pair%%=*}"
+        val="${pair#*=}"
+        case "$key" in
+            start_unix_ms|end_unix_ms|latency_ms|bytes_len)
+                # 数値が空 / 非数値の場合は null にフォールバック
+                case "$val" in
+                    ''|*[!0-9-]*) line+=",\"$key\":null" ;;
+                    *) line+=",\"$key\":$val" ;;
+                esac
+                ;;
+            *)
+                line+=",\"$key\":"
+                line+="$(json_escape_fallback "$val")"
+                ;;
+        esac
+        shift
+    done
+    line+='}'
+    printf '%s\n' "$line" >> "$INTERACTION_EVENTS"
+}
+
+inject_terminal_type() {
+    local idx="$1"
+    local start_ms
+    start_ms="$(unix_ms)"
+
+    if [ -z "${APP_PID:-}" ] || ! kill -0 "$APP_PID" 2>/dev/null; then
+        emit_event "skipped" "terminal-type" "$idx" \
+            "start_unix_ms=$start_ms" "reason=app_not_running"
+        return
+    fi
+    if [ "${HAS_OSASCRIPT:-0}" -ne 1 ]; then
+        emit_event "skipped" "terminal-type" "$idx" \
+            "start_unix_ms=$start_ms" "reason=no_osascript"
+        return
+    fi
+
+    # bytes_len は app 側 (terminal/mod.rs) の "terminal input forwarded" だけが
+    # 出す。注入文字列そのものは ここの interaction_events にだけ書き、app.log
+    # には keystroke の結果として bytes_len のみが流れる。
+    local payload="locus-diagnostic-input"
+    emit_event "start" "terminal-type" "$idx" \
+        "start_unix_ms=$start_ms" "detail=type '$payload' + return"
+
+    if osascript \
+        -e "tell application \"System Events\"" \
+        -e "    tell (first application process whose unix id is $APP_PID)" \
+        -e "        set frontmost to true" \
+        -e "    end tell" \
+        -e "    delay 0.2" \
+        -e "    keystroke \"$payload\"" \
+        -e "    key code 36" \
+        -e "end tell" >/dev/null 2>&1; then
+        local end_ms
+        end_ms="$(unix_ms)"
+        emit_event "done" "terminal-type" "$idx" \
+            "start_unix_ms=$start_ms" "end_unix_ms=$end_ms" \
+            "bytes_len=$((${#payload} + 1))"
+    else
+        emit_event "failed" "terminal-type" "$idx" \
+            "start_unix_ms=$start_ms" "reason=osascript_failed"
+    fi
+}
+
+inject_terminal_scroll() {
+    local idx="$1"
+    local start_ms
+    start_ms="$(unix_ms)"
+
+    if [ -z "${APP_PID:-}" ] || ! kill -0 "$APP_PID" 2>/dev/null; then
+        emit_event "skipped" "terminal-scroll" "$idx" \
+            "start_unix_ms=$start_ms" "reason=app_not_running"
+        return
+    fi
+    if [ -z "${HAS_PYTHON3_BIN:-}" ]; then
+        emit_event "skipped" "terminal-scroll" "$idx" \
+            "start_unix_ms=$start_ms" "reason=no_python3"
+        return
+    fi
+
+    # focus は best-effort: scroll wheel event は HID 層で post されるため、
+    # 対象 window が前面でないとロケータ次第で別 app に届く可能性がある。
+    if [ "${HAS_OSASCRIPT:-0}" -eq 1 ]; then
+        osascript \
+            -e "tell application \"System Events\" to set frontmost of (first application process whose unix id is $APP_PID) to true" \
+            >/dev/null 2>&1 || true
+        sleep 0.2
+    fi
+
+    emit_event "start" "terminal-scroll" "$idx" \
+        "start_unix_ms=$start_ms" "detail=post 6 scroll wheel events (line, dy=-3)"
+
+    "$HAS_PYTHON3_BIN" - >/dev/null 2>&1 <<'PY'
+import sys, time
+try:
+    import Quartz
+except ImportError:
+    sys.exit(11)
+for _ in range(6):
+    e = Quartz.CGEventCreateScrollWheelEvent(
+        None, Quartz.kCGScrollEventUnitLine, 1, -3
+    )
+    if e is None:
+        sys.exit(20)
+    Quartz.CGEventPost(Quartz.kCGHIDEventTap, e)
+    time.sleep(0.05)
+PY
+    local rc=$?
+    case "$rc" in
+        0)
+            local end_ms
+            end_ms="$(unix_ms)"
+            emit_event "done" "terminal-scroll" "$idx" \
+                "start_unix_ms=$start_ms" "end_unix_ms=$end_ms"
+            ;;
+        11)
+            emit_event "skipped" "terminal-scroll" "$idx" \
+                "start_unix_ms=$start_ms" "reason=no_quartz"
+            ;;
+        *)
+            emit_event "failed" "terminal-scroll" "$idx" \
+                "start_unix_ms=$start_ms" "reason=quartz_post_failed"
+            ;;
+    esac
+}
+
+run_interactions() {
+    [ "${#INTERACTIONS[@]}" -gt 0 ] || return
+    local i=0 name
+    for name in "${INTERACTIONS[@]}"; do
+        case "$name" in
+            terminal-type)   inject_terminal_type "$i" ;;
+            terminal-scroll) inject_terminal_scroll "$i" ;;
+            *)
+                # 未対応 NAME は parse 段階で die しているため到達しないが
+                # 防衛的に残す。
+                local _start_ms
+                _start_ms="$(unix_ms)"
+                emit_event "skipped" "$name" "$i" \
+                    "start_unix_ms=$_start_ms" "reason=unknown_interaction"
+                ;;
+        esac
+        i=$((i + 1))
+        # 連続した interaction が同フレームに混ざらないよう少しだけ間を空ける
+        sleep 0.2
+    done
+}
+
+# events と app.log を突き合わせて latency_ms / counts を JSON で出す。
+# Python があるときに完全版、無いときは skip note 入りの最小 JSON。
+write_interaction_summary() {
+    if [ -n "${HAS_PYTHON3_BIN:-}" ]; then
+        APP_LOG="$APP_LOG" \
+        EVENTS_FILE="$INTERACTION_EVENTS" \
+        SUMMARY_FILE="$INTERACTION_SUMMARY" \
+        REQUESTED_INTERACTIONS_JSON="${INTERACTIONS_JSON:-[]}" \
+        INTERACTION_DELAY_SEC="$INTERACTION_DELAY" \
+            "$HAS_PYTHON3_BIN" - <<'PY'
+import json, os, re
+from datetime import datetime
+
+app_log = os.environ.get("APP_LOG") or ""
+events_path = os.environ.get("EVENTS_FILE") or ""
+summary_path = os.environ.get("SUMMARY_FILE") or ""
+
+try:
+    requested = json.loads(os.environ.get("REQUESTED_INTERACTIONS_JSON") or "[]")
+except json.JSONDecodeError:
+    requested = []
+
+events = []
+if events_path and os.path.exists(events_path):
+    with open(events_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+# tracing_subscriber default fmt の RFC3339 timestamp ("...Z") を
+# Unix epoch ms に変換する。マッチしない行は黙って捨てる。
+TS_RE = re.compile(r'^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\s')
+
+def parse_ts(ts):
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return int(dt.timestamp() * 1000)
+
+forwarded = []
+render_hits = []
+if app_log and os.path.exists(app_log):
+    with open(app_log, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            m = TS_RE.match(line)
+            if not m:
+                continue
+            ums = parse_ts(m.group(1))
+            if ums is None:
+                continue
+            if "terminal input forwarded" in line:
+                forwarded.append(ums)
+            if "terminal render tick" in line or "terminal render idle flush" in line:
+                render_hits.append(ums)
+
+def first_after(items, threshold):
+    for ums in items:
+        if ums >= threshold:
+            return ums
+    return None
+
+# events を index ごとに集約。done/skipped/failed が start を上書きしないよう
+# start_unix_ms は最初に来た値を優先する。
+agg = {}
+for ev in events:
+    idx = ev.get("index")
+    if idx is None:
+        continue
+    a = agg.setdefault(idx, {
+        "index": idx,
+        "name": ev.get("name"),
+        "status": "unknown",
+        "start_unix_ms": None,
+        "end_unix_ms": None,
+        "injection_duration_ms": None,
+        "latency_ms": None,
+        "match_keyword": None,
+        "reason": None,
+        "detail": None,
+    })
+    if ev.get("name"):
+        a["name"] = ev["name"]
+    s_ms = ev.get("start_unix_ms")
+    if a["start_unix_ms"] is None and s_ms is not None:
+        a["start_unix_ms"] = s_ms
+    if ev.get("event") == "start":
+        if a["status"] in ("unknown",):
+            a["status"] = "started"
+        if ev.get("detail"):
+            a["detail"] = ev["detail"]
+    elif ev.get("event") == "done":
+        a["status"] = ev.get("status") or "ok"
+        if ev.get("end_unix_ms") is not None:
+            a["end_unix_ms"] = ev["end_unix_ms"]
+    elif ev.get("event") == "skipped":
+        a["status"] = "skipped"
+        a["reason"] = ev.get("reason")
+    elif ev.get("event") == "failed":
+        a["status"] = "failed"
+        a["reason"] = ev.get("reason")
+
+# latency 計算: ok/started のときだけ意味がある。
+for a in agg.values():
+    if a["start_unix_ms"] is not None and a["end_unix_ms"] is not None:
+        a["injection_duration_ms"] = a["end_unix_ms"] - a["start_unix_ms"]
+    if a["status"] not in ("ok", "started"):
+        continue
+    start = a["start_unix_ms"]
+    if start is None:
+        continue
+    if a["name"] == "terminal-type":
+        hit = first_after(forwarded, start)
+        if hit is not None:
+            a["latency_ms"] = hit - start
+            a["match_keyword"] = "terminal input forwarded"
+    elif a["name"] == "terminal-scroll":
+        hit = first_after(render_hits, start)
+        if hit is not None:
+            a["latency_ms"] = hit - start
+            a["match_keyword"] = "terminal render tick|terminal render idle flush"
+
+ordered = [agg[k] for k in sorted(agg.keys())]
+events_total = len(ordered)
+skipped = sum(1 for a in ordered if a["status"] == "skipped")
+failed = sum(1 for a in ordered if a["status"] == "failed")
+
+out = {
+    "schema_version": 1,
+    "requested": requested,
+    "interaction_delay_seconds": int(os.environ.get("INTERACTION_DELAY_SEC") or 0),
+    "interactions": ordered,
+    "counts": {
+        "events_total": events_total,
+        "skipped": skipped,
+        "failed": failed,
+    },
+}
+
+with open(summary_path, "w", encoding="utf-8") as f:
+    json.dump(out, f, ensure_ascii=False, indent=2)
+    f.write("\n")
+PY
+        return
+    fi
+
+    # Python 不在: 最低限の skip JSON を残しておく
+    {
+        printf '{\n'
+        printf '  "schema_version": 1,\n'
+        printf '  "requested": [],\n'
+        printf '  "interaction_delay_seconds": %s,\n' "$INTERACTION_DELAY"
+        printf '  "interactions": [],\n'
+        printf '  "counts": { "events_total": 0, "skipped": 0, "failed": 0 },\n'
+        printf '  "notes": "skipped: python3 not available"\n'
+        printf '}\n'
+    } > "$INTERACTION_SUMMARY"
+}
+
 # ---- arg parsing -----------------------------------------------------------
 
 MODE=""
@@ -497,6 +866,8 @@ TERMINAL_FONT_SIZE=""
 WINDOW_SIZE=""
 WINDOW_WIDTH=""
 WINDOW_HEIGHT=""
+INTERACTIONS=()
+INTERACTION_DELAY=1
 NO_BUILD=0
 
 if [ "$#" -lt 1 ]; then
@@ -593,6 +964,18 @@ while [ "$#" -gt 0 ]; do
             WINDOW_SIZE="$1"
             shift
             ;;
+        --interaction)
+            shift
+            [ "$#" -gt 0 ] || die "--interaction requires a value (terminal-type | terminal-scroll)"
+            INTERACTIONS+=("$1")
+            shift
+            ;;
+        --interaction-delay)
+            shift
+            [ "$#" -gt 0 ] || die "--interaction-delay requires a value"
+            INTERACTION_DELAY="$1"
+            shift
+            ;;
         --no-build)
             NO_BUILD=1
             shift
@@ -610,6 +993,20 @@ done
 case "$DURATION" in
     ''|*[!0-9]*) die "--duration must be a non-negative integer (got: $DURATION)" ;;
 esac
+
+case "$INTERACTION_DELAY" in
+    ''|*[!0-9]*) die "--interaction-delay must be a non-negative integer (got: $INTERACTION_DELAY)" ;;
+esac
+
+if [ "${#INTERACTIONS[@]}" -gt 0 ]; then
+    for _name in "${INTERACTIONS[@]}"; do
+        case "$_name" in
+            terminal-type|terminal-scroll) ;;
+            *) die "--interaction must be one of: terminal-type, terminal-scroll (got: $_name)" ;;
+        esac
+    done
+    unset _name
+fi
 
 if [ -n "$WINDOW_SIZE" ]; then
     case "$WINDOW_SIZE" in
@@ -643,6 +1040,8 @@ COMMAND_TXT="$OUT_DIR/command.txt"
 ENV_TXT="$OUT_DIR/env.txt"
 PERF_SUMMARY="$OUT_DIR/perf_summary.txt"
 SCREENSHOT="$OUT_DIR/screenshot.png"
+INTERACTION_EVENTS="$OUT_DIR/interaction_events.jsonl"
+INTERACTION_SUMMARY="$OUT_DIR/interaction_summary.json"
 REPORT_JSON="$OUT_DIR/report.json"
 
 REPORT_NOTES=""
@@ -681,6 +1080,12 @@ command -v cargo >/dev/null 2>&1 && HAS_CARGO=1
     printf '# font_family: %s\n' "$FONT_FAMILY"
     printf '# terminal_font_size: %s\n' "$TERMINAL_FONT_SIZE"
     printf '# window_size: %s\n' "$WINDOW_SIZE"
+    if [ "${#INTERACTIONS[@]}" -gt 0 ]; then
+        printf '# interactions: %s\n' "${INTERACTIONS[*]}"
+    else
+        printf '# interactions:\n'
+    fi
+    printf '# interaction_delay: %s\n' "$INTERACTION_DELAY"
     printf '# no_build: %s\n' "$NO_BUILD"
 } > "$COMMAND_TXT"
 
@@ -742,9 +1147,15 @@ esac
 if [ -n "$HAS_PYTHON3_BIN" ]; then
     CMD_ARGS_JSON="$(to_json_array "${CMD_ARGS[@]}")"
     ENV_VARS_JSON="$(to_json_array "${ENV_VARS[@]}")"
+    if [ "${#INTERACTIONS[@]}" -gt 0 ]; then
+        INTERACTIONS_JSON="$(to_json_array "${INTERACTIONS[@]}")"
+    else
+        INTERACTIONS_JSON="[]"
+    fi
 else
     CMD_ARGS_JSON="[]"
     ENV_VARS_JSON="[]"
+    INTERACTIONS_JSON="[]"
 fi
 
 # command.txt に最終的な argv / env も追記
@@ -770,10 +1181,25 @@ env "${ENV_VARS[@]}" "${CMD_ARGS[@]}" > "$APP_LOG" 2>&1 &
 APP_PID=$!
 APP_TERMINATION="running"
 
-log "launched pid=$APP_PID; sleeping ${DURATION}s"
+log "launched pid=$APP_PID"
 
-# DURATION が 0 でも sleep 0 を呼ぶと一瞬で抜けるだけで安全。
-sleep "$DURATION"
+# DURATION が 0 でも sleep 0 を呼ぶと一瞬で抜けるだけで安全。interactions が
+# 指定されていれば INTERACTION_DELAY 秒待って注入し、残り duration を sleep。
+# interactions 未指定なら従来通り duration 全部 sleep。
+if [ "${#INTERACTIONS[@]}" -gt 0 ]; then
+    : > "$INTERACTION_EVENTS"
+    log "sleeping ${INTERACTION_DELAY}s before interactions: ${INTERACTIONS[*]}"
+    sleep "$INTERACTION_DELAY"
+    run_interactions
+    REMAINING_DURATION=$((DURATION - INTERACTION_DELAY))
+    if [ "$REMAINING_DURATION" -gt 0 ]; then
+        log "sleeping remaining ${REMAINING_DURATION}s after interactions"
+        sleep "$REMAINING_DURATION"
+    fi
+else
+    log "sleeping ${DURATION}s"
+    sleep "$DURATION"
+fi
 
 # 既に死んでいたら exit code を読み、screenshot は試みない。
 # `wait` の終了コードを `APP_EXIT` に取りたいので、`|| true` を挟まない
@@ -855,6 +1281,9 @@ esac
         "preview refreshed" \
         "terminal resized" \
         "terminal resize failed" \
+        "terminal input forwarded" \
+        "terminal render tick" \
+        "terminal render idle flush" \
         "window session saved" \
         "pr session saved" \
         "pr switch fetch completed" \
@@ -873,7 +1302,7 @@ esac
     printf '\n'
     printf '== matched lines ==\n'
     if [ -f "$APP_LOG" ]; then
-        grep -E -- 'typography configured|preview refreshed|terminal resized|terminal resize failed|window session saved|pr session saved|pr switch fetch completed|linked issues fetched|initial hydrate snapshot\+list fetched|initial hydrate completed|initial hydrate snapshot failed' \
+        grep -E -- 'typography configured|preview refreshed|terminal resized|terminal resize failed|terminal input forwarded|terminal render tick|terminal render idle flush|window session saved|pr session saved|pr switch fetch completed|linked issues fetched|initial hydrate snapshot\+list fetched|initial hydrate completed|initial hydrate snapshot failed' \
             "$APP_LOG" 2>/dev/null \
             | head -n 200 \
             || printf '  (no matching debug lines found)\n'
@@ -889,6 +1318,12 @@ esac
     fi
 } > "$PERF_SUMMARY"
 
+# interaction_summary.json — events file が無い (interactions 未指定) でも
+# Python があれば空の interactions / counts を持つ JSON を出す。
+if [ "${#INTERACTIONS[@]}" -gt 0 ] || [ -f "$INTERACTION_EVENTS" ]; then
+    write_interaction_summary
+fi
+
 # report.json
 write_report_json "$REPORT_JSON"
 
@@ -896,5 +1331,7 @@ log "done. artifacts:"
 log "  $REPORT_JSON"
 log "  $APP_LOG"
 log "  $PERF_SUMMARY"
+[ -f "$INTERACTION_EVENTS" ]  && log "  $INTERACTION_EVENTS"
+[ -f "$INTERACTION_SUMMARY" ] && log "  $INTERACTION_SUMMARY"
 [ "$SCREENSHOT_STATUS" = "ok" ] && log "  $SCREENSHOT"
 exit "$FINAL_EXIT"

--- a/scripts/diagnose_ui.sh
+++ b/scripts/diagnose_ui.sh
@@ -48,6 +48,8 @@
 #                             目視診断向け)
 #   --interaction NAME        起動後に注入する操作。複数回指定可。対応 NAME:
 #                             terminal-type / terminal-scroll
+#                             terminal-scroll は Python Quartz
+#                             (pyobjc-framework-Quartz) がある macOS で有効
 #   --interaction-delay SEC   launch から interactions 開始までの待ち秒数 (default 1)
 #   --no-build                cargo build をスキップ (target/debug/locus 既存前提)
 #   -h, --help                このヘルプ
@@ -90,6 +92,8 @@ options:
                             リサイズ (例: 1280x720)
   --interaction NAME        起動後に注入する操作。複数回指定可。
                             NAME: terminal-type | terminal-scroll
+                            terminal-scroll requires Python Quartz
+                            (pyobjc-framework-Quartz) on macOS; otherwise skipped.
   --interaction-delay SEC   launch から interactions 開始までの待ち秒数 (default 1)
   --no-build                cargo build をスキップ
   -h, --help                ヘルプ

--- a/scripts/diagnose_ui.sh
+++ b/scripts/diagnose_ui.sh
@@ -12,7 +12,7 @@
 #   perf_summary.txt           LOCUS_LOG=debug が吐く主要 perf 行の grep カウント
 #   screenshot.png             screencapture が使える環境では起動 N 秒後の画面
 #   interaction_events.jsonl   --interaction で注入した操作の start/done/skipped/failed イベント
-#   interaction_summary.json   イベントと app.log を突き合わせた latency_ms / counts サマリ
+#   interaction_summary.json   イベントと app.log を突き合わせた latency_ms / observed counts サマリ
 #   report.json                mode / command / env / duration / exit_status / paths / tools
 #
 # ふるまい:
@@ -817,6 +817,9 @@ for ev in events:
         "injection_duration_ms": None,
         "latency_ms": None,
         "match_keyword": None,
+        "observed": False,
+        "observation_status": "pending",
+        "observation_reason": None,
         "reason": None,
         "detail": None,
     })
@@ -845,31 +848,64 @@ for ev in events:
 for a in agg.values():
     if a["start_unix_ms"] is not None and a["end_unix_ms"] is not None:
         a["injection_duration_ms"] = a["end_unix_ms"] - a["start_unix_ms"]
+    if a["status"] == "skipped":
+        a["observation_status"] = "skipped"
+        a["observation_reason"] = a["reason"]
+        continue
+    if a["status"] == "failed":
+        a["observation_status"] = "failed"
+        a["observation_reason"] = a["reason"]
+        continue
     if a["status"] not in ("ok", "started"):
+        a["observation_status"] = "unknown"
         continue
     start = a["start_unix_ms"]
     if start is None:
+        a["observation_status"] = "unmatched"
+        a["observation_reason"] = "missing_start_timestamp"
         continue
     if a["name"] == "terminal-type":
         hit = first_after(forwarded, start)
         if hit is not None:
             a["latency_ms"] = hit - start
             a["match_keyword"] = "terminal input forwarded"
+        else:
+            a["observation_status"] = "unmatched"
+            a["observation_reason"] = "no terminal input forwarded log after injection"
     elif a["name"] == "terminal-scroll":
         hit = first_after(render_hits, start)
         if hit is not None:
             a["latency_ms"] = hit - start
             a["match_keyword"] = "terminal render tick|terminal render idle flush"
+        else:
+            a["observation_status"] = "unmatched"
+            a["observation_reason"] = "no terminal render tick/idle flush log after injection"
     elif a["name"] == "file-switch-next":
         hit = first_after(file_switch_hits, start)
         if hit is not None:
             a["latency_ms"] = hit - start
             a["match_keyword"] = "file switch requested"
+        else:
+            a["observation_status"] = "unmatched"
+            a["observation_reason"] = "no file switch requested log after injection"
+    else:
+        a["observation_status"] = "unknown"
+        a["observation_reason"] = "unknown_interaction"
+    if a["latency_ms"] is not None:
+        a["observed"] = True
+        a["observation_status"] = "matched"
+        a["observation_reason"] = None
 
 ordered = [agg[k] for k in sorted(agg.keys())]
 events_total = len(ordered)
 skipped = sum(1 for a in ordered if a["status"] == "skipped")
 failed = sum(1 for a in ordered if a["status"] == "failed")
+observed = sum(1 for a in ordered if a["observed"])
+unobserved = sum(
+    1
+    for a in ordered
+    if a["status"] in ("ok", "started") and not a["observed"]
+)
 
 out = {
     "schema_version": 1,
@@ -880,6 +916,8 @@ out = {
         "events_total": events_total,
         "skipped": skipped,
         "failed": failed,
+        "observed": observed,
+        "unobserved": unobserved,
     },
 }
 
@@ -1348,6 +1386,7 @@ esac
         "terminal resized" \
         "terminal resize failed" \
         "terminal input forwarded" \
+        "terminal input forward failed" \
         "terminal render tick" \
         "terminal render idle flush" \
         "file switch requested" \
@@ -1370,7 +1409,7 @@ esac
     printf '\n'
     printf '== matched lines ==\n'
     if [ -f "$APP_LOG" ]; then
-        grep -E -- 'typography configured|preview refreshed|terminal resized|terminal resize failed|terminal input forwarded|terminal render tick|terminal render idle flush|file switch requested|diagnostic file switch|window session saved|pr session saved|pr switch fetch completed|linked issues fetched|initial hydrate snapshot\+list fetched|initial hydrate completed|initial hydrate snapshot failed' \
+        grep -E -- 'typography configured|preview refreshed|terminal resized|terminal resize failed|terminal input forwarded|terminal input forward failed|terminal render tick|terminal render idle flush|file switch requested|diagnostic file switch|window session saved|pr session saved|pr switch fetch completed|linked issues fetched|initial hydrate snapshot\+list fetched|initial hydrate completed|initial hydrate snapshot failed' \
             "$APP_LOG" 2>/dev/null \
             | head -n 200 \
             || printf '  (no matching debug lines found)\n'

--- a/scripts/diagnose_ui.sh
+++ b/scripts/diagnose_ui.sh
@@ -518,6 +518,15 @@ unix_ms() {
     fi
 }
 
+sleep_ms() {
+    local ms="$1"
+    case "$ms" in
+        ''|*[!0-9]*) return ;;
+    esac
+    [ "$ms" -gt 0 ] || return
+    sleep "$((ms / 1000)).$(printf '%03d' "$((ms % 1000))")"
+}
+
 # JSONL に 1 行追記する。固定フィールド (event/name/index) と任意の
 # key=value ペアを取る。数値キー (start_unix_ms / end_unix_ms / latency_ms)
 # はそのまま number として出力し、それ以外は string として escape する。
@@ -691,7 +700,11 @@ PY
 inject_file_switch_next() {
     local idx="$1"
     local start_ms
-    start_ms="$(unix_ms)"
+    if [ -n "${RUN_START_MS:-}" ] && [ -n "${FILE_SWITCH_TRIGGER_OFFSET_MS:-}" ]; then
+        start_ms="$((RUN_START_MS + FILE_SWITCH_TRIGGER_OFFSET_MS))"
+    else
+        start_ms="$(unix_ms)"
+    fi
 
     if [ "$MODE" != "github" ]; then
         emit_event "skipped" "file-switch-next" "$idx" \
@@ -1206,6 +1219,8 @@ WINDOW_ID=""
 WINDOW_ID_STATUS="skipped"
 BUILD_STATUS="skipped"
 BIN="target/debug/locus"
+RUN_START_MS=""
+FILE_SWITCH_TRIGGER_OFFSET_MS=""
 
 # tool availability
 HAS_PYTHON3_BIN="$(command -v python3 || true)"
@@ -1296,8 +1311,9 @@ fi
 for _interaction in "${INTERACTIONS[@]}"; do
     if [ "$_interaction" = "file-switch-next" ]; then
         # app 側 single-shot timer が file-switch-requested callback を発火する。
-        # script 側 event start よりわずかに後に出るよう +250ms しておく。
-        ENV_VARS+=("LOCUS_DIAG_FILE_SWITCH_AFTER_MS=$((INTERACTION_DELAY * 1000 + 250))")
+        # script 側 event start はこの timer の予定発火時刻に合わせる。
+        FILE_SWITCH_TRIGGER_OFFSET_MS=$((INTERACTION_DELAY * 1000))
+        ENV_VARS+=("LOCUS_DIAG_FILE_SWITCH_AFTER_MS=$FILE_SWITCH_TRIGGER_OFFSET_MS")
     fi
 done
 unset _interaction
@@ -1343,6 +1359,7 @@ log "out-dir: $OUT_DIR"
 env "${ENV_VARS[@]}" "${CMD_ARGS[@]}" > "$APP_LOG" 2>&1 &
 APP_PID=$!
 APP_TERMINATION="running"
+RUN_START_MS="$(unix_ms)"
 
 log "launched pid=$APP_PID"
 
@@ -1352,12 +1369,15 @@ log "launched pid=$APP_PID"
 if [ "${#INTERACTIONS[@]}" -gt 0 ]; then
     : > "$INTERACTION_EVENTS"
     log "sleeping ${INTERACTION_DELAY}s before interactions: ${INTERACTIONS[*]}"
-    sleep "$INTERACTION_DELAY"
+    sleep_ms "$((INTERACTION_DELAY * 1000))"
     run_interactions
-    REMAINING_DURATION=$((DURATION - INTERACTION_DELAY))
-    if [ "$REMAINING_DURATION" -gt 0 ]; then
-        log "sleeping remaining ${REMAINING_DURATION}s after interactions"
-        sleep "$REMAINING_DURATION"
+    NOW_MS="$(unix_ms)"
+    REMAINING_MS=$((RUN_START_MS + (DURATION * 1000) - NOW_MS))
+    if [ "$REMAINING_MS" -gt 0 ]; then
+        log "sleeping remaining ${REMAINING_MS}ms after interactions"
+        sleep_ms "$REMAINING_MS"
+    else
+        log "duration already elapsed after interactions"
     fi
 else
     log "sleeping ${DURATION}s"

--- a/scripts/diagnose_ui.sh
+++ b/scripts/diagnose_ui.sh
@@ -94,7 +94,8 @@ options:
                             NAME: terminal-type | terminal-scroll | file-switch-next
                             terminal-scroll requires Python Quartz
                             (pyobjc-framework-Quartz) on macOS; otherwise skipped.
-                            file-switch-next は app-side single-shot のため 1 回のみ指定可。
+                            file-switch-next は app-side single-shot のため
+                            1 回のみ、かつ単独指定のみ可。
   --interaction-delay SEC   launch から interactions 開始までの待ち秒数 (default 1)。
                             --interaction 指定時は --duration 以下であること。
   --no-build                cargo build をスキップ
@@ -1148,6 +1149,9 @@ if [ "${#INTERACTIONS[@]}" -gt 0 ]; then
             *) die "--interaction must be one of: terminal-type, terminal-scroll, file-switch-next (got: $_name)" ;;
         esac
     done
+    if [ "$_file_switch_count" -eq 1 ] && [ "${#INTERACTIONS[@]}" -gt 1 ]; then
+        die "--interaction file-switch-next must be used alone (app-side timer is armed from launch)"
+    fi
     unset _name _file_switch_count
 fi
 

--- a/scripts/diagnose_ui.sh
+++ b/scripts/diagnose_ui.sh
@@ -537,7 +537,10 @@ emit_event() {
     line+=',"name":'
     line+="$(json_escape_fallback "$iname")"
     line+=",\"index\":$iindex"
-    line+=",\"timestamp_unix_ms\":$emitted_ms"
+    case "$emitted_ms" in
+        ''|*[!0-9-]*) line+=',"timestamp_unix_ms":null' ;;
+        *) line+=",\"timestamp_unix_ms\":$emitted_ms" ;;
+    esac
     line+=',"status":'
     line+="$(json_escape_fallback "$default_status")"
     while [ "$#" -gt 0 ]; do

--- a/src/app/diagnostics.rs
+++ b/src/app/diagnostics.rs
@@ -39,7 +39,7 @@ fn schedule_diagnostic_file_switch(ui: &DiffViewerWindow, delay: Duration, attem
             from = current,
             to = next,
             files = count,
-            "diagnostic file switch requested"
+            "diagnostic file switch triggered"
         );
         ui.invoke_file_switch_requested(next);
     });

--- a/src/app/diagnostics.rs
+++ b/src/app/diagnostics.rs
@@ -1,0 +1,60 @@
+//! 実機診断ハーネス (`scripts/diagnose_ui.sh`) から使う UI 操作注入。
+//!
+//! 通常起動では環境変数が無い限り何もしない。LLM が `--interaction` 付き
+//! diagnostics を実行したときだけ、アプリ側でしか安定して発火できない操作
+//! (diff viewer の file switch など) を timer 経由で起こす。
+
+use std::time::Duration;
+
+use slint::{ComponentHandle, Model};
+
+use crate::DiffViewerWindow;
+
+fn schedule_diagnostic_file_switch(ui: &DiffViewerWindow, delay: Duration, attempts_left: u8) {
+    let ui_weak = ui.as_weak();
+    slint::Timer::single_shot(delay, move || {
+        let Some(ui) = ui_weak.upgrade() else { return };
+        let files = ui.get_files();
+        let count = files.row_count();
+        if count <= 1 {
+            if attempts_left > 0 {
+                schedule_diagnostic_file_switch(
+                    &ui,
+                    Duration::from_millis(250),
+                    attempts_left - 1,
+                );
+            } else {
+                tracing::debug!(files = count, "diagnostic file switch skipped");
+            }
+            return;
+        }
+
+        let current = ui.get_selected_file_index().max(0);
+        let next = if (current as usize) + 1 < count {
+            current + 1
+        } else {
+            0
+        };
+        tracing::debug!(
+            from = current,
+            to = next,
+            files = count,
+            "diagnostic file switch requested"
+        );
+        ui.invoke_file_switch_requested(next);
+    });
+}
+
+/// 診断用 interaction を必要に応じて arm する。
+///
+/// 現在は `LOCUS_DIAG_FILE_SWITCH_AFTER_MS` が指定された diff viewer run で、
+/// file list が hydrate され次第 `file-switch-requested` を 1 回発火させる。
+pub(crate) fn schedule_diagnostic_interactions(ui: &DiffViewerWindow) {
+    let Some(delay_ms) = std::env::var("LOCUS_DIAG_FILE_SWITCH_AFTER_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+    else {
+        return;
+    };
+    schedule_diagnostic_file_switch(ui, Duration::from_millis(delay_ms), 20);
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
 //! アプリケーション層 (Slint UI を駆動するロジック)。
 
+pub(crate) mod diagnostics;
 pub(crate) mod diff_viewer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
-use slint::{ComponentHandle, Model, SharedString};
+use slint::{ComponentHandle, SharedString};
 
 slint::include_modules!();
 
@@ -24,6 +24,7 @@ mod terminal;
 mod ui_state;
 
 use app::diff_viewer::linked_issues::fetch_linked_issues_parallel;
+use app::diagnostics::schedule_diagnostic_interactions;
 use app::diff_viewer::snapshot::{apply_snapshot_to_ui, build_pr_list_model};
 use app::diff_viewer::refresh::{
     append_history, refresh_current_anchor_label, refresh_draft_panel, refresh_history_panel,
@@ -154,51 +155,6 @@ fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
     ui.run()?;
     drop(pane);
     Ok(())
-}
-
-fn schedule_diagnostic_file_switch(ui: &DiffViewerWindow, delay: Duration, attempts_left: u8) {
-    let ui_weak = ui.as_weak();
-    slint::Timer::single_shot(delay, move || {
-        let Some(ui) = ui_weak.upgrade() else { return };
-        let files = ui.get_files();
-        let count = files.row_count();
-        if count <= 1 {
-            if attempts_left > 0 {
-                schedule_diagnostic_file_switch(
-                    &ui,
-                    Duration::from_millis(250),
-                    attempts_left - 1,
-                );
-            } else {
-                tracing::debug!(files = count, "diagnostic file switch skipped");
-            }
-            return;
-        }
-
-        let current = ui.get_selected_file_index().max(0);
-        let next = if (current as usize) + 1 < count {
-            current + 1
-        } else {
-            0
-        };
-        tracing::debug!(
-            from = current,
-            to = next,
-            files = count,
-            "diagnostic file switch requested"
-        );
-        ui.invoke_file_switch_requested(next);
-    });
-}
-
-fn schedule_diagnostic_interactions(ui: &DiffViewerWindow) {
-    let Some(delay_ms) = std::env::var("LOCUS_DIAG_FILE_SWITCH_AFTER_MS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-    else {
-        return;
-    };
-    schedule_diagnostic_file_switch(ui, Duration::from_millis(delay_ms), 20);
 }
 
 fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-use slint::{ComponentHandle, SharedString};
+use slint::{ComponentHandle, Model, SharedString};
 
 slint::include_modules!();
 
@@ -154,6 +154,51 @@ fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
     ui.run()?;
     drop(pane);
     Ok(())
+}
+
+fn schedule_diagnostic_file_switch(ui: &DiffViewerWindow, delay: Duration, attempts_left: u8) {
+    let ui_weak = ui.as_weak();
+    slint::Timer::single_shot(delay, move || {
+        let Some(ui) = ui_weak.upgrade() else { return };
+        let files = ui.get_files();
+        let count = files.row_count();
+        if count <= 1 {
+            if attempts_left > 0 {
+                schedule_diagnostic_file_switch(
+                    &ui,
+                    Duration::from_millis(250),
+                    attempts_left - 1,
+                );
+            } else {
+                tracing::debug!(files = count, "diagnostic file switch skipped");
+            }
+            return;
+        }
+
+        let current = ui.get_selected_file_index().max(0);
+        let next = if (current as usize) + 1 < count {
+            current + 1
+        } else {
+            0
+        };
+        tracing::debug!(
+            from = current,
+            to = next,
+            files = count,
+            "diagnostic file switch requested"
+        );
+        ui.invoke_file_switch_requested(next);
+    });
+}
+
+fn schedule_diagnostic_interactions(ui: &DiffViewerWindow) {
+    let Some(delay_ms) = std::env::var("LOCUS_DIAG_FILE_SWITCH_AFTER_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+    else {
+        return;
+    };
+    schedule_diagnostic_file_switch(ui, Duration::from_millis(delay_ms), 20);
 }
 
 fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -500,6 +545,7 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
         let repo = repo.clone();
         ui.on_file_switch_requested(move |new_idx| {
             let Some(ui) = ui_weak.upgrade() else { return };
+            let started = Instant::now();
             let old_idx = ui.get_selected_file_index() as usize;
             let cur_scroll = ui.get_diff_scroll_y();
             state.borrow_mut().scroll_positions.insert(old_idx, cur_scroll);
@@ -518,6 +564,14 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
             save_pr_session(&owner, &repo, &state.borrow(), &ui);
 
             ui.invoke_file_switched(new_idx);
+            tracing::debug!(
+                old_idx,
+                new_idx,
+                saved_scroll = cur_scroll,
+                restored_scroll = restore,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "file switch requested"
+            );
         });
     }
 
@@ -960,6 +1014,8 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
             },
         );
     }
+
+    schedule_diagnostic_interactions(&ui);
 
     ui.run()?;
     drop(position_save_timer);

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -222,16 +222,30 @@ fn spawn_core(
 }
 
 /// UI から受け取った key text を PTY に流し込むハンドラ。
+///
+/// 入力遅延診断 (#310) のために `bytes_len` と PTY write の `elapsed_us` を
+/// debug log で残すが、入力テキスト自体はパスワード等が混じり得るため絶対に
+/// log に乗せない。
 fn make_key_handler(writer: Arc<Mutex<Box<dyn Write + Send>>>) -> impl Fn(SharedString) + 'static {
     move |text: SharedString| {
         let bytes = translate_key(text.as_str());
         if bytes.is_empty() {
             return;
         }
+        let bytes_len = bytes.len();
+        let started = Instant::now();
+        let mut forwarded = false;
         if let Ok(mut w) = writer.lock() {
             let _ = w.write_all(&bytes);
             let _ = w.flush();
+            forwarded = true;
         }
+        tracing::debug!(
+            bytes_len,
+            forwarded,
+            elapsed_us = started.elapsed().as_micros() as u64,
+            "terminal input forwarded"
+        );
     }
 }
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -434,7 +434,7 @@ fn start_render_timer(
     let timer = slint::Timer::default();
     let deferred_since: Cell<Option<Instant>> = Cell::new(None);
     let trace_all_render_ticks = std::env::var("LOCUS_DIAG_TRACE_RENDER_TICKS")
-        .map(|v| v == "true" || v == "1")
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "on" | "yes"))
         .unwrap_or(false);
     timer.start(
         slint::TimerMode::Repeated,

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -9,7 +9,7 @@
 use std::cell::{Cell, RefCell};
 use std::io::{Read, Write};
 use std::rc::Rc;
-use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -18,7 +18,7 @@ use alacritty_terminal::event::{Event, EventListener};
 use alacritty_terminal::grid::Dimensions;
 use alacritty_terminal::term::{Config, Term, TermDamage};
 use alacritty_terminal::vte::ansi::{Processor, StdSyncHandler};
-use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
+use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
 use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
 use crate::ui_state::{build_row, empty_row};
@@ -432,6 +432,9 @@ fn start_render_timer(
 ) -> slint::Timer {
     let timer = slint::Timer::default();
     let deferred_since: Cell<Option<Instant>> = Cell::new(None);
+    let trace_all_render_ticks = std::env::var("LOCUS_DIAG_TRACE_RENDER_TICKS")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
     timer.start(
         slint::TimerMode::Repeated,
         Duration::from_millis(16),
@@ -518,7 +521,8 @@ fn start_render_timer(
                     drop(term_guard);
 
                     let elapsed = tick_start.elapsed();
-                    if budget_hit || elapsed >= RENDER_SLOW_TICK_THRESHOLD {
+                    if trace_all_render_ticks || budget_hit || elapsed >= RENDER_SLOW_TICK_THRESHOLD
+                    {
                         tracing::debug!(
                             chunks,
                             bytes,
@@ -773,9 +777,9 @@ fn sanitize_for_pty(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        compute_grid_size, decide_idle_action, decide_render_action, drain_with_budget,
-        encode_paste_bytes, sanitize_for_pty, translate_key, IdleTickAction, PaintDecision,
-        RenderBudget, MIN_COLS, MIN_ROWS,
+        IdleTickAction, MIN_COLS, MIN_ROWS, PaintDecision, RenderBudget, compute_grid_size,
+        decide_idle_action, decide_render_action, drain_with_budget, encode_paste_bytes,
+        sanitize_for_pty, translate_key,
     };
     use std::sync::mpsc::sync_channel;
     use std::time::{Duration, Instant};

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -248,6 +248,21 @@ fn make_key_handler(writer: Arc<Mutex<Box<dyn Write + Send>>>) -> impl Fn(Shared
     }
 }
 
+fn diag_trace_render_ticks_enabled() -> bool {
+    std::env::var("LOCUS_DIAG_TRACE_RENDER_TICKS")
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "on" | "yes"))
+        .unwrap_or(false)
+}
+
+fn make_scroll_diagnostic_handler() -> impl Fn(f32, f32) + 'static {
+    let trace_scroll_events = diag_trace_render_ticks_enabled();
+    move |delta_x, delta_y| {
+        if trace_scroll_events {
+            tracing::debug!(delta_x, delta_y, "terminal scroll event");
+        }
+    }
+}
+
 /// 1 tick あたりの VTE 処理量を制限する budget。
 ///
 /// terminal が大量に書き込んでくると VTE 処理 + row model 更新が UI thread
@@ -431,9 +446,7 @@ fn start_render_timer(
 ) -> slint::Timer {
     let timer = slint::Timer::default();
     let deferred_since: Cell<Option<Instant>> = Cell::new(None);
-    let trace_all_render_ticks = std::env::var("LOCUS_DIAG_TRACE_RENDER_TICKS")
-        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "on" | "yes"))
-        .unwrap_or(false);
+    let trace_all_render_ticks = diag_trace_render_ticks_enabled();
     timer.start(
         slint::TimerMode::Repeated,
         Duration::from_millis(16),
@@ -561,6 +574,7 @@ pub fn launch(
     ui.set_rows(ModelRc::from(core.row_model.clone()));
 
     ui.on_key_pressed(make_key_handler(core.writer.clone()));
+    ui.on_terminal_scroll_diagnostic(make_scroll_diagnostic_handler());
 
     let ui_weak = ui.as_weak();
     let timer = start_render_timer(
@@ -607,6 +621,7 @@ pub fn launch_for_diff_viewer(
     ui.set_terminal_rows(ModelRc::from(core.row_model.clone()));
 
     ui.on_terminal_key_pressed(make_key_handler(core.writer.clone()));
+    ui.on_terminal_scroll_diagnostic(make_scroll_diagnostic_handler());
 
     let ui_weak = ui.as_weak();
     let timer = start_render_timer(

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -237,16 +237,14 @@ fn make_key_handler(writer: Arc<Mutex<Box<dyn Write + Send>>>) -> impl Fn(Shared
         let started = Instant::now();
         let mut forwarded = false;
         if let Ok(mut w) = writer.lock() {
-            let _ = w.write_all(&bytes);
-            let _ = w.flush();
-            forwarded = true;
+            forwarded = w.write_all(&bytes).and_then(|_| w.flush()).is_ok();
         }
-        tracing::debug!(
-            bytes_len,
-            forwarded,
-            elapsed_us = started.elapsed().as_micros() as u64,
-            "terminal input forwarded"
-        );
+        let elapsed_us = started.elapsed().as_micros() as u64;
+        if forwarded {
+            tracing::debug!(bytes_len, elapsed_us, "terminal input forwarded");
+        } else {
+            tracing::debug!(bytes_len, elapsed_us, "terminal input forward failed");
+        }
     }
 }
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -224,8 +224,9 @@ fn spawn_core(
 /// UI から受け取った key text を PTY に流し込むハンドラ。
 ///
 /// 入力遅延診断 (#310) のために `bytes_len` と PTY write の `elapsed_us` を
-/// debug log で残すが、入力テキスト自体はパスワード等が混じり得るため絶対に
-/// log に乗せない。
+/// debug log で残す。key forwarding は sub-ms で終わることが多いため、
+/// ここだけは ms ではなく us で記録する。入力テキスト自体はパスワード等が
+/// 混じり得るため絶対に log に乗せない。
 fn make_key_handler(writer: Arc<Mutex<Box<dyn Write + Send>>>) -> impl Fn(SharedString) + 'static {
     move |text: SharedString| {
         let bytes = translate_key(text.as_str());

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -40,6 +40,7 @@ export component AppWindow inherits Window {
 
     callback key-pressed(string);
     callback resized(length, length);
+    callback terminal-scroll-diagnostic(length, length);
 
     title: @tr("locus — Terminal pane");
     preferred-width: 900px;
@@ -147,6 +148,13 @@ export component AppWindow inherits Window {
                 background: #ffffff40;
                 border-width: 1px;
                 border-color: #ffffff;
+            }
+
+            terminal-scroll-area := TouchArea {
+                scroll-event(event) => {
+                    root.terminal-scroll-diagnostic(event.delta-x, event.delta-y);
+                    reject
+                }
             }
         }
     }
@@ -294,6 +302,7 @@ export component DiffViewerWindow inherits Window {
     callback send-copy-to-clipboard(string);
     callback terminal-key-pressed(string);
     callback terminal-resized(length, length);
+    callback terminal-scroll-diagnostic(length, length);
 
     callback pr-clicked(int);
     callback pr-filter-changed(int);
@@ -1160,6 +1169,11 @@ export component DiffViewerWindow inherits Window {
                             terminal-click-area := TouchArea {
                                 clicked => {
                                     terminal-focus.focus();
+                                }
+
+                                scroll-event(event) => {
+                                    root.terminal-scroll-diagnostic(event.delta-x, event.delta-y);
+                                    reject
                                 }
                             }
                         }


### PR DESCRIPTION
## Motivation

#310 は #288 の「スクロール・入力などの操作遅延」を LLM が実機 artifact で自律確認できるようにするための診断ハーネス整備。PR #309 で terminal burst render coalescing は入ったが、操作注入と event/log 突合の artifact が不足していた。

## Changes

- `scripts/diagnose_ui.sh` に `--interaction` / `--interaction-delay` を追加。
  - `terminal-type`: macOS System Events で固定診断文字列 + Enter を注入。
  - `terminal-scroll`: Python + Quartz で scroll wheel event を注入。
  - 複数 `--interaction` 指定に対応。
- `interaction_events.jsonl` と `interaction_summary.json` を追加。
  - event/name/phase/timestamp/status/detail を JSONL に記録。
  - app.log と突合し、terminal-type → `terminal input forwarded` までの latency と injection duration を出力。
  - scroll は render tick が無いケースでは latency null としつつ injection duration/status を残す。
- `report.json` に requested interactions / delay / interaction artifacts を追加。
- `perf_summary.txt` に `terminal input forwarded`, `terminal render tick`, `terminal render idle flush` を追加。
- terminal key handler に秘匿情報を出さない debug log (`bytes_len`, `forwarded`, `elapsed_us`) を追加。

## Validation

- `rtk bash -n scripts/diagnose_ui.sh`
- `rtk rustfmt src/terminal/mod.rs`
- `rtk cargo test` — 169 passed
- `rtk cargo clippy --all-targets -- -D warnings`
- `rtk cargo build`
- no-interaction smoke:
  - `rtk bash scripts/diagnose_ui.sh terminal --no-build --no-debug-grid --duration 1 --agent-cmd /tmp/locus-sleep-agent.sh --out-dir target/locus-diagnostics/issue310-no-interaction-smoke`
- interaction実機診断:
  - `rtk bash scripts/diagnose_ui.sh terminal --no-build --no-debug-grid --duration 3 --interaction-delay 1 --interaction terminal-type --interaction terminal-scroll --window-size 1280x720 --agent-cmd /tmp/locus-interaction-agent.sh --out-dir target/locus-diagnostics/issue310-terminal-interactions-final2`

## Evidence

- `target/locus-diagnostics/issue310-terminal-interactions-final2/interaction_events.jsonl`
  - `terminal-type` / `terminal-scroll` とも `status=ok`。
- `target/locus-diagnostics/issue310-terminal-interactions-final2/interaction_summary.json`
  - `terminal-type`: `latency_ms=371`, `injection_duration_ms=397`, match=`terminal input forwarded`。
  - `terminal-scroll`: `injection_duration_ms=877`, render latency は該当 render tick が無いため null。
- `target/locus-diagnostics/issue310-terminal-interactions-final2/screenshot.png`
  - prefill lines と注入された `locus-diagnostic-input` が表示されていることを目視確認。

Refs #310
