### PR TITLE
feat(dx): add diff scroll diagnostics

### DIFF
--- a/scripts/diagnose_ui.sh
+++ b/scripts/diagnose_ui.sh
@@ -55,7 +55,8 @@
 #                             リサイズして再現スクショを撮る (#290 等の min-size
 #                             目視診断向け)
 #   --interaction NAME        起動後に注入する操作。複数回指定可。対応 NAME:
-#                             terminal-type / terminal-scroll / file-switch-next
+#                             terminal-type / terminal-scroll / diff-scroll /
+#                             file-switch-next
 #                             terminal-scroll は Python Quartz
 #                             (pyobjc-framework-Quartz) がある macOS で有効
 #   --interaction-delay SEC   launch から interactions 開始までの待ち秒数 (default 1)
@@ -107,9 +108,11 @@ options:
   --window-size WxH         macOS で起動後に front window を WIDTHxHEIGHT に
                             リサイズ (例: 1280x720)
   --interaction NAME        起動後に注入する操作。複数回指定可。
-                            NAME: terminal-type | terminal-scroll | file-switch-next
+                            NAME: terminal-type | terminal-scroll | diff-scroll | file-switch-next
                             terminal-scroll requires Python Quartz
                             (pyobjc-framework-Quartz) on macOS; otherwise skipped.
+                            diff-scroll requires github mode and uses an
+                            app-side timer for stable viewport diagnostics.
                             file-switch-next は app-side single-shot のため
                             1 回のみ、かつ単独指定のみ可。
   --interaction-delay SEC   launch から interactions 開始までの待ち秒数 (default 1)。
@@ -785,6 +788,35 @@ PY
     esac
 }
 
+inject_diff_scroll() {
+    local idx="$1"
+    local start_ms
+
+    if [ "$MODE" != "github" ]; then
+        start_ms="$(unix_ms)"
+        emit_event "skipped" "diff-scroll" "$idx" \
+            "start_unix_ms=$start_ms" "reason=requires_github_mode"
+        return
+    fi
+    if [ -z "${APP_PID:-}" ] || ! kill -0 "$APP_PID" 2>/dev/null; then
+        start_ms="$(unix_ms)"
+        emit_event "skipped" "diff-scroll" "$idx" \
+            "start_unix_ms=$start_ms" "reason=app_not_running"
+        return
+    fi
+
+    if [ -n "${RUN_START_MS:-}" ] && [ -n "${DIFF_SCROLL_TRIGGER_OFFSET_MS:-}" ]; then
+        start_ms="$((RUN_START_MS + DIFF_SCROLL_TRIGGER_OFFSET_MS))"
+    else
+        start_ms="$(unix_ms)"
+    fi
+    emit_event "start" "diff-scroll" "$idx" \
+        "start_unix_ms=$start_ms" "detail=app-side diagnostic timer scrolls diff viewport"
+    emit_event "done" "diff-scroll" "$idx" \
+        "start_unix_ms=$start_ms" "end_unix_ms=$(unix_ms)" \
+        "detail=armed via LOCUS_DIAG_DIFF_SCROLL_AFTER_MS"
+}
+
 inject_file_switch_next() {
     local idx="$1"
     local start_ms
@@ -819,6 +851,7 @@ run_interactions() {
         case "$name" in
             terminal-type)   inject_terminal_type "$i" ;;
             terminal-scroll) inject_terminal_scroll "$i" ;;
+            diff-scroll)     inject_diff_scroll "$i" ;;
             file-switch-next) inject_file_switch_next "$i" ;;
             *)
                 # 未対応 NAME は parse 段階で die しているため到達しないが
@@ -883,6 +916,7 @@ def parse_ts(ts):
 forwarded = []
 render_hits = []
 scroll_hits = []
+diff_scroll_hits = []
 file_switch_hits = []
 if app_log and os.path.exists(app_log):
     with open(app_log, "r", encoding="utf-8", errors="replace") as f:
@@ -899,6 +933,8 @@ if app_log and os.path.exists(app_log):
                 render_hits.append(ums)
             if "terminal scroll event" in line:
                 scroll_hits.append(ums)
+            if "diff scroll event" in line:
+                diff_scroll_hits.append(ums)
             if "file switch requested" in line:
                 file_switch_hits.append(ums)
 
@@ -987,6 +1023,14 @@ for a in agg.values():
         else:
             a["observation_status"] = "unmatched"
             a["observation_reason"] = "no terminal scroll event log after injection"
