### PR TITLE
refactor(app): main を composition root に縮小

### DIFF
--- a/src/app/logging.rs
+++ b/src/app/logging.rs
@@ -1,0 +1,12 @@
+//! tracing-subscriber の初期化。
+
+/// `LOCUS_LOG` 環境変数 (`error` / `warn` / `info` / `debug` / `trace`)
+/// を tracing-subscriber の EnvFilter に流し込む。未設定時は `warn`。
+pub(crate) fn init_logging() {
+    use tracing_subscriber::EnvFilter;
+    let filter = EnvFilter::try_from_env("LOCUS_LOG").unwrap_or_else(|_| EnvFilter::new("warn"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init();
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,3 +2,5 @@
 
 pub(crate) mod diagnostics;
 pub(crate) mod diff_viewer;
+pub(crate) mod logging;
+pub(crate) mod terminal_mode;

--- a/src/app/terminal_mode.rs
+++ b/src/app/terminal_mode.rs
@@ -1,0 +1,79 @@
+//! Terminal-only モード (`locus` / `locus <command>`) のエントリポイント。
+
+use std::rc::Rc;
+use std::time::Instant;
+
+use slint::{ComponentHandle, SharedString};
+
+use crate::AppWindow;
+use crate::{config, terminal};
+
+pub(crate) fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let ui_cfg = config::UiConfig::from_env();
+    let ui = AppWindow::new()?;
+    ui.set_font_family(SharedString::from(ui_cfg.terminal_font_family.as_str()));
+    ui.set_font_size(ui_cfg.terminal_font_size);
+    ui.set_cell_w(ui_cfg.terminal_cell_w());
+    ui.set_cell_h(ui_cfg.terminal_cell_h());
+    ui.set_terminal_debug_grid(ui_cfg.terminal_debug_grid);
+    tracing::debug!(
+        terminal_font_family = %ui_cfg.terminal_font_family,
+        terminal_font_size = ui_cfg.terminal_font_size,
+        terminal_cell_w = ui_cfg.terminal_cell_w(),
+        terminal_cell_h = ui_cfg.terminal_cell_h(),
+        terminal_probe_metrics = ui_cfg.terminal_probe_metrics,
+        terminal_debug_grid = ui_cfg.terminal_debug_grid,
+        "terminal typography configured"
+    );
+    let pane = Rc::new(terminal::launch(&ui, command, ui_cfg.bracketed_paste)?);
+    {
+        let pane = pane.clone();
+        let ui_weak = ui.as_weak();
+        let ui_cfg = ui_cfg.clone();
+        ui.on_resized(move |w_logical: f32, h_logical: f32| {
+            let started = Instant::now();
+            let Some(ui) = ui_weak.upgrade() else {
+                return;
+            };
+            // 初期 layout settling や hidden 中の transient 0x0 では PTY を縮めない。
+            // measured-* も layout 確定前は 0 になるので両条件で skip する。
+            if w_logical <= 0.0 || h_logical <= 0.0 {
+                return;
+            }
+            let measured_cell_w = ui.get_measured_cell_w();
+            let measured_cell_h = ui.get_measured_cell_h();
+            let cell_w = ui_cfg.terminal_cell_w_from_measurement(measured_cell_w);
+            let cell_h = ui_cfg.terminal_cell_h_from_measurement(measured_cell_h);
+            let cell_w_source = ui_cfg.terminal_cell_w_source(measured_cell_w);
+            let cell_h_source = ui_cfg.terminal_cell_h_source(measured_cell_h);
+            ui.set_cell_w(cell_w);
+            ui.set_cell_h(cell_h);
+            let (cols, rows) = terminal::compute_grid_size(w_logical, h_logical, cell_w, cell_h);
+            match pane.resize(cols, rows) {
+                Ok(()) => {
+                    let (cols_now, rows_now) = pane.current_size();
+                    ui.set_cols(cols_now as i32);
+                    ui.set_visible_rows(rows_now as i32);
+                    tracing::debug!(
+                        pane_w = w_logical,
+                        pane_h = h_logical,
+                        cell_w,
+                        cell_h,
+                        cell_w_source,
+                        cell_h_source,
+                        cols = cols_now,
+                        rows = rows_now,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "terminal resized"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(%cols, %rows, error = %e, "terminal resize failed");
+                }
+            }
+        });
+    }
+    ui.run()?;
+    drop(pane);
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,6 @@
 //! - `cargo run` / `cargo run -- <command>` — Terminal ペインモード
 //! - `cargo run -- github <owner>/<repo>#<pr_number>` — Diff viewer モード
 
-use std::rc::Rc;
-use std::time::Instant;
-
-use slint::{ComponentHandle, SharedString};
-
 slint::include_modules!();
 
 mod app;
@@ -25,7 +20,7 @@ mod ui_state;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // tracing-subscriber を最初に初期化する。LOCUS_LOG=debug 等で詳細
     // レベルを上げられる。設定なしでは warn 以上のみ stderr に出る。
-    init_logging();
+    app::logging::init_logging();
     // i18n を初期化する。LANG が未設定なら locus 既定の ja に揃える。
     let _ = i18n::init_from_env();
 
@@ -33,12 +28,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match args.as_slice() {
         [mode, spec] if mode == "github" => app::diff_viewer::run_diff_viewer(spec),
-        [command] => run_terminal(command),
+        [command] => app::terminal_mode::run_terminal(command),
         [] => {
             // terminal-only モードでも LOCUS_AGENT_CMD を尊重する。diff viewer
             // 側と挙動を揃えることで README に書ける起動形を一貫させる。
             let cmd = std::env::var("LOCUS_AGENT_CMD").unwrap_or_else(|_| "claude".to_string());
-            run_terminal(&cmd)
+            app::terminal_mode::run_terminal(&cmd)
         }
         _ => {
             eprintln!("Usage:");
@@ -52,85 +47,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             std::process::exit(2);
         }
     }
-}
-
-/// `LOCUS_LOG` 環境変数 (`error` / `warn` / `info` / `debug` / `trace`)
-/// を tracing-subscriber の EnvFilter に流し込む。未設定時は `warn`。
-fn init_logging() {
-    use tracing_subscriber::EnvFilter;
-    let filter = EnvFilter::try_from_env("LOCUS_LOG").unwrap_or_else(|_| EnvFilter::new("warn"));
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_writer(std::io::stderr)
-        .try_init();
-}
-
-fn run_terminal(command: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let ui_cfg = config::UiConfig::from_env();
-    let ui = AppWindow::new()?;
-    ui.set_font_family(SharedString::from(ui_cfg.terminal_font_family.as_str()));
-    ui.set_font_size(ui_cfg.terminal_font_size);
-    ui.set_cell_w(ui_cfg.terminal_cell_w());
-    ui.set_cell_h(ui_cfg.terminal_cell_h());
-    ui.set_terminal_debug_grid(ui_cfg.terminal_debug_grid);
-    tracing::debug!(
-        terminal_font_family = %ui_cfg.terminal_font_family,
-        terminal_font_size = ui_cfg.terminal_font_size,
-        terminal_cell_w = ui_cfg.terminal_cell_w(),
-        terminal_cell_h = ui_cfg.terminal_cell_h(),
-        terminal_probe_metrics = ui_cfg.terminal_probe_metrics,
-        terminal_debug_grid = ui_cfg.terminal_debug_grid,
-        "terminal typography configured"
-    );
-    let pane = Rc::new(terminal::launch(&ui, command, ui_cfg.bracketed_paste)?);
-    {
-        let pane = pane.clone();
-        let ui_weak = ui.as_weak();
-        let ui_cfg = ui_cfg.clone();
-        ui.on_resized(move |w_logical: f32, h_logical: f32| {
-            let started = Instant::now();
-            let Some(ui) = ui_weak.upgrade() else {
-                return;
-            };
-            // 初期 layout settling や hidden 中の transient 0x0 では PTY を縮めない。
-            // measured-* も layout 確定前は 0 になるので両条件で skip する。
-            if w_logical <= 0.0 || h_logical <= 0.0 {
-                return;
-            }
-            let measured_cell_w = ui.get_measured_cell_w();
-            let measured_cell_h = ui.get_measured_cell_h();
-            let cell_w = ui_cfg.terminal_cell_w_from_measurement(measured_cell_w);
-            let cell_h = ui_cfg.terminal_cell_h_from_measurement(measured_cell_h);
-            let cell_w_source = ui_cfg.terminal_cell_w_source(measured_cell_w);
-            let cell_h_source = ui_cfg.terminal_cell_h_source(measured_cell_h);
-            ui.set_cell_w(cell_w);
-            ui.set_cell_h(cell_h);
-            let (cols, rows) = terminal::compute_grid_size(w_logical, h_logical, cell_w, cell_h);
-            match pane.resize(cols, rows) {
-                Ok(()) => {
-                    let (cols_now, rows_now) = pane.current_size();
-                    ui.set_cols(cols_now as i32);
-                    ui.set_visible_rows(rows_now as i32);
-                    tracing::debug!(
-                        pane_w = w_logical,
-                        pane_h = h_logical,
-                        cell_w,
-                        cell_h,
-                        cell_w_source,
-                        cell_h_source,
-                        cols = cols_now,
-                        rows = rows_now,
-                        elapsed_ms = started.elapsed().as_millis() as u64,
-                        "terminal resized"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(%cols, %rows, error = %e, "terminal resize failed");
-                }
-            }
-        });
-    }
-    ui.run()?;
-    drop(pane);
-    Ok(())
 }


### PR DESCRIPTION
## Motivation

#224 の main.rs 分割の仕上げ。#318〜#320 で diff viewer 側を分離した結果、main.rs には terminal-only mode と logging init が残っていた。

この PR では terminal-only mode と logging init も app layer に移し、main.rs を起動モード dispatch の composition root に縮小する。

Closes #224

## Changes

- `src/app/terminal_mode.rs` を追加し、`run_terminal(...)` を移動
- `src/app/logging.rs` を追加し、`init_logging()` を移動
- `src/app/mod.rs` に module export を追加
- `src/main.rs` は module declarations / `slint::include_modules!()` / argv dispatch のみへ縮小
- `src/main.rs`: 136 lines → 50 lines

## Validation

- Claude Code Opus implementation pass
- `rtk cargo build`
- `rtk cargo test` — 169 passed
- `rtk cargo clippy --all-targets -- -D warnings` — no issues
- `rtk git diff --check`
- Terminal-mode diagnostic/log check:
  - `rtk scripts/diagnose_ui.sh terminal --agent-cmd sh --profile debug --no-build --duration 4 --window-size 900x600 --no-debug-grid --out-dir target/locus-diagnostics/issue224-terminal-mode-smoke`
  - `perf_summary.txt`: `terminal typography configured` 1, `terminal resized` 2, no warn/error lines

## Notes / Residual risk

- Screenshot artifact for terminal smoke fell back to desktop capture, but app log confirms terminal mode started and resize callback fired.
- `slint::include_modules!()` remains at crate root intentionally, so generated `AppWindow` / `DiffViewerWindow` continue to be referenced as `crate::AppWindow` / `crate::DiffViewerWindow` from app modules.
