### PR TITLE
docs(ux): files changed 風レイアウト方針を追加

### DIFF
--- a/docs/adr/0008-files-changed-diff-viewer-layout.ja.md
+++ b/docs/adr/0008-files-changed-diff-viewer-layout.ja.md
@@ -1,0 +1,235 @@
+# ADR 0008: diff viewer に GitHub "Files changed" 風レイアウトを採用する
+
+> English: [0008-files-changed-diff-viewer-layout.md](0008-files-changed-diff-viewer-layout.md)
+
+- Status: Proposed
+- Date: 2026-05-10
+
+## Context（背景）
+
+現状の locus diff viewer は、PR メタ情報・PR list・file list・diff 本体・選択 controls・preview・送信 controls・terminal pane・draft / history pane を **1 枚の画面に同時に並べる** 構成になっている (`ui/app.slint::DiffViewerWindow`)。
+
+実機での観察 (2026-05-08 検証, 1280×720) では以下の制約が顕在化している:
+
+- **情報密度が高すぎる**: header (最大 150px) + 4 列 (PR list 190px / File list 220px / center / draft 300px) + bottom hint bar が常時固定で、中央 diff の実効幅が 1280px 環境では ~570px しか残らない。
+- **focus が定まらない**: 「PR を選ぶ」「ファイルを切り替える」「行を選ぶ」「preview を編集する」「terminal を読む」「draft を見る」が同じ視野内で並列に存在し、利用者がどこを見るべきか視線移動が頻繁になる。
+- **terminal pane が固定 220px**: diff content が縦方向にも 圧迫される。送信後にエージェント応答を読みたいフェーズでは terminal を広げたい一方、diff を読んでいる間は terminal を閉じたい。固定高では切替えられない。
+- **collapsible / Viewed 概念がない**: 大きい PR (10+ files) を読むときに、すでに見たファイルを畳んだり、未読の Viewed 進捗を確認する手段がない。File list のカーソル移動だけでは「読んだ／読んでない」のトラッキングができない。
+- **side-by-side mode が存在しない**: 現状 unified diff のみ。コードレビューで delete + add の対応関係を視認するときに不利。
+- **行コメントの位置付けが曖昧**: ADR 0007 で comment-driven send レイヤーを別途追加するが、現行レイアウトに comment pane を増やすと右側がさらに混雑する。
+
+GitHub の PR "Files changed" タブはこれらに対する成熟した UX 解 (公式 docs 参照: [References](#references-参考資料)) を持っている。ファイルごと折りたたみ・Viewed 進捗・ファイルツリー / filter・unified / split 切替・行クリックでのコメント追加 — を locus に取り込むのが本 ADR のスコープである。
+
+本 ADR は **設計とワイヤーフレーム のみ** を扱う。Slint 実装は別 issue で扱い、本 PR では doc commit のみ行う。
+
+## Decision（決定）
+
+PR diff viewer を **Files changed 風レイアウト** に再設計する。実装はフラグ駆動で旧レイアウトと共存させ、安定後に既定切替 → 旧レイアウト撤去まで段階的に進める。
+
+### 1. 画面の二段階モデル
+
+PR を **選んでいない / 選んでいる** で UI の支配的領域を変える:
+
+- **Inbox stage**: PR list が画面左側を 30〜35% 占有。中央は PR の preview / metadata。
+- **Review stage** (本 ADR の主対象): PR list は左端の breadcrumb / 折り畳み済みサイドバーに退き、Files changed view が画面の主役になる。
+
+この遷移は単方向ではなく、Inbox に戻るボタン (`< PRs`) で常時戻れる。
+
+### 2. Review stage の三分割
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Header bar: < PRs │ PR title │ base...head │ Viewed N/M │ filters│
+├────────────┬───────────────────────────────────┬─────────────────┤
+│            │                                   │ Comments / Term │
+│ File tree  │   Diff stack (collapsible files)  │  (tabbed)       │
+│ + filter   │                                   │                 │
+│            │                                   │                 │
+├────────────┴───────────────────────────────────┴─────────────────┤
+│ Bottom hint bar (key bindings / hover tooltip)                    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+- **左**: File tree (ディレクトリツリー) + filter chips (All / Modified / Added / Removed / Renamed) + 検索ボックス + Viewed-hide toggle。
+- **中央**: ファイル単位のセクションを **縦に積んだ単一 ListView**。各セクションは header (path / status / Viewed checkbox / collapse) + diff body。
+- **右**: Comments / Terminal の **タブ切替**。draft pane と history は Comments タブの下部にまとめる (現状の右 300px 列を再構成)。
+
+具体的なワイヤーフレームは [docs/wireframes/diff-viewer-files-changed.ja.md](../wireframes/diff-viewer-files-changed.ja.md) を参照。
+
+### 3. Files changed の locus 化
+
+GitHub の概念を locus 文脈で 1:1 ではなく **ローカル AI 駆動レビュー** 向けに調整する:
+
+| GitHub Files changed | locus での扱い |
+|---|---|
+| Viewed checkbox (per file) | ローカル SQLite (ADR 0007 の `comments.db` を共有) に保存。PR を再度開くと復元。 |
+| Viewed 進捗バー | header bar に `Viewed 3/12` のテキスト。Inbox stage の PR list でも進捗 chip を表示。 |
+| File tree | `ui/app.slint` に新規ツリーコンポーネントを追加。階層は path 先頭 segment で集約。1 ファイルしかないディレクトリは flatten してパス連結 (例: `src/comments/repository.rs`)。 |
+| File filter (All / 拡張子 / status) | filter chip + free-text 検索。LCS でなく substring match で十分。 |
+| Hide already-viewed | filter chip の 1 つとして実装。 |
+| Hide deleted | filter chip の 1 つ。default で見えるが toggle で隠せる。 |
+| Unified / Split toggle | header bar の単一 toggle。state は session local (永続化しない) で開始。要望が出れば永続化する。 |
+| Rich diff (markdown / image) | **non-goal** (後述)。 |
+| 行クリックで comment | ADR 0007 の `Add Comment` フローと統合。クリックした行の直下に inline 入力エリアを開く。 |
+| Resolve conversation | ADR 0007 の `resolved` ステータスをそのまま使う。 |
+| Submit review (Approve / Request changes) | **non-goal**。GitHub Review Comments への push は ADR 0007 同様スコープ外。 |
+
+### 4. Side-by-side / Unified
+
+- **Unified** (既定): 現状と同様、`+ ` / `- ` / context を 1 列で。新旧の行番号は左端に併記 (現状の `old / new` 90px ガターを継続)。
+- **Side-by-side**: 1 行を `[old line# | old content | new line# | new content]` の 4 セルで描画。context 行は左右同内容。Added 行は左を空 cell、Removed 行は右を空 cell。
+
+Slint レイアウトの観点では、`DiffLineView` を **両モード共通の中間表現** とし、レンダラーだけ切替える (Unified renderer / SideBySide renderer)。新たな per-line state (例えば `paired-line-id`) は本 ADR では追加せず、Hunk 単位の matching を Side-by-side renderer が hunk 内 line index で隣接対応に解決する。完全な before/after pairing が必要になった時点で `DiffLineView` に拡張フィールドを足す (本 ADR ではしない)。
+
+ターミナル幅に対する fallback: Side-by-side の最低幅 (例: 1100px) を下回った場合は自動的に Unified に切替え、header の toggle を disabled にする。
+
+### 5. Collapsible files
+
+- 各ファイルセクションは **default expanded**。GitHub と異なり、locus は一度に 1 PR の diff を扱うことが多く、最初の 1 view ですべて見えていた方が情報損失が少ない。
+- File 数が **threshold 超え (既定 20)** の場合のみ default collapsed にして、ユーザーが意図的に開く運用にする。threshold は env (`LOCUS_DIFF_AUTOCOLLAPSE_THRESHOLD`) で上書き可能。
+- **Viewed = checked** にすると、そのファイルは自動で collapse される (GitHub と同じ挙動)。チェックを外すと再展開。
+- 全展開 / 全 collapse のヘッダー操作 (`Expand all` / `Collapse all`)。
+
+### 6. File tree / filter / Viewed state
+
+- File tree は **lazy ではなく eager** に全ノードを構築する (PR の files API はすでに full list を持っている)。仮想化はスクロール領域 (Slint の `ListView`) に任せる。
+- 選択中ファイルは tree 上で highlight。中央 diff stack 側の scroll 位置と双方向同期: tree クリック → diff の該当ファイル冒頭へ scroll、diff scroll → tree の active highlight 移動。
+- Viewed state は `viewed_files` テーブルで永続化:
+
+  ```sql
+  CREATE TABLE viewed_files (
+    session_id   INTEGER NOT NULL REFERENCES sessions(id),
+    file_path    TEXT NOT NULL,
+    viewed_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (session_id, file_path)
+  );
+  ```
+
+  ADR 0007 の `sessions` を再利用する。`viewed_at` を持つことで、後で「いつ確認したか」を traceary に渡せる余地を残す。
+
+### 7. Terminal pane と Comments / Draft pane の同居
+
+右側カラムは **タブ切替の 1 ペイン** とする:
+
+- **Comments タブ** (既定): ADR 0007 の Comments 一覧 + draft entries + history を縦スタック。`Send All Open` ボタンは Comments タブ header に常駐。
+- **Terminal タブ**: 現状の terminal pane をそのまま縦に最大化したもの。タブ切替時にフォーカスが terminal-focus に移る。
+- **同時表示モード** (option): 縦に 2 分割し上 Comments / 下 Terminal。`LOCUS_RIGHT_PANE=split` で起動時に有効化。default は tab 切替。
+
+これにより:
+
+- 通常レビュー時: Comments タブで draft / open コメントを見る。terminal pane は隠れる。
+- Send 後: 自動で Terminal タブにスイッチ (option, `LOCUS_AUTOSWITCH_TERMINAL=true`)、エージェント応答を全画面で確認。
+- ハイブリッドにしたい人は split mode を使う。
+
+右ペインの幅は **resizable** にする (既存の固定 300px をやめる)。最小 280px / 最大 600px / persisted in `comments.db` の `ui_state` テーブル。ADR 0007 は `comments.db` と `sessions` を導入するが `ui_state` は定義しないため、`ui_state` の `CREATE TABLE IF NOT EXISTS` は本 ADR の Phase 2 以降が所有する。
+
+### 8. 行コメント・draft とのインタラクション
+
+ADR 0007 を前提に:
+
+- 各行 hover で右端に `+` ボタンを表示。クリックすると行の **直下に inline 入力エリア** が開く (新規 row として diff stack に挿入される)。Esc でキャンセル、Cmd/Ctrl + Enter で保存。
+- 既にコメントがある行は **左ガターに丸ドット** + 数字 (件数)。ドットクリックで右ペイン Comments タブの当該コメントへ scroll & highlight。
+- range 選択 (shift + click または現状の Range ボタン) → range の最終行直下に入力エリア。
+- 既存 selection-driven の `Insert` / `Insert + Send` / `Copy` / `Add to draft` フローは preview pane に集約 (現状と同じ機能を Comments タブの上部 collapsible section に寄せる)。
+
+### 9. 移行戦略
+
+実装フェーズ:
+
+1. **Phase 0 (本 PR)**: ADR + ASCII wireframe を merge。コードは触らない。
+2. **Phase 1**: feature flag `LOCUS_DIFF_VIEWER=files-changed` を追加し、新旧レイアウトを 2 つの Slint window component として並走させる。default は旧レイアウト。
+3. **Phase 2**: file tree / filter / collapsible / Viewed の最小実装で flag 経由のレビューを開始 (drogfooding)。
+4. **Phase 3**: side-by-side renderer 追加、右ペインタブ切替、ADR 0007 の Comments と統合。
+5. **Phase 4**: default を `files-changed` に切替。旧レイアウトは `LOCUS_DIFF_VIEWER=classic` で 1 minor version (例: v0.2.x → v0.3.0) 残す。
+6. **Phase 5**: 旧レイアウト削除。`DiffViewerWindow` の単一 component を新レイアウトに置換。
+
+各 Phase は別 issue / 別 PR とし、CI の `cargo test` / `cargo clippy` を通す。Phase 1〜3 の途中で UX レビューを行い、必要なら本 ADR を改訂する。
+
+### 10. 状態管理 (ADR 0006 との整合)
+
+新レイアウトでも state の唯一の真は `DIFF_APP_STATE` (thread_local / `Rc<RefCell<>>`) に閉じる。新規 state:
+
+- `viewed_files: HashSet<PathBuf>` — DB から起動時に hydrate。
+- `expanded_files: HashSet<PathBuf>` — session-local。永続化しない。
+- `diff_view_mode: DiffViewMode { Unified, SideBySide }` — session-local。
+- `right_pane_tab: RightPaneTab { Comments, Terminal }` — session-local。
+- `right_pane_width: f32` — DB 永続化。
+- `file_tree_filter: FileTreeFilter` — session-local。
+
+`tokio::spawn` 経由で fetch する側 (PR snapshot / linked issue) には変化なし。新 state は UI thread 上のみで mutate されるため `Send` 要件は発生しない。
+
+### 11. i18n
+
+新規 UI 文字列はすべて `src/i18n.rs::translate_ja` テーブルと Slint `@tr` の両方に登録する (CLAUDE.md の i18n 注意事項に従う)。新規キー候補:
+
+- `Viewed`, `Unviewed`, `Hide viewed`, `Hide deleted`
+- `Unified`, `Side by side`, `Expand all`, `Collapse all`
+- `< PRs`, `Comments`, `Terminal`
+- `(no comments yet)`, `(no diff to show)`
+
+## Consequences（結果）
+
+### 正の影響
+
+- 1 ファイルにフォーカスして読みやすくなる。Viewed 進捗で「あといくつ」が見える。
+- file tree により、深いディレクトリ構造の PR でも navigate しやすい。
+- 右ペインのタブ化で、レビュー中は Comments・送信後は Terminal という時間軸の使い分けがしやすい。
+- side-by-side で delete + add 対応の視認性が上がる。
+- ADR 0007 の comment 流入口が「行直下の inline 入力」として自然に置ける。
+
+### 負の影響
+
+- Slint のレイアウトコードが大幅に増える (`DiffViewerWindow` の sub-component 化が必要)。`ui/` を複数ファイルに分割する仕事が新規に発生する。
+- 旧レイアウトとの並走期間 (Phase 1〜4) は 2 経路のメンテが必要。bug fix を両方に当てる。
+- File tree のレンダリングは Slint の reactive ListView 上で深さを表現する必要があり、現状にない実装パターン (indent guide / disclosure triangle) を導入する。
+- Viewed / expanded / right pane width など new persisted state が増え、`comments.db` のスキーマが追加される (ADR 0007 とのリリース順序を調整する必要がある)。
+
+### 境界 (Non-goals)
+
+- **GitHub Review Comments への push**: ADR 0007 同様スコープ外。Viewed state も locus ローカルに閉じる。
+- **Rich diff (markdown / image preview)**: GitHub の rich diff toggle 相当は実装しない。`is-unsupported` の現行扱い (テキスト diff として表示できない旨の注記) を継続。
+- **Blame / history**: ファイル単位の git history 表示は本 ADR のスコープ外。
+- **Multi-PR diff comparison**: 複数 PR を 1 画面に並べる UI は対象外。
+- **Terminal の機能再設計**: alacritty_terminal / portable-pty まわりの挙動 (#perf / #font issues) は別 issue。本 ADR は terminal の **配置** だけを変える。
+- **Semantic change IR の活用**: ADR 0004 の semantic diff を Files changed view に重ねる議論は本 ADR ではしない (将来 ADR で再検討)。
+- **Approve / Request changes ボタン**: GitHub の Submit review に相当する操作は対象外。
+- **個別の見切れ / もっさり / 文字化け修正** (#見切れ / #perf / #font): 旧レイアウト上で軽微なものだけ最小限維持。新レイアウト前に深追いしない (issue #291 の Scope NOT 通り)。
+
+## 代替案
+
+1. **既存レイアウトを維持しつつ collapse / Viewed だけ追加する**: 安いが、情報密度・focus 不足という根本問題は解決しない。collapse の効果は file 数依存だが、レイアウト全体の縦方向 (terminal 220px 固定など) には効かない。
+2. **GitHub Files changed の DOM をそのままコピーする (split / file tree も full pixel-parity)**: 過剰最適化。locus の使われ方は GitHub Web 版とは違い、エージェント terminal を必須要素として含むため、3 列構成 (tree / diff / agent) を locus 固有形にする方が良い。
+3. **diff viewer を完全別 window に切り出す (multi-window)**: macOS native では成立するが、PR list と diff の往復頻度が高く、window 切替コストが UX を悪化させる。Window 内タブ (Inbox / Review stage) で十分。
+4. **file tree を持たず、breadcrumb + ファイルリストだけにする**: シンプルだが、深い path (例: `src/diff/render/side_by_side/mod.rs`) を持つ Rust リポジトリでは tree 表現が navigate に効く。
+5. **Inline コメントではなく、行選択 → 右ペインで入力する従来形 (現行に近い)**: ADR 0007 をそのまま実装するならこちらが安い。ただし「行の文脈を見ながら書く」ことが review の本質なので、inline 入力を default にする本案を採用。
+
+## 実装計画 (high level)
+
+詳細スケジュールと issue 分解は別途登録 (Phase 1〜5 で 5+ 件想定)。ここでは順序のみ:
+
+1. **ADR + wireframe** ← 本 PR
+2. `ui/diff_viewer_v2.slint` に新 component 雛形 + feature flag を追加 (旧 component と並走)
+3. file tree component + filter chips
+4. collapsible file section + Viewed 永続化 (`viewed_files` table)
+5. Unified renderer の流用 + side-by-side renderer 新規実装
+6. 右ペイン tab 切替 + ADR 0007 Comments 統合 + inline 入力エリア
+7. flag 既定値切替 + 旧 component 削除 (ADR 改訂時点)
+
+## References (参考資料)
+
+GitHub 公式ドキュメントを一次情報として参照した。
+
+- [GitHub Docs — Reviewing proposed changes in a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request?tool=webui) — file 単位レビュー、Viewed checkbox、Viewed 進捗バー、unified / split 切替、PR submit フロー。
+- [GitHub Docs — Filtering files in a pull request](https://docs.github.com/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/filtering-files-in-a-pull-request) — 大きい PR のための file filter / file tree、Viewed / deleted 隠し。
+- [GitHub Docs — About comparing branches in pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests) — Files changed タブが merge 後を見せる事実、unified / split / rich / source の 4 表示、whitespace ignore、Viewed / deleted フィルタ。
+
+関連 ADR:
+
+- [ADR 0003: layered server architecture](0003-layered-server-architecture.ja.md) — モジュール分割の方針を継承。
+- [ADR 0005: Rust + Slint native rewrite](0005-rust-slint-native-rewrite.ja.md) — Slint 上での UI 構築前提。
+- [ADR 0006: thread_local app state](0006-thread-local-app-state.ja.md) — 新 state を `DIFF_APP_STATE` に閉じる根拠。
+- [ADR 0007: comment-driven send](0007-comment-driven-send.ja.md) — Comments タブと inline コメント入力の前提。
+
+実機検証ログ:
+
+- 2026-05-08 1280×720 の `scripts/diagnose_ui.sh github` 結果より、現行レイアウトの中央 diff 実効幅と固定 chrome の比率を確認 (issue #291 本文)。

--- a/docs/adr/0008-files-changed-diff-viewer-layout.md
+++ b/docs/adr/0008-files-changed-diff-viewer-layout.md
@@ -1,0 +1,235 @@
+# ADR 0008: GitHub "Files changed"-style layout for the diff viewer
+
+> 日本語: [0008-files-changed-diff-viewer-layout.ja.md](0008-files-changed-diff-viewer-layout.ja.md)
+
+- Status: Proposed
+- Date: 2026-05-10
+
+## Context
+
+Today's locus diff viewer packs everything onto **a single screen** (`ui/app.slint::DiffViewerWindow`): PR metadata header, PR list, file list, diff body, selection controls, preview, send controls, terminal pane, and the draft / history pane.
+
+On-device observation (verified 2026-05-08, 1280×720) surfaces several constraints:
+
+- **Information density is too high.** Header (up to 150px) + four columns (PR list 190px / file list 220px / center / draft 300px) + bottom hint bar are always pinned, leaving the center diff with only ~570px of effective width at 1280px.
+- **Focus is diffuse.** "Pick a PR", "switch files", "select a line", "edit the preview", "read the terminal", and "review the draft" all live side by side. The user's gaze hops constantly.
+- **Terminal pane is hard-pinned to 220px.** Diff content gets vertically squeezed too. After Send the user wants the terminal large; while reading diff they want it gone. A fixed height cannot do both.
+- **No collapsible / Viewed concepts.** Reviewing a large PR (10+ files), there is no way to fold already-seen files away or track Viewed progress. The file list cursor alone does not tell the user "which files have I already read".
+- **No side-by-side mode.** Only unified diff exists. Visualising delete + add correspondence is harder.
+- **Line comments do not have a clear home.** ADR 0007 will introduce the comment-driven send layer, but bolting another pane onto the current right column would crowd the screen further.
+
+GitHub's PR "Files changed" tab has a mature UX answer to all of this (see the official docs cited in [References](#references)). Per-file collapse, Viewed progress, file tree / filter, unified / split toggle, and click-to-comment are exactly what locus needs to import.
+
+This ADR covers **design and wireframes only**. The Slint implementation is tracked in follow-up issues; this PR ships docs only.
+
+## Decision
+
+Re-shape the PR diff viewer into a **Files changed-style layout**. Implementation is feature-flagged so the new and the classic layout coexist, with a staged migration that flips defaults and finally removes the classic path.
+
+### 1. Two-stage screen model
+
+Switch the dominant region based on whether a PR is **selected**:
+
+- **Inbox stage**: PR list occupies 30–35% on the left. Centre shows the focused PR's preview / metadata.
+- **Review stage** (the focus of this ADR): PR list collapses to a left-edge breadcrumb / folded sidebar, and the Files changed view becomes the screen's lead actor.
+
+The transition is reversible — a `< PRs` button always returns to Inbox.
+
+### 2. Three-column Review stage
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Header: < PRs │ PR title │ base...head │ Viewed N/M │ filters     │
+├────────────┬───────────────────────────────────┬─────────────────┤
+│            │                                   │ Comments / Term │
+│ File tree  │   Diff stack (collapsible files)  │  (tabbed)       │
+│ + filter   │                                   │                 │
+│            │                                   │                 │
+├────────────┴───────────────────────────────────┴─────────────────┤
+│ Bottom hint bar (key bindings / hover tooltip)                    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+- **Left**: file tree + filter chips (All / Modified / Added / Removed / Renamed) + search box + Viewed-hide toggle.
+- **Centre**: a single **vertically scrolling ListView of per-file sections**. Each section has a header (path / status / Viewed checkbox / collapse) and a diff body.
+- **Right**: a tab-switched pane between **Comments** and **Terminal**. Draft and history live inside the Comments tab (the current 300px right column is reorganised, not duplicated).
+
+See [docs/wireframes/diff-viewer-files-changed.md](../wireframes/diff-viewer-files-changed.md) for the concrete wireframes.
+
+### 3. Translating Files changed into locus
+
+GitHub's concepts adapt to the **local AI-driven review** context, not 1:1:
+
+| GitHub Files changed | Locus interpretation |
+|---|---|
+| Per-file Viewed checkbox | Persisted to local SQLite (shares ADR 0007's `comments.db`). State rehydrates on PR reopen. |
+| Viewed progress bar | Header-bar text `Viewed 3/12`. The Inbox PR list shows the same counter as a chip. |
+| File tree | New tree component in `ui/`. Path segments are aggregated; directories with a single file are flattened (e.g. `src/comments/repository.rs`). |
+| File filter (All / extension / status) | Filter chips + free-text search. Substring match is enough — no LCS / fuzzy. |
+| Hide already-viewed | One of the filter chips. |
+| Hide deleted | Filter chip. Visible by default; toggleable. |
+| Unified / split toggle | Single toggle in the header bar. State is session-local at first; persistence can come later. |
+| Rich diff (markdown / image) | **Non-goal** (see below). |
+| Click-line-to-comment | Folds into ADR 0007's `Add Comment` flow. The input area opens **inline beneath the clicked line**. |
+| Resolve conversation | Reuses ADR 0007's `resolved` status verbatim. |
+| Submit review (Approve / Request changes) | **Non-goal**. As in ADR 0007, no GitHub Review Comments push. |
+
+### 4. Side-by-side / unified
+
+- **Unified** (default): same as today — `+ ` / `- ` / context in a single column. Old/new line numbers stay in the left 90px gutter.
+- **Side-by-side**: each row is `[old line# | old content | new line# | new content]` (4 cells). Context lines mirror across. Added rows leave the left side empty; removed rows leave the right side empty.
+
+Architecturally, `DiffLineView` stays as a **shared intermediate representation** for both modes. Only the renderer differs (Unified renderer / SideBySide renderer). No new per-line state (e.g. `paired-line-id`) is introduced in this ADR — the SideBySide renderer pairs by hunk-local index, which is sufficient. Adding explicit pairing fields is deferred until a real need shows up.
+
+Width fallback: below a minimum side-by-side width (e.g. 1100px), the renderer auto-falls back to Unified and the toggle is disabled.
+
+### 5. Collapsible files
+
+- Each file section is **expanded by default**. Unlike GitHub Web, locus typically shows one PR's diff at a time, and showing all files up front loses less information.
+- When the file count exceeds a **threshold (default 20)**, default to collapsed and let the user expand intentionally. Threshold is overridable via env (`LOCUS_DIFF_AUTOCOLLAPSE_THRESHOLD`).
+- **Viewed = checked** auto-collapses the file (matches GitHub). Unchecking re-expands.
+- Header-level `Expand all` / `Collapse all` buttons.
+
+### 6. File tree / filter / Viewed state
+
+- The file tree is **eagerly built** (the PR files API already returns the full list). Virtualisation is delegated to Slint's `ListView` for the visible rows.
+- The active file is highlighted in the tree, and tree ↔ diff scroll are bidirectionally synced: clicking a tree node scrolls diff to that file's start, scrolling the diff updates the tree highlight.
+- Viewed state is persisted as:
+
+  ```sql
+  CREATE TABLE viewed_files (
+    session_id   INTEGER NOT NULL REFERENCES sessions(id),
+    file_path    TEXT NOT NULL,
+    viewed_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (session_id, file_path)
+  );
+  ```
+
+  This reuses ADR 0007's `sessions` table. Keeping `viewed_at` leaves room for traceary integration ("when did the user check this file?").
+
+### 7. Coexisting terminal pane and Comments / Draft pane
+
+The right column becomes **a single tab-switched pane**:
+
+- **Comments tab** (default): ADR 0007 comment list + draft entries + history, stacked vertically. `Send All Open` lives in this tab's header.
+- **Terminal tab**: today's terminal pane, vertically maximised. Switching to this tab moves focus to terminal-focus.
+- **Split mode** (option): vertical split — Comments on top, Terminal on bottom. Enable at startup with `LOCUS_RIGHT_PANE=split`. Default remains tab.
+
+This gives:
+
+- During review: Comments tab shows the draft / open comments; the terminal is hidden.
+- After Send: optionally auto-switch to Terminal (`LOCUS_AUTOSWITCH_TERMINAL=true`) and read the agent response full-height.
+- Users who want both at once enable split mode.
+
+The right pane width is **resizable** (the current fixed 300px goes away). Min 280px, max 600px, persisted in `comments.db` `ui_state`. ADR 0007 introduces `comments.db` and `sessions` but does not define `ui_state`; the `CREATE TABLE IF NOT EXISTS` for `ui_state` is owned by Phase 2+ of this ADR.
+
+### 8. Line comments and draft interaction
+
+Building on ADR 0007:
+
+- Hovering a line shows a `+` button on the right edge. Clicking opens an **inline input area directly beneath the line** (a new ListView row inserted into the diff stack). Esc cancels, Cmd/Ctrl + Enter saves.
+- Lines with existing comments show a **dot in the left gutter** plus a count. Clicking the dot scrolls and highlights that comment in the right Comments tab.
+- Range selections (shift+click or the existing Range button) open the input area beneath the last line of the range.
+- The existing selection-driven `Insert` / `Insert + Send` / `Copy` / `Add to draft` flow lives at the top of the Comments tab as a collapsible section — same buttons, different home.
+
+### 9. Migration strategy
+
+Phases:
+
+1. **Phase 0 (this PR)**: ADR + ASCII wireframes merge. No code changes.
+2. **Phase 1**: Add a feature flag `LOCUS_DIFF_VIEWER=files-changed` and parallel-run the new and old layouts as two Slint window components. Default stays on the old layout.
+3. **Phase 2**: Minimal new layout — file tree, filter, collapsible, Viewed — usable for dogfooding via the flag.
+4. **Phase 3**: Add side-by-side renderer, right-pane tab swap, full ADR 0007 Comments integration.
+5. **Phase 4**: Flip the default to `files-changed`. Keep the classic layout reachable via `LOCUS_DIFF_VIEWER=classic` for one minor version (e.g. v0.2.x → v0.3.0).
+6. **Phase 5**: Remove the classic layout. `DiffViewerWindow` collapses back to a single component.
+
+Each phase is its own issue / PR and must keep `cargo test` and `cargo clippy` green. UX checkpoints during phases 1–3 may revise this ADR.
+
+### 10. State management (consistency with ADR 0006)
+
+The single source of truth stays in `DIFF_APP_STATE` (thread_local / `Rc<RefCell<>>`). New state slots:
+
+- `viewed_files: HashSet<PathBuf>` — hydrated from the DB at startup.
+- `expanded_files: HashSet<PathBuf>` — session-local; not persisted.
+- `diff_view_mode: DiffViewMode { Unified, SideBySide }` — session-local.
+- `right_pane_tab: RightPaneTab { Comments, Terminal }` — session-local.
+- `right_pane_width: f32` — DB-persisted.
+- `file_tree_filter: FileTreeFilter` — session-local.
+
+Code that fetches via `tokio::spawn` (PR snapshot, linked issues) is unchanged. The new state is mutated only on the UI thread, so no `Send` requirement appears.
+
+### 11. i18n
+
+Every new UI string is registered in **both** `src/i18n.rs::translate_ja` and Slint `@tr` (per CLAUDE.md). Candidate keys:
+
+- `Viewed`, `Unviewed`, `Hide viewed`, `Hide deleted`
+- `Unified`, `Side by side`, `Expand all`, `Collapse all`
+- `< PRs`, `Comments`, `Terminal`
+- `(no comments yet)`, `(no diff to show)`
+
+## Consequences
+
+### Positive
+
+- One file at a time becomes the focus, with a Viewed counter telling users how much is left.
+- The file tree makes deep directory structures navigable.
+- Right-pane tabs cleanly separate the review phase (Comments) from the post-Send phase (Terminal).
+- Side-by-side improves visual correspondence of delete + add.
+- ADR 0007's comment intake fits naturally as an "inline input directly under the line".
+
+### Negative
+
+- Slint layout code grows substantially. `DiffViewerWindow` will need to be split into sub-components, and `ui/` must be reorganised across multiple files.
+- Phases 1–4 require maintaining two layouts in parallel — bug fixes apply twice.
+- File-tree rendering on Slint's reactive ListView introduces patterns we don't have today (indent guides / disclosure triangles).
+- New persisted state (Viewed, right-pane width) extends the `comments.db` schema, so this ADR's ship order has to coordinate with ADR 0007's.
+
+### Boundaries (Non-goals)
+
+- **No GitHub Review Comments push.** Same boundary as ADR 0007. Viewed state is also locus-local.
+- **No rich diff (markdown / image preview).** GitHub's rich-diff toggle is not implemented. The current `is-unsupported` notice continues to handle non-text content.
+- **No blame / history view.** Per-file git history is out of scope.
+- **No multi-PR diff comparison.** Showing diffs from several PRs in one window is out of scope.
+- **No terminal-internals redesign.** alacritty_terminal / portable-pty changes (#perf, #font issues) are tracked separately. This ADR only changes terminal **placement**.
+- **No semantic-change-IR overlay.** Layering ADR 0004's semantic diff onto Files changed is deferred to a future ADR.
+- **No Approve / Request changes button.** GitHub's Submit review is out of scope.
+- **No deep dives into individual clipping / lag / glyph fixes** (#見切れ, #perf, #font). Only the bare minimum to keep the classic layout usable while the new one rolls out (per issue #291's NOT scope).
+
+## Alternatives considered
+
+1. **Bolt collapse + Viewed onto the existing layout.** Cheap, but does not address the density / focus root cause. Collapse helps only with file count, not with the vertical chrome (e.g. the fixed 220px terminal).
+2. **1:1 copy of GitHub's Files changed DOM (split + tree at full pixel parity).** Over-fitting. Locus has the agent terminal as a first-class element that GitHub Web does not, so a locus-shaped 3-column layout (tree / diff / agent) is preferable.
+3. **Move the diff viewer to its own window (multi-window).** Plausible on macOS, but the round-trip between PR list and diff is high-frequency, and window switches hurt UX. In-window stages (Inbox / Review) suffice.
+4. **Drop the file tree and ship only breadcrumb + flat list.** Simpler, but Rust repos with deep paths (`src/diff/render/side_by_side/mod.rs`) navigate noticeably better with a real tree.
+5. **Right-pane input instead of inline (closer to today).** Cheaper if ADR 0007 lands as-is. But "writing a comment while still seeing the line in context" is the core of review, so inline-as-default wins.
+
+## Implementation plan (high-level)
+
+A more detailed schedule and issue split lives in follow-up issues (≥5 expected for phases 1–5). Order only:
+
+1. **ADR + wireframes** ← this PR.
+2. New component skeleton in `ui/diff_viewer_v2.slint` + feature flag, parallel to the classic component.
+3. File tree component + filter chips.
+4. Collapsible file sections + Viewed persistence (`viewed_files` table).
+5. Reuse Unified renderer; add the SideBySide renderer.
+6. Right-pane tab swap + ADR 0007 Comments integration + inline input area.
+7. Default flip + classic layout removal (this ADR is revised at that point).
+
+## References
+
+GitHub's official docs are the primary source for the Files changed UX.
+
+- [GitHub Docs — Reviewing proposed changes in a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request?tool=webui) — per-file review, Viewed checkbox, Viewed progress bar, unified / split toggle, PR submit flow.
+- [GitHub Docs — Filtering files in a pull request](https://docs.github.com/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/filtering-files-in-a-pull-request) — file filter and file tree for large PRs; hide already-viewed / deleted.
+- [GitHub Docs — About comparing branches in pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests) — Files changed shows post-merge state; unified / split / rich / source views; whitespace ignore; Viewed / deleted filters.
+
+Related ADRs:
+
+- [ADR 0003: layered server architecture](0003-layered-server-architecture.md) — module-split philosophy carried forward.
+- [ADR 0005: Rust + Slint native rewrite](0005-rust-slint-native-rewrite.md) — the Slint UI premise.
+- [ADR 0006: thread_local app state](0006-thread-local-app-state.md) — rationale for keeping new state inside `DIFF_APP_STATE`.
+- [ADR 0007: comment-driven send](0007-comment-driven-send.md) — the Comments tab and inline-comment input premise.
+
+On-device verification:
+
+- 2026-05-08, `scripts/diagnose_ui.sh github` at 1280×720 — used to confirm effective center-diff width and the share of fixed chrome (issue #291 body).

--- a/docs/wireframes/diff-viewer-files-changed.ja.md
+++ b/docs/wireframes/diff-viewer-files-changed.ja.md
@@ -1,0 +1,301 @@
+# Wireframe: Files changed 風 diff viewer (ja)
+
+> English: [diff-viewer-files-changed.md](diff-viewer-files-changed.md)
+> 関連 ADR: [ADR 0008](../adr/0008-files-changed-diff-viewer-layout.ja.md)
+
+このドキュメントは、ADR 0008 で決定した GitHub "Files changed" 風レイアウトの **ASCII ワイヤーフレーム** をまとめる。記号は次の通り:
+
+- `─ │ ┌ ┐ └ ┘ ├ ┤ ┬ ┴ ┼` レイアウト枠
+- `▼ ▶` collapsible セクション (展開 / 折り畳み)
+- `[ ]` チェックボックス未チェック / `[x]` チェック済み
+- `( )` ラジオ未選択 / `(•)` 選択中
+- `…` 省略
+
+すべての寸法は概算で、Slint 実装時に解像度ごとに再調整する。
+
+---
+
+## 1. Inbox stage (PR を選んでいない状態)
+
+```
+┌────────────────────────────────────────────────────────────────────────────────────┐
+│ locus — diff viewer                                                                 │
+├────────────────────────────────────────────────────────────────────────────────────┤
+│ Header: アプリタイトル / 接続中リポジトリ / Open settings                           │
+├──────────────────────────────┬─────────────────────────────────────────────────────┤
+│ PRs (Open)  (Closed)  (All)  │ Welcome / 最近開いた PR の preview など              │
+│ ──────────────────────────── │                                                     │
+│ #302  duck8823               │  #302 files changed adr wireframe                   │
+│   files changed adr wirefr.. │  base main … head issue291-files-changed-adr-wir.. │
+│   Viewed 0/4    [open]       │  body excerpt …                                     │
+│ ──────────────────────────── │  Viewed 0/4    Comments 0                           │
+│ #301  bot                    │                                                     │
+│   refactor diff viewer …     │  [ Open this PR ]                                   │
+│   Viewed 2/3    [open]       │                                                     │
+│ ──────────────────────────── │                                                     │
+│ #298  duck8823               │                                                     │
+│   thread_local app state     │                                                     │
+│   Viewed 5/5 ✓  [merged]     │                                                     │
+│ ──────────────────────────── │                                                     │
+│ …                            │                                                     │
+│                              │                                                     │
+└──────────────────────────────┴─────────────────────────────────────────────────────┘
+```
+
+- 左 PR list は 30〜35% 幅。Viewed counter が PR 行に常駐し、レビュー再開が見えるようにする。
+- 中央は preview。`Open this PR` で Review stage に遷移する。
+
+---
+
+## 2. Review stage — Unified mode (既定)
+
+```
+┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ < PRs   #302 files changed adr wireframe   base main … head issue291…   Viewed 1/4   ⌥=⌘opts  │
+├──────────────┬───────────────────────────────────────────────────────────┬─────────────────────┤
+│ Filter:      │  ▼ docs/adr/0008-files-changed-diff-viewer-layout.ja.md  │ Comments | Terminal │
+│ [All ▾]      │     status: A   +312 / -0    Viewed [ ]    Collapse ▲    │ ─────────────────── │
+│ [search…]    │  ┌─────────┬───────────────────────────────────────────┐ │ Send All Open  ↗   │
+│ [ ] Hide     │  │ old new │ content                                   │ │ ─────────────────── │
+│     viewed   │  │   1     │ # ADR 0008: …                             │ │ Open (2)            │
+│ [ ] Hide     │  │   2     │                                           │ │ • src/foo.rs:42     │
+│     deleted  │  │   3     │ > English: [0008-…]                       │ │   missing null chk  │
+│ ──────────── │  │ @@ -0,0 +1,42 @@   <hunk header — Cmd+click to send>│ │ • docs/adr/0008..   │
+│ ▾ docs       │  │   …                                                  │ │   typo on line 5    │
+│   ▾ adr      │  │   42    │ ## References                             │ │ ─────────────────── │
+│     0008-…ja │  │                                                      │ │ Sent (1)            │
+│     0008-…   │  │   ・[+] Add comment row appears here on hover         │ │ • src/bar.rs:10-25  │
+│   ▾ wirefr.. │  └─────────┴───────────────────────────────────────────┘ │ ─────────────────── │
+│     diff-…ja │                                                           │ Resolved (0)        │
+│     diff-…   │  ▶ docs/wireframes/diff-viewer-files-changed.ja.md       │                     │
+│ ▾ ui         │     status: A   +180 / -0    Viewed [x]    Expand ▼      │ ─────────────────── │
+│   app.slint  │  (collapsed; Viewed = checked のため自動折り畳み)         │ Draft (1)           │
+│              │                                                           │ • #302/foo.rs:42    │
+│              │  ▼ src/i18n.rs                                            │   note: …           │
+│              │     status: M   +6 / -0     Viewed [ ]    Collapse ▲     │ ─────────────────── │
+│              │  ┌─────────┬───────────────────────────────────────────┐ │ History (3)         │
+│              │  │  85  85 │   match key {                              │ │ 14:02  Send  3 cmts │
+│              │  │  86  86 │       "Click a diff line, …" => …          │ │ 13:44  Insert       │
+│              │  │     87  │+      "Viewed" => "確認済み",              │ │ 13:30  Copy         │
+│              │  │     88  │+      "Hide viewed" => "確認済みを隠す",    │ │                     │
+│              │  │  87  89 │       "Esc: clear selection" => …          │ │                     │
+│              │  └─────────┴───────────────────────────────────────────┘ │                     │
+│              │                                                           │                     │
+│              │  ▶ ui/diff_viewer_v2.slint   status: A  Viewed [ ]        │                     │
+│              │                                                           │                     │
+├──────────────┴───────────────────────────────────────────────────────────┴─────────────────────┤
+│ Click: select line  •  +: add comment  •  Cmd↵: Send  •  V: toggle Viewed  •  ⌘B: toggle tree │
+└────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+- **左** (file tree + filter): 240〜280px。`Filter` chip + 検索 + Viewed/Deleted hide。tree はディレクトリ折り畳み可。1 ファイルしかないディレクトリは flatten 表示。
+- **中央** (diff stack): 全ファイルが 1 つの ListView に積み重なる。各セクションの header は `▼/▶ path  status  +N/-M  Viewed [x]  Collapse/Expand`。Viewed = checked のセクションは折り畳まれる。
+- **右** (Comments / Terminal の tab): 既定は Comments。`Send All Open` / Open / Sent / Resolved / Draft / History を縦スタック。
+
+---
+
+## 3. Review stage — Side-by-side mode
+
+```
+┌──────────────┬────────────────────────────────────────────────────────────────┬──────────┐
+│ (file tree)  │  ▼ src/i18n.rs   status: M   +6 / -0   Viewed [ ]   Collapse ▲│ (right)  │
+│              │  ┌─────┬──────────────────────┬─────┬──────────────────────┐ │          │
+│              │  │ old │ before               │ new │ after                │ │          │
+│              │  ├─────┼──────────────────────┼─────┼──────────────────────┤ │          │
+│              │  │  85 │   match key {        │  85 │   match key {        │ │          │
+│              │  │  86 │       "Click …" => …│  86 │       "Click …" => …│ │          │
+│              │  │     │                      │  87 │+      "Viewed" => …  │ │          │
+│              │  │     │                      │  88 │+      "Hide viewed"  │ │          │
+│              │  │  87 │       "Esc: …" => … │  89 │       "Esc: …" => … │ │          │
+│              │  └─────┴──────────────────────┴─────┴──────────────────────┘ │          │
+│              │                                                              │          │
+└──────────────┴──────────────────────────────────────────────────────────────┴──────────┘
+```
+
+- 4 セル `[old# | before | new# | after]`。Added 行は左を空、Removed 行は右を空にする。
+- ウィンドウ幅が **1100px 未満** に縮むと自動的に Unified にフォールバックし、header の toggle を disabled にする。
+
+---
+
+## 4. 折り畳み済みファイル + Viewed checkbox
+
+```
+▼ docs/adr/0008-files-changed-diff-viewer-layout.ja.md
+   status: A   +312 / -0    Viewed [ ]    Collapse ▲
+   <diff body 表示中>
+   …
+
+▶ docs/wireframes/diff-viewer-files-changed.ja.md
+   status: A   +180 / -0    Viewed [x]    Expand ▼
+   (collapsed: Viewed = checked のため自動折り畳み)
+
+▶ ui/diff_viewer_v2.slint
+   status: A   +0 / -0    Viewed [ ]    Expand ▼
+   (manual collapse)
+```
+
+- collapse triangle と Viewed checkbox は独立操作。Viewed=checked にすると自動 collapse、ただし `Expand ▼` で再展開可。再展開しても Viewed=checked は維持される (= "見たけどもう一度見たい" を表現)。
+- header 全体をクリックで collapse 切替、Viewed checkbox はバブルしない (TouchArea を分ける)。
+
+---
+
+## 5. 行コメント入力 (inline)
+
+```
+   42  42      something_useful();
+   43  43  +   another_line();        <- hover で右端に [+] 表示
+              ┌──────────────────────────────────────────────┐
+              │ Add comment on docs/adr/0008-…ja.md:43       │
+              │ ┌──────────────────────────────────────────┐ │
+              │ │ ここのリンクが古い、最新 ADR に直して     │ │
+              │ │                                          │ │
+              │ └──────────────────────────────────────────┘ │
+              │ [ Cancel ]      [ Save (Cmd+Enter) ]         │
+              └──────────────────────────────────────────────┘
+   44  44      yet_another_line();
+   45  ●●  -   removed_line();        <- 左ガターのドット = 既存コメントあり (件数つき)
+   46  45      tail_line();
+```
+
+- 行を hover すると右端に `+`。クリックで **その行直下に新しい row** として inline 入力エリアを差し込む。Esc cancel / Cmd+Enter save。
+- 既にコメントがある行は **左ガターのドット** で示す。ドットクリックで右ペイン Comments タブの該当エントリへ scroll & highlight。
+- range 選択 (shift+click) → range 終端の直下に inline 入力。
+
+---
+
+## 6. 右ペイン (Comments / Terminal タブ切替)
+
+### 6a. Comments タブ (既定)
+
+```
+┌─────────────────────────────────┐
+│ Comments | Terminal             │   <- tab strip
+├─────────────────────────────────┤
+│ [ Send All Open ↗ ]   filters ▾ │
+├─────────────────────────────────┤
+│ Selection (collapsed) ▶          │   <- 旧 preview / Insert / Copy をまとめた折り畳み
+├─────────────────────────────────┤
+│ Open (2)                         │
+│ • docs/adr/0008-…ja.md:43        │
+│   ここのリンクが古い…             │
+│   [edit] [send] [resolve]        │
+│ • src/foo.rs:42                  │
+│   missing null check             │
+├─────────────────────────────────┤
+│ Sent (1)                         │
+│ • src/bar.rs:10-25               │
+│   this function has no test      │
+├─────────────────────────────────┤
+│ Resolved (0)                     │
+│   (none yet)                     │
+├─────────────────────────────────┤
+│ Draft (1)                        │
+│ • #302/foo.rs:42 — note: …       │
+├─────────────────────────────────┤
+│ History (3)                      │
+│ 14:02  Send  3 cmts              │
+│ 13:44  Insert  selection         │
+│ 13:30  Copy   selection          │
+└─────────────────────────────────┘
+```
+
+- `Selection` セクションは現行の preview pane を折り畳み式で温存 (旧フローからの移行コスト低減)。
+- `Open / Sent / Resolved` は ADR 0007 の status 区分。
+- 右ペインの幅は drag handle で resizable (280〜600px)。
+
+### 6b. Terminal タブ
+
+```
+┌─────────────────────────────────┐
+│ Comments | Terminal             │
+├─────────────────────────────────┤
+│ agent: claude code (running)    │
+├─────────────────────────────────┤
+│ $ claude code                   │
+│ ▍                               │
+│ > files changed の wireframe を  │
+│   adr 0008 と整合させてくれ      │
+│                                 │
+│ I'll update the wireframe to …  │
+│ ──────────────────────────────  │
+│                                 │
+│ (terminal full-height; PTY)     │
+│                                 │
+└─────────────────────────────────┘
+```
+
+- 起動時のデフォルトは Comments タブ。`LOCUS_AUTOSWITCH_TERMINAL=true` の場合 `Send All Open` 完了直後に Terminal タブへ自動切替。
+- `LOCUS_RIGHT_PANE=split` で Comments / Terminal を縦 2 分割表示にも切替可 (上 50% / 下 50% を初期分割比とし、grip で resize)。
+
+---
+
+## 7. Filter / Viewed-hide / 検索
+
+```
+Filter:
+  [All ▾]                    ← 拡張子 / status を選ぶ dropdown
+  [search…           ]       ← path substring match
+  [ ] Hide already viewed
+  [ ] Hide deleted
+  [ Reset ]
+```
+
+- filter は file tree とリアルタイムに連動。tree のルート (`docs/`, `src/` 等) は子要素が 0 件になっても残し、`(0 files)` と灰色化する。
+- `Reset` で全 filter を解除し、`Viewed` checkbox の状態は保持。
+
+---
+
+## 8. 1280×720 環境での縮約レイアウト
+
+最小サポート 1280×720 (CLAUDE.md `min-width 1280px`) では、左ペイン / 右ペインの一部を一時的に縮める想定:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ < PRs  #302 …  Viewed 1/4         [Unified ▾]  ⌘B tree  ⌘J side      │
+├────┬─────────────────────────────────────────────────────┬──────────┤
+│ ▼  │ ▼ docs/adr/0008-…ja.md   +312/-0   [ ]  ▲           │ Comments │
+│ ▾d │   …                                                  │ Open(2)  │
+│ ▾a │                                                      │ Sent(1)  │
+│ 8j │ ▶ docs/wireframes/diff-…ja.md   +180/-0   [x]  ▼     │ ─────── │
+│ 8e │ ▼ src/i18n.rs   +6/-0   [ ]  ▲                       │ Draft(1) │
+│ ▾w │   …                                                  │ History  │
+│ dj │                                                      │          │
+│ d  │                                                      │          │
+│ ▾u │                                                      │          │
+│ as │                                                      │          │
+├────┴─────────────────────────────────────────────────────┴──────────┤
+│ Click: select  •  +: comment  •  Cmd↵: Send  •  V: Viewed  •  ⌘B/⌘J │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+- 左 file tree は **アイコン+省略表示モード** に切替 (幅 ~60px)。`⌘B` で full ↔ icon ↔ hidden をサイクル。実装時は幅変更を即時切替にし、ListView 内で横幅 animation を掛けない (row reflow のガタつきを避ける)。
+- 右ペインは default 280px / 最小幅 280px を維持。`⌘J` で右ペインを完全に隠して中央 diff を最大化することもできる。
+
+---
+
+## 8. キーバインド (新規 / 既存)
+
+| Key | Action |
+|---|---|
+| `Click` (line) | 行を選択 (現行と同じ) |
+| `Shift + Click` | range 選択 |
+| `+` (hover アイコン) または `Cmd/Ctrl + N` | inline コメント入力を開く (ADR 0007) |
+| `Cmd/Ctrl + Enter` (コメント入力中) | 保存 |
+| `Esc` (コメント入力中) | キャンセル |
+| `Cmd/Ctrl + Shift + Enter` | Send All Open (ADR 0007) |
+| `V` (file header 上で) | Viewed toggle |
+| `Cmd/Ctrl + B` | 左の file tree を full / icon / hidden サイクル |
+| `Cmd/Ctrl + J` | 右ペインを show / hide |
+| `Cmd/Ctrl + Shift + U` | Unified / Side-by-side toggle |
+| `Cmd/Ctrl + Enter` (selection 中) | Insert + Send (現行と同じ) |
+| `Cmd/Ctrl + C` | Copy (現行と同じ) |
+
+ADR 0007 のキーと衝突しないこと、現行 (CLAUDE.md / `ui/app.slint::global-focus`) を破壊しないことを保証する。
+
+---
+
+## 9. 注記
+
+- ASCII の比率 / 字下げは Slint 実装の正確な寸法ではなく、要素の **位置関係と階層** を示すための図形である。実装時は `min-width 1280px / min-height 720px` の制約 (`ui/app.slint`) と、resize に伴う side-by-side / file tree 切替の閾値を守る。
+- 右ペインの draft / history は ADR 0007 の Comments tab に **集約** する。現状の独立した 300px 列は廃止する。
+- Side-by-side renderer の line-pair 解決は hunk-local index を採用し、複雑なペアリングが要求された時点で `DiffLineView` を拡張する (本 ADR の決定事項)。

--- a/docs/wireframes/diff-viewer-files-changed.md
+++ b/docs/wireframes/diff-viewer-files-changed.md
@@ -1,0 +1,301 @@
+# Wireframe: Files changed-style diff viewer
+
+> 日本語: [diff-viewer-files-changed.ja.md](diff-viewer-files-changed.ja.md)
+> Related ADR: [ADR 0008](../adr/0008-files-changed-diff-viewer-layout.md)
+
+This document collects the **ASCII wireframes** for the Files changed-style layout decided in ADR 0008. Conventions:
+
+- `─ │ ┌ ┐ └ ┘ ├ ┤ ┬ ┴ ┼` — layout chrome
+- `▼ ▶` — collapsible section (expanded / collapsed)
+- `[ ]` unchecked checkbox / `[x]` checked
+- `( )` unselected radio / `(•)` selected
+- `…` truncation
+
+All measurements are approximate; exact pixel sizing is decided per resolution at Slint implementation time.
+
+---
+
+## 1. Inbox stage (no PR selected)
+
+```
+┌────────────────────────────────────────────────────────────────────────────────────┐
+│ locus — diff viewer                                                                 │
+├────────────────────────────────────────────────────────────────────────────────────┤
+│ Header: app title / connected repo / Open settings                                  │
+├──────────────────────────────┬─────────────────────────────────────────────────────┤
+│ PRs (Open)  (Closed)  (All)  │ Welcome / preview of the most recent PR, etc.       │
+│ ──────────────────────────── │                                                     │
+│ #302  duck8823               │  #302 files changed adr wireframe                   │
+│   files changed adr wirefr.. │  base main … head issue291-files-changed-adr-wir.. │
+│   Viewed 0/4    [open]       │  body excerpt …                                     │
+│ ──────────────────────────── │  Viewed 0/4    Comments 0                           │
+│ #301  bot                    │                                                     │
+│   refactor diff viewer …     │  [ Open this PR ]                                   │
+│   Viewed 2/3    [open]       │                                                     │
+│ ──────────────────────────── │                                                     │
+│ #298  duck8823               │                                                     │
+│   thread_local app state     │                                                     │
+│   Viewed 5/5 ✓  [merged]     │                                                     │
+│ ──────────────────────────── │                                                     │
+│ …                            │                                                     │
+│                              │                                                     │
+└──────────────────────────────┴─────────────────────────────────────────────────────┘
+```
+
+- Left PR list takes 30–35%. The Viewed counter sits on each row so review-resume is visible.
+- Centre is a preview. `Open this PR` transitions to the Review stage.
+
+---
+
+## 2. Review stage — Unified mode (default)
+
+```
+┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ < PRs   #302 files changed adr wireframe   base main … head issue291…   Viewed 1/4   ⌥=⌘opts  │
+├──────────────┬───────────────────────────────────────────────────────────┬─────────────────────┤
+│ Filter:      │  ▼ docs/adr/0008-files-changed-diff-viewer-layout.md     │ Comments | Terminal │
+│ [All ▾]      │     status: A   +312 / -0    Viewed [ ]    Collapse ▲    │ ─────────────────── │
+│ [search…]    │  ┌─────────┬───────────────────────────────────────────┐ │ Send All Open  ↗   │
+│ [ ] Hide     │  │ old new │ content                                   │ │ ─────────────────── │
+│     viewed   │  │   1     │ # ADR 0008: …                             │ │ Open (2)            │
+│ [ ] Hide     │  │   2     │                                           │ │ • src/foo.rs:42     │
+│     deleted  │  │   3     │ > 日本語: [0008-…ja]                      │ │   missing null chk  │
+│ ──────────── │  │ @@ -0,0 +1,42 @@   <hunk header — Cmd+click sends>  │ │ • docs/adr/0008..   │
+│ ▾ docs       │  │   …                                                  │ │   typo on line 5    │
+│   ▾ adr      │  │   42    │ ## References                             │ │ ─────────────────── │
+│     0008-…   │  │                                                      │ │ Sent (1)            │
+│     0008-…ja │  │   ・[+] add-comment row appears here on hover         │ │ • src/bar.rs:10-25  │
+│   ▾ wirefr.. │  └─────────┴───────────────────────────────────────────┘ │ ─────────────────── │
+│     diff-…   │                                                           │ Resolved (0)        │
+│     diff-…ja │  ▶ docs/wireframes/diff-viewer-files-changed.md          │                     │
+│ ▾ ui         │     status: A   +180 / -0    Viewed [x]    Expand ▼      │ ─────────────────── │
+│   app.slint  │  (collapsed; auto because Viewed = checked)               │ Draft (1)           │
+│              │                                                           │ • #302/foo.rs:42    │
+│              │  ▼ src/i18n.rs                                            │   note: …           │
+│              │     status: M   +6 / -0     Viewed [ ]    Collapse ▲     │ ─────────────────── │
+│              │  ┌─────────┬───────────────────────────────────────────┐ │ History (3)         │
+│              │  │  85  85 │   match key {                              │ │ 14:02  Send  3 cmts │
+│              │  │  86  86 │       "Click a diff line, …" => …          │ │ 13:44  Insert       │
+│              │  │     87  │+      "Viewed" => "Viewed",                │ │ 13:30  Copy         │
+│              │  │     88  │+      "Hide viewed" => "Hide viewed",      │ │                     │
+│              │  │  87  89 │       "Esc: clear selection" => …          │ │                     │
+│              │  └─────────┴───────────────────────────────────────────┘ │                     │
+│              │                                                           │                     │
+│              │  ▶ ui/diff_viewer_v2.slint   status: A  Viewed [ ]        │                     │
+│              │                                                           │                     │
+├──────────────┴───────────────────────────────────────────────────────────┴─────────────────────┤
+│ Click: select line  •  +: add comment  •  Cmd↵: Send  •  V: toggle Viewed  •  ⌘B: toggle tree │
+└────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+- **Left** (file tree + filter): 240–280px. Filter chip + search + Viewed/Deleted hide. Tree directories are collapsible. Single-file directories are flattened in the label.
+- **Centre** (diff stack): all files stacked into one ListView. Each section header is `▼/▶ path  status  +N/-M  Viewed [x]  Collapse/Expand`. Sections with Viewed = checked auto-collapse.
+- **Right** (Comments / Terminal tab): defaults to Comments. `Send All Open`, then Open / Sent / Resolved / Draft / History stacked vertically.
+
+---
+
+## 3. Review stage — Side-by-side mode
+
+```
+┌──────────────┬────────────────────────────────────────────────────────────────┬──────────┐
+│ (file tree)  │  ▼ src/i18n.rs   status: M   +6 / -0   Viewed [ ]   Collapse ▲│ (right)  │
+│              │  ┌─────┬──────────────────────┬─────┬──────────────────────┐ │          │
+│              │  │ old │ before               │ new │ after                │ │          │
+│              │  ├─────┼──────────────────────┼─────┼──────────────────────┤ │          │
+│              │  │  85 │   match key {        │  85 │   match key {        │ │          │
+│              │  │  86 │       "Click …" => …│  86 │       "Click …" => …│ │          │
+│              │  │     │                      │  87 │+      "Viewed" => … │ │          │
+│              │  │     │                      │  88 │+      "Hide viewed" │ │          │
+│              │  │  87 │       "Esc: …" => … │  89 │       "Esc: …" => … │ │          │
+│              │  └─────┴──────────────────────┴─────┴──────────────────────┘ │          │
+│              │                                                              │          │
+└──────────────┴──────────────────────────────────────────────────────────────┴──────────┘
+```
+
+- Four cells: `[old# | before | new# | after]`. Added rows leave the left empty; removed rows leave the right empty.
+- Below **1100px window width** the renderer auto-falls back to Unified and the toggle is disabled.
+
+---
+
+## 4. Collapsed file + Viewed checkbox
+
+```
+▼ docs/adr/0008-files-changed-diff-viewer-layout.md
+   status: A   +312 / -0    Viewed [ ]    Collapse ▲
+   <diff body shown>
+   …
+
+▶ docs/wireframes/diff-viewer-files-changed.md
+   status: A   +180 / -0    Viewed [x]    Expand ▼
+   (collapsed: auto-folded because Viewed = checked)
+
+▶ ui/diff_viewer_v2.slint
+   status: A   +0 / -0    Viewed [ ]    Expand ▼
+   (manual collapse)
+```
+
+- Collapse triangle and Viewed checkbox act independently. Setting Viewed = checked auto-collapses, but `Expand ▼` reopens the body without unchecking Viewed (i.e. "I've seen it but want to look again").
+- Clicking the header anywhere except the Viewed checkbox toggles collapse — the checkbox uses its own TouchArea so the click does not bubble.
+
+---
+
+## 5. Inline comment input
+
+```
+   42  42      something_useful();
+   43  43  +   another_line();        <- hover shows [+] on the right
+              ┌──────────────────────────────────────────────┐
+              │ Add comment on docs/adr/0008-…md:43          │
+              │ ┌──────────────────────────────────────────┐ │
+              │ │ This link is stale; point at the latest  │ │
+              │ │ ADR.                                      │ │
+              │ └──────────────────────────────────────────┘ │
+              │ [ Cancel ]      [ Save (Cmd+Enter) ]         │
+              └──────────────────────────────────────────────┘
+   44  44      yet_another_line();
+   45  ●●  -   removed_line();        <- left-gutter dot = existing comments (count)
+   46  45      tail_line();
+```
+
+- Hovering a line surfaces a `+` on the right edge. Clicking inserts **a new row directly beneath the line** with the input area. Esc cancels, Cmd+Enter saves.
+- Lines that already have comments show **a dot in the left gutter**. Clicking the dot scrolls and highlights the matching entry in the right Comments tab.
+- Range selection (shift+click) opens the inline input below the last line of the range.
+
+---
+
+## 6. Right pane (Comments / Terminal tab swap)
+
+### 6a. Comments tab (default)
+
+```
+┌─────────────────────────────────┐
+│ Comments | Terminal             │   <- tab strip
+├─────────────────────────────────┤
+│ [ Send All Open ↗ ]   filters ▾ │
+├─────────────────────────────────┤
+│ Selection (collapsed) ▶          │   <- former preview / Insert / Copy folded here
+├─────────────────────────────────┤
+│ Open (2)                         │
+│ • docs/adr/0008-…md:43           │
+│   This link is stale, …          │
+│   [edit] [send] [resolve]        │
+│ • src/foo.rs:42                  │
+│   missing null check             │
+├─────────────────────────────────┤
+│ Sent (1)                         │
+│ • src/bar.rs:10-25               │
+│   this function has no test      │
+├─────────────────────────────────┤
+│ Resolved (0)                     │
+│   (none yet)                     │
+├─────────────────────────────────┤
+│ Draft (1)                        │
+│ • #302/foo.rs:42 — note: …       │
+├─────────────────────────────────┤
+│ History (3)                      │
+│ 14:02  Send  3 cmts              │
+│ 13:44  Insert  selection         │
+│ 13:30  Copy   selection          │
+└─────────────────────────────────┘
+```
+
+- The `Selection` section preserves today's preview pane as a collapsible band — old flow stays available during migration.
+- `Open / Sent / Resolved` mirror ADR 0007's status grouping.
+- Right-pane width is drag-resizable (280–600px).
+
+### 6b. Terminal tab
+
+```
+┌─────────────────────────────────┐
+│ Comments | Terminal             │
+├─────────────────────────────────┤
+│ agent: claude code (running)    │
+├─────────────────────────────────┤
+│ $ claude code                   │
+│ ▍                               │
+│ > Reconcile the wireframe with  │
+│   ADR 0008.                     │
+│                                 │
+│ I'll update the wireframe to …  │
+│ ──────────────────────────────  │
+│                                 │
+│ (terminal full-height; PTY)     │
+│                                 │
+└─────────────────────────────────┘
+```
+
+- Defaults to Comments at startup. With `LOCUS_AUTOSWITCH_TERMINAL=true` the pane auto-switches to Terminal right after `Send All Open`.
+- `LOCUS_RIGHT_PANE=split` shows Comments and Terminal stacked vertically (50/50 initial split, drag handle to resize).
+
+---
+
+## 7. Filter / Viewed-hide / search
+
+```
+Filter:
+  [All ▾]                    ← dropdown for extension / status
+  [search…           ]       ← path substring match
+  [ ] Hide already viewed
+  [ ] Hide deleted
+  [ Reset ]
+```
+
+- Filter is live-applied to the file tree. Tree roots (`docs/`, `src/`, …) remain visible even when child counts drop to 0; they are greyed out and labelled `(0 files)`.
+- `Reset` clears the filters but keeps Viewed checkbox state intact.
+
+---
+
+## 8. 1280×720 compact layout
+
+The supported minimum (per CLAUDE.md `min-width 1280px`) compresses the side panes:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ < PRs  #302 …  Viewed 1/4         [Unified ▾]  ⌘B tree  ⌘J side      │
+├────┬─────────────────────────────────────────────────────┬──────────┤
+│ ▼  │ ▼ docs/adr/0008-…md   +312/-0   [ ]  ▲              │ Comments │
+│ ▾d │   …                                                  │ Open(2)  │
+│ ▾a │                                                      │ Sent(1)  │
+│ 8j │ ▶ docs/wireframes/diff-…md   +180/-0   [x]  ▼        │ ─────── │
+│ 8e │ ▼ src/i18n.rs   +6/-0   [ ]  ▲                       │ Draft(1) │
+│ ▾w │   …                                                  │ History  │
+│ dj │                                                      │          │
+│ d  │                                                      │          │
+│ ▾u │                                                      │          │
+│ as │                                                      │          │
+├────┴─────────────────────────────────────────────────────┴──────────┤
+│ Click: select  •  +: comment  •  Cmd↵: Send  •  V: Viewed  •  ⌘B/⌘J │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+- The left tree switches to **icon + truncated label mode** (~60px). `⌘B` cycles full ↔ icon ↔ hidden. Implementation should make the width change immediate and avoid animating ListView row width, to prevent visible reflow jitter.
+- The right pane is 280px by default and refuses to drop below 280px. `⌘J` hides the right pane entirely so the centre diff can use the full width.
+
+---
+
+## 9. Keybindings (new + existing)
+
+| Key | Action |
+|---|---|
+| `Click` (line) | Select line (unchanged from today) |
+| `Shift + Click` | Range select |
+| `+` (hover icon) or `Cmd/Ctrl + N` | Open inline comment input (ADR 0007) |
+| `Cmd/Ctrl + Enter` (in comment input) | Save comment |
+| `Esc` (in comment input) | Cancel |
+| `Cmd/Ctrl + Shift + Enter` | Send All Open (ADR 0007) |
+| `V` (over a file header) | Toggle Viewed |
+| `Cmd/Ctrl + B` | Cycle left tree: full / icon / hidden |
+| `Cmd/Ctrl + J` | Show / hide right pane |
+| `Cmd/Ctrl + Shift + U` | Toggle Unified / Side-by-side |
+| `Cmd/Ctrl + Enter` (with selection) | Insert + Send (unchanged) |
+| `Cmd/Ctrl + C` | Copy (unchanged) |
+
+These must not collide with ADR 0007 keys, nor break the current `ui/app.slint::global-focus` bindings.
+
+---
+
+## 10. Notes
+
+- ASCII proportions are not Slint pixel sizes; they show **structure and hierarchy**, not measurements. Implementation must respect `min-width 1280px / min-height 720px` (`ui/app.slint`) and the side-by-side / file-tree breakpoints described above.
+- Draft and history are **consolidated into the Comments tab** (ADR 0007). The current standalone 300px right column is retired.
+- Side-by-side line pairing uses hunk-local indices; explicit pairing fields on `DiffLineView` are deferred until a concrete need (per ADR 0008's decision).


### PR DESCRIPTION
## Motivation

#291 は現行 diff viewer の single-screen layout の限界を整理し、GitHub PR "Files changed" 風の構造へ作り直す前段として ADR / mock / migration plan を要求している。

この PR では実装には入らず、v0.2 候補としての設計判断と ASCII wireframe を固定する。

Closes #291

## Changes

- `docs/adr/0008-files-changed-diff-viewer-layout.ja.md` / `.md` を追加
  - 現行 layout の制約評価
  - GitHub Files changed UX の locus への落とし込み
  - file tree / filter / viewed / collapsible / unified-split / right pane tab 方針
  - ADR 0007 Comments との統合方針
  - feature flag 併走による段階的 migration
  - non-goals / alternatives / implementation plan
- `docs/wireframes/diff-viewer-files-changed.ja.md` / `.md` を追加
  - Inbox stage / Review stage
  - Unified / Side-by-side
  - collapsed + Viewed
  - inline comment input
  - Comments / Terminal right pane
  - 1280x720 compact mode

## Validation

- Claude Code Opus design/docs pass
- `rtk git diff --check`
- Documentation-only change; Rust build/test skipped

## Sources

- GitHub Docs — Reviewing proposed changes in a pull request
- GitHub Docs — Filtering files in a pull request
- GitHub Docs — About comparing branches in pull requests