+    elif a["name"] == "diff-scroll":
+        hit = first_after(diff_scroll_hits, start)
+        if hit is not None:
+            a["latency_ms"] = hit - start
+            a["match_keyword"] = "diff scroll event"
+        else:
+            a["observation_status"] = "unmatched"
+            a["observation_reason"] = "no diff scroll event log after injection"
     elif a["name"] == "file-switch-next":
         hit = first_after(file_switch_hits, start)
         if hit is not None:
@@ -1229,7 +1273,7 @@ while [ "$#" -gt 0 ]; do
             ;;
         --interaction)
             shift
-            [ "$#" -gt 0 ] || die "--interaction requires a value (terminal-type | terminal-scroll | file-switch-next)"
+            [ "$#" -gt 0 ] || die "--interaction requires a value (terminal-type | terminal-scroll | diff-scroll | file-switch-next)"
             INTERACTIONS+=("$1")
             shift
             ;;
@@ -1271,22 +1315,32 @@ if [ "${#INTERACTIONS[@]}" -gt 0 ]; then
         die "--interaction-delay must be less than or equal to --duration when --interaction is used (delay=$INTERACTION_DELAY duration=$DURATION)"
     fi
     _file_switch_count=0
+    _diff_scroll_count=0
     for _name in "${INTERACTIONS[@]}"; do
         case "$_name" in
             terminal-type|terminal-scroll) ;;
+            diff-scroll)
+                _diff_scroll_count=$((_diff_scroll_count + 1))
+                if [ "$_diff_scroll_count" -gt 1 ]; then
+                    die "--interaction diff-scroll can be specified at most once (app-side single-shot diagnostic)"
+                fi
+                if [ "$MODE" != "github" ]; then
+                    die "--interaction diff-scroll requires github mode"
+                fi
+                ;;
             file-switch-next)
                 _file_switch_count=$((_file_switch_count + 1))
                 if [ "$_file_switch_count" -gt 1 ]; then
                     die "--interaction file-switch-next can be specified at most once (app-side single-shot diagnostic)"
                 fi
                 ;;
-            *) die "--interaction must be one of: terminal-type, terminal-scroll, file-switch-next (got: $_name)" ;;
+            *) die "--interaction must be one of: terminal-type, terminal-scroll, diff-scroll, file-switch-next (got: $_name)" ;;
         esac
     done
     if [ "$_file_switch_count" -eq 1 ] && [ "${#INTERACTIONS[@]}" -gt 1 ]; then
         die "--interaction file-switch-next must be used alone (app-side timer is armed from launch)"
     fi
-    unset _name _file_switch_count
+    unset _name _file_switch_count _diff_scroll_count
 fi
 
 if [ -n "$WINDOW_SIZE" ]; then
@@ -1342,6 +1396,7 @@ case "$PROFILE" in
 esac
 RUN_START_MS=""
 FILE_SWITCH_TRIGGER_OFFSET_MS=""
+DIFF_SCROLL_TRIGGER_OFFSET_MS=""
 
 # tool availability
 HAS_PYTHON3_BIN="$(command -v python3 || true)"
@@ -1444,6 +1499,12 @@ if [ "${#INTERACTIONS[@]}" -gt 0 ]; then
             # script 側 event start はこの timer の予定発火時刻に合わせる。
             FILE_SWITCH_TRIGGER_OFFSET_MS=$((INTERACTION_DELAY * 1000))
             ENV_VARS+=("LOCUS_DIAG_FILE_SWITCH_AFTER_MS=$FILE_SWITCH_TRIGGER_OFFSET_MS")
+        elif [ "$_interaction" = "diff-scroll" ]; then
+            # diff ListView の OS wheel event は環境差が大きいため、app 側
+            # single-shot timer でも viewport-y を動かして安定した診断 signal
+            # を出す。script 側 event start は timer の予定発火時刻に合わせる。
+            DIFF_SCROLL_TRIGGER_OFFSET_MS=$((INTERACTION_DELAY * 1000))
+            ENV_VARS+=("LOCUS_DIAG_DIFF_SCROLL_AFTER_MS=$DIFF_SCROLL_TRIGGER_OFFSET_MS")
         fi
     done
     unset _interaction
@@ -1609,6 +1670,7 @@ esac
         "terminal input forwarded" \
         "terminal input forward failed" \
         "terminal scroll event" \
+        "diff scroll event" \
         "terminal render tick" \
         "terminal render idle flush" \
         "file switch requested" \
@@ -1631,7 +1693,7 @@ esac
     printf '\n'
     printf '== matched lines ==\n'
     if [ -f "$APP_LOG" ]; then
