### PR TITLE
fix(ui): compact diff viewer chrome for 1280px

### DIFF
--- a/ui/app.slint
+++ b/ui/app.slint
@@ -339,9 +339,11 @@ export component DiffViewerWindow inherits Window {
     title: @tr("locus — diff viewer");
     preferred-width: 1700px;
     preferred-height: 960px;
-    // 240(PR list) + 240(file list) + 540(diff) + 320(draft/history) = 1340 が
-    // 横方向の最小機能幅。ヘッダー圧縮を避けるため min-width を 1280px と
-    // やや厳しめに、min-height を 720px に設定する。
+    // 1280x720 の実機確認では固定 sidebars / bottom panes が中央 diff と
+    // terminal pane を圧迫していたため、全体の固定 chrome を少し詰める。
+    // root.width/root.height 連動の adaptive binding は Slint の layoutinfo
+    // loop warning になるため、固定値として最小サイズでも破綻しにくい
+    // バランスに寄せる。
     min-width: 1280px;
     min-height: 720px;
     background: #101014;
@@ -467,7 +469,9 @@ export component DiffViewerWindow inherits Window {
 
             // Header with PR context card (title + base/head + body excerpt + linked issues)
         Rectangle {
-            height: (root.pr-body-excerpt != "" || root.linked-issues.length > 0) ? 150px : 52px;
+            height: (root.pr-body-excerpt != "" || root.linked-issues.length > 0)
+                ? 150px
+                : 52px;
             background: #1a1a22;
             VerticalBox {
                 padding-left: 16px;
@@ -568,7 +572,7 @@ export component DiffViewerWindow inherits Window {
 
             // PR list sidebar (leftmost)
             Rectangle {
-                width: 240px;
+                width: 190px;
                 background: #14141a;
                 border-width: 1px;
                 border-color: #1a1a22;
@@ -691,7 +695,7 @@ export component DiffViewerWindow inherits Window {
 
             // File list sidebar
             Rectangle {
-                width: 240px;
+                width: 220px;
                 background: #14141a;
 
                 ListView {
@@ -853,7 +857,7 @@ export component DiffViewerWindow inherits Window {
 
                     // Selection controls strip
                     Rectangle {
-                        height: 80px;
+                        height: 72px;
                         background: #14141a;
                         border-width: 1px;
                         border-color: #24242c;
@@ -920,7 +924,7 @@ export component DiffViewerWindow inherits Window {
 
                     // Preview + send buttons strip
                     Rectangle {
-                        height: 180px;
+                        height: 160px;
                         background: #14141a;
                         border-width: 1px;
                         border-color: #24242c;
@@ -1088,7 +1092,7 @@ export component DiffViewerWindow inherits Window {
 
                     // Terminal pane (bottom)
                     terminal-pane := Rectangle {
-                        height: 258px;
+                        height: 220px;
                         background: #0b0b0b;
                         border-width: 1px;
                         border-color: #24242c;
@@ -1191,7 +1195,7 @@ export component DiffViewerWindow inherits Window {
 
             // Right: draft + history panel
             Rectangle {
-                width: 320px;
+                width: 300px;
                 background: #14141a;
 
                 VerticalBox {


### PR DESCRIPTION
## Motivation
#290 の 1280x720 実機スクリーンショットで、固定幅の sidebars / right pane と下部 panes が中央 diff / terminal pane を圧迫し、文字やコンポーネントの見切れが目立っていた。#291 の大規模 UI 再設計に入る前に、現行 layout の固定 chrome を詰めて minimum window size での破綻を減らす。

Closes #290

## Changes
- PR list/sidebar width: 240px → 190px
- File list width: 240px → 220px
- Draft/history pane width: 320px → 300px
- Selection controls height: 80px → 72px
- Preview strip height: 180px → 160px
- Terminal pane height: 258px → 220px
- `root.width` / `root.height` 連動の adaptive binding は Slint layoutinfo loop warning を避けるため採用せず、固定値として 1280x720 でも破綻しにくいバランスに調整

## Validation
- `rtk cargo build`
- `rtk cargo build --release`
- `rtk scripts/diagnose_ui.sh github duck8823/locus#309 --profile release --no-build --duration 8 --window-size 1280x720 --no-debug-grid --out-dir target/locus-diagnostics/issue290-compact-1280x720-release-v2`
- `rtk cargo test` — 169 passed
- `rtk cargo clippy --all-targets -- -D warnings` — no issues
- `rtk git diff --check`
- Visual check: `target/locus-diagnostics/issue290-compact-1280x720-release-v2/screenshot.png`