-        grep -E -- 'Slint: Build config|average frames per second|typography configured|preview refreshed|terminal resized|terminal resize failed|terminal input forwarded|terminal input forward failed|terminal scroll event|terminal render tick|terminal render idle flush|file switch requested|diagnostic file switch|window session saved|pr session saved|pr switch fetch completed|linked issues fetched|initial hydrate snapshot\+list fetched|initial hydrate completed|initial hydrate snapshot failed' \
+        grep -E -- 'Slint: Build config|average frames per second|typography configured|preview refreshed|terminal resized|terminal resize failed|terminal input forwarded|terminal input forward failed|terminal scroll event|diff scroll event|terminal render tick|terminal render idle flush|file switch requested|diagnostic file switch|window session saved|pr session saved|pr switch fetch completed|linked issues fetched|initial hydrate snapshot\+list fetched|initial hydrate completed|initial hydrate snapshot failed' \
             "$APP_LOG" 2>/dev/null \
             | head -n 200 \
             || printf '  (no matching debug lines found)\n'

--- a/src/app/diagnostics.rs
+++ b/src/app/diagnostics.rs
@@ -45,16 +45,68 @@ fn schedule_diagnostic_file_switch(ui: &DiffViewerWindow, delay: Duration, attem
     });
 }
 
+fn schedule_diagnostic_diff_scroll(ui: &DiffViewerWindow, delay: Duration, attempts_left: u8) {
+    let ui_weak = ui.as_weak();
+    slint::Timer::single_shot(delay, move || {
+        let Some(ui) = ui_weak.upgrade() else { return };
+        let files = ui.get_files();
+        let count = files.row_count();
+        if count == 0 {
+            if attempts_left > 0 {
+                schedule_diagnostic_diff_scroll(
+                    &ui,
+                    Duration::from_millis(250),
+                    attempts_left - 1,
+                );
+            } else {
+                tracing::debug!("diagnostic diff scroll skipped");
+            }
+            return;
+        }
+        let selected = ui.get_selected_file_index().max(0) as usize;
+        let Some(file) = files.row_data(selected) else {
+            tracing::debug!(selected, files = count, "diagnostic diff scroll skipped");
+            return;
+        };
+        if file.is_unsupported {
+            tracing::debug!(
+                selected,
+                files = count,
+                file_path = %file.file_path,
+                "diagnostic diff scroll skipped unsupported file"
+            );
+            return;
+        }
+
+        let from = ui.get_diff_scroll_y();
+        let to = from + 360.0;
+        ui.set_diff_scroll_y(to);
+        tracing::debug!(from, to, files = count, "diagnostic diff scroll triggered");
+        // Rust 側から set_diff_scroll_y() しただけでは Slint の `changed
+        // diff-scroll-y` callback が診断ログとして観測されない環境がある。
+        // app-side timer 診断では「viewport を動かした直後の signal」を安定して
+        // app.log に残すため、明示的に diagnostic callback も発火させる。
+        ui.invoke_diff_scroll_diagnostic(0.0, to);
+    });
+}
+
 /// 診断用 interaction を必要に応じて arm する。
 ///
-/// 現在は `LOCUS_DIAG_FILE_SWITCH_AFTER_MS` が指定された diff viewer run で、
+/// `LOCUS_DIAG_FILE_SWITCH_AFTER_MS` が指定された diff viewer run では
 /// file list が hydrate され次第 `file-switch-requested` を 1 回発火させる。
+/// `LOCUS_DIAG_DIFF_SCROLL_AFTER_MS` では diff viewport-y を動かして
+/// ListView scroll/render の app-side signal を出す。
 pub(crate) fn schedule_diagnostic_interactions(ui: &DiffViewerWindow) {
-    let Some(delay_ms) = std::env::var("LOCUS_DIAG_FILE_SWITCH_AFTER_MS")
+    if let Some(delay_ms) = std::env::var("LOCUS_DIAG_FILE_SWITCH_AFTER_MS")
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
-    else {
-        return;
-    };
-    schedule_diagnostic_file_switch(ui, Duration::from_millis(delay_ms), 20);
+    {
+        schedule_diagnostic_file_switch(ui, Duration::from_millis(delay_ms), 20);
+    }
+    if let Some(delay_ms) = std::env::var("LOCUS_DIAG_DIFF_SCROLL_AFTER_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+    {
+        schedule_diagnostic_diff_scroll(ui, Duration::from_millis(delay_ms), 20);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,12 @@ fn init_logging() {
         .try_init();
 }
 
+fn diag_trace_ui_events_enabled() -> bool {
+    std::env::var("LOCUS_DIAG_TRACE_RENDER_TICKS")
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "on" | "yes"))
+        .unwrap_or(false)
+}
+
 fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
     let ui_cfg = config::UiConfig::from_env();
     let ui = AppWindow::new()?;
@@ -261,6 +267,15 @@ fn run_diff_viewer(spec: &str) -> Result<(), Box<dyn std::error::Error>> {
             let Some(ui) = ui_weak.upgrade() else { return };
             state.borrow_mut().dismiss_toast(id);
             refresh_toasts(&ui, &state);
+        });
+    }
+
+    {
+        let trace_diff_scroll_events = diag_trace_ui_events_enabled();
+        ui.on_diff_scroll_diagnostic(move |delta_x, delta_y| {
+            if trace_diff_scroll_events {
+                tracing::debug!(delta_x, delta_y, "diff scroll event");
+            }
         });
     }
 

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -227,6 +227,9 @@ export component DiffViewerWindow inherits Window {
     // ファイル毎の HashMap として保存し、file-switch-requested の中で
     // 切替前後に save / restore する。
     in-out property <length> diff-scroll-y;
+    changed diff-scroll-y => {
+        root.diff-scroll-diagnostic(0px, root.diff-scroll-y);
+    }
 
     in property <string> current-anchor-label: @tr("(no selection)");
     in property <bool> has-selection: false;
@@ -303,6 +306,7 @@ export component DiffViewerWindow inherits Window {
     callback terminal-key-pressed(string);
     callback terminal-resized(length, length);
     callback terminal-scroll-diagnostic(length, length);
+    callback diff-scroll-diagnostic(length, length);
 
     callback pr-clicked(int);
     callback pr-filter-changed(int);
@@ -792,6 +796,10 @@ export component DiffViewerWindow inherits Window {
                                                 line.new-line-no
                                             );
                                         }
+                                    }
+                                    scroll-event(event) => {
+                                        root.diff-scroll-diagnostic(event.delta-x, event.delta-y);
+                                        reject
                                     }
                                 }
 


### PR DESCRIPTION
## Motivation

#288 の「スクロールがもっさり」は terminal pane だけでなく、中央 diff ListView 側のスクロールが主因である可能性がある。#310 では terminal-scroll/file-switch/input までは計測できたが、diff content の scroll signal が無く、LLM 側で実機ログと artifact を突き合わせられなかった。

Closes #315
Parent: #288

## Changes

- `scripts/diagnose_ui.sh --interaction diff-scroll` を追加。
  - github mode 専用。
  - `LOCUS_DIAG_DIFF_SCROLL_AFTER_MS` を注入し、app-side timer で diff viewport を動かす。
  - `interaction_summary.json` で `diff-scroll` と `diff scroll event` を突き合わせる。
- `perf_summary.txt` に `diff scroll event` count/matched lines を追加。
- DiffViewer の `diff-scroll-y` 変更と row scroll-event から `diff-scroll-diagnostic` callback を出す。
- 診断時 (`LOCUS_DIAG_TRACE_RENDER_TICKS=true`) のみ `diff scroll event` を app.log に出す。
- `src/app/diagnostics.rs` に app-side diff scroll timer を追加し、hydrate 前なら短く retry する。

## Validation

- `rtk bash -n scripts/diagnose_ui.sh`
- `rtk cargo test` — 169 passed
- `rtk cargo clippy --all-targets -- -D warnings`
- `rtk cargo build`
- `rtk git diff --check`
- `rtk scripts/diagnose_ui.sh github duck8823/locus#309 --profile debug --no-build --duration 7 --interaction diff-scroll --interaction-delay 4 --out-dir target/locus-diagnostics/issue315-diff-scroll-final-smoke`
  - `interaction_summary.json`: `observed=1`, `latency_stats.overall.p50_ms=1093`
  - `perf_summary.txt`: `diff scroll event` count=1
  - app.log: `diagnostic diff scroll triggered` + `diff scroll event`
  - warn/error: none
- terminal mode reject smoke: `--interaction diff-scroll requires github mode`

## Review triage

- Gemini scout reported possible missing `LOCUS_DIAG_TRACE_RENDER_TICKS`, but the harness injects it for all `--interaction` runs and smoke artifacts confirm `diff scroll event` is observed.
- Gemini scout reported possible invalid Slint callback placement, but `cargo test`/`cargo build` compile the Slint file successfully; the added `scroll-event` is inside `line-touch := TouchArea`.
- Gemini scout noted potential double signal. `set_diff_scroll_y()` alone was tested in `target/locus-diagnostics/issue315-diff-scroll-setonly-smoke` and did not produce `diff scroll event`; the explicit callback is required and documented in code.
