### PR TITLE
feat(semantic): Go import mini-map を追加

### DIFF
--- a/lang/ja/LC_MESSAGES/locus.po
+++ b/lang/ja/LC_MESSAGES/locus.po
@@ -91,6 +91,22 @@ msgstr "セマンティック"
 msgid "(no semantic changes)"
 msgstr "(意味的変更なし)"
 
+# Architecture mini-map (#208)
+msgid "Architecture"
+msgstr "アーキテクチャ"
+
+msgid "(no architecture data)"
+msgstr "(アーキテクチャ情報なし)"
+
+msgid "Center"
+msgstr "中心"
+
+msgid "Upstream"
+msgstr "上流"
+
+msgid "Downstream"
+msgstr "下流"
+
 msgid "function"
 msgstr "関数"
 

--- a/src/app/diff_viewer/callbacks.rs
+++ b/src/app/diff_viewer/callbacks.rs
@@ -10,7 +10,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Instant;
 
-use slint::{ComponentHandle, SharedString};
+use slint::{ComponentHandle, Model, SharedString};
 
 use super::linked_issues::fetch_linked_issues_parallel;
 use super::refresh::{
@@ -38,6 +38,50 @@ fn diag_trace_ui_events_enabled() -> bool {
     std::env::var("LOCUS_DIAG_TRACE_RENDER_TICKS")
         .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "on" | "yes"))
         .unwrap_or(false)
+}
+
+const DIFF_ROW_HEIGHT_PX: f32 = 18.0;
+
+/// source line number を現在の diff ListView row index に近似変換する。
+///
+/// `line_no` は source file の絶対行番号だが、diff viewer が描画しているのは
+/// hunk header + 変更行 + context 行だけである。そのため単純な
+/// `(line_no - 1) * row_height` ではなく、表示中の DiffLineView を走査して
+/// old/new line number が一致する row、なければ最も近い row を使う。
+fn diff_scroll_y_for_source_line(
+    ui: &DiffViewerWindow,
+    file_index: usize,
+    line_no: i32,
+) -> Option<f32> {
+    if line_no <= 0 {
+        return None;
+    }
+
+    let file = ui.get_files().row_data(file_index)?;
+    let mut best: Option<(usize, u32)> = None;
+    for row in 0..file.lines.row_count() {
+        let Some(diff_line) = file.lines.row_data(row) else {
+            continue;
+        };
+        if diff_line.is_hunk_header {
+            continue;
+        }
+
+        for raw in [diff_line.old_line_no.as_str(), diff_line.new_line_no.as_str()] {
+            let Ok(row_line) = raw.parse::<i32>() else {
+                continue;
+            };
+            let distance = row_line.abs_diff(line_no);
+            if distance == 0 {
+                return Some(row as f32 * DIFF_ROW_HEIGHT_PX);
+            }
+            if best.is_none_or(|(_, best_distance)| distance < best_distance) {
+                best = Some((row, distance));
+            }
+        }
+    }
+
+    best.map(|(row, _)| row as f32 * DIFF_ROW_HEIGHT_PX)
 }
 
 /// Diff viewer の Slint コールバックをまとめて配線する。
@@ -467,6 +511,60 @@ pub(crate) fn wire_diff_viewer_callbacks(
                     });
                 });
             });
+        });
+    }
+
+    // architecture-node-clicked (#208): mini-map のノードクリックから呼ばれる。
+    // file-index < 0 は外部 import / overflow なので no-op。それ以外は
+    // 現在の diff-scroll-y を旧 file index で保存し、selected-file-index を
+    // 切り替え、復元する。line-no > 0 のときは diff row の old/new line number
+    // から対象 source line に最も近い表示 row を探してスクロールする。
+    {
+        let state = state.clone();
+        let ui_weak = ui.as_weak();
+        let owner = owner.to_string();
+        let repo = repo.to_string();
+        ui.on_architecture_node_clicked(move |file_index: i32, line_no: i32| {
+            let Some(ui) = ui_weak.upgrade() else { return };
+            if file_index < 0 {
+                return;
+            }
+            let new_idx = file_index as usize;
+            let file_count = ui.get_files().row_count();
+            if new_idx >= file_count {
+                return;
+            }
+
+            let old_idx = ui.get_selected_file_index() as usize;
+            if old_idx != new_idx {
+                let cur_scroll = ui.get_diff_scroll_y();
+                state
+                    .borrow_mut()
+                    .scroll_positions
+                    .insert(old_idx, cur_scroll);
+                ui.set_selected_file_index(file_index);
+                let restore = state
+                    .borrow()
+                    .scroll_positions
+                    .get(&new_idx)
+                    .copied()
+                    .unwrap_or(0.0);
+                ui.set_diff_scroll_y(restore);
+                save_pr_session(&owner, &repo, &state.borrow(), &ui);
+                // 既存 on_file_switched closure が pending_range の解除と
+                // anchor label の refresh を担う。ここでは invoke するだけ。
+                ui.invoke_file_switched(file_index);
+            }
+
+            if line_no > 0
+                && let Some(target) = diff_scroll_y_for_source_line(&ui, new_idx, line_no)
+            {
+                ui.set_diff_scroll_y(target);
+                state
+                    .borrow_mut()
+                    .scroll_positions
+                    .insert(new_idx, target);
+            }
         });
     }
 

--- a/src/app/diff_viewer/snapshot.rs
+++ b/src/app/diff_viewer/snapshot.rs
@@ -11,9 +11,15 @@ use crate::github::issue_context::{IssueContextRecord, IssueState};
 use crate::github::pull_request::{
     PrListState, PullRequestFile, PullRequestSnapshot, PullRequestSummary,
 };
-use crate::semantic::{ChangeType, SymbolKind, analyze_pull_request_file};
+use crate::semantic::{
+    ArchitectureNodeKind, ChangeType, SymbolKind, analyze_pull_request_file,
+    build_architecture_nodes,
+};
 use crate::ui_state::diff_view::build_diff_file_views;
-use crate::{DiffViewerWindow, IssueContextView, PullRequestListItemView, SemanticItemView};
+use crate::{
+    ArchitectureNodeView, DiffViewerWindow, IssueContextView, PullRequestListItemView,
+    SemanticItemView,
+};
 
 use super::util::{excerpt, short_sha};
 
@@ -48,6 +54,41 @@ pub(crate) fn apply_snapshot_to_ui(
     ui.set_selected_file_index(0);
     ui.set_diff_scroll_y(0.0);
     ui.set_semantic_items(build_semantic_items_model(&snapshot.files));
+    ui.set_architecture_nodes(build_architecture_nodes_model(&snapshot.files));
+}
+
+/// Architecture mini-map (#208) のノード列を Slint Model に詰め直す。
+///
+/// `file_index` は usize → i32。PR_FILE 数は実用的な範囲で i32 に収まる
+/// 想定なので、unwrap_or(-1) と as i32 で外部 / 解決不可ノードを表現する。
+pub(crate) fn build_architecture_nodes_model(
+    files: &[PullRequestFile],
+) -> ModelRc<ArchitectureNodeView> {
+    let nodes = build_architecture_nodes(files);
+    let model = VecModel::<ArchitectureNodeView>::default();
+    for node in nodes {
+        let (kind_label, kind_key) = architecture_kind_labels(node.kind);
+        model.push(ArchitectureNodeView {
+            kind_label: SharedString::from(kind_label),
+            kind_key: SharedString::from(kind_key),
+            label: SharedString::from(node.label.as_str()),
+            detail: SharedString::from(node.detail.as_str()),
+            file_index: node.file_index.map(|i| i as i32).unwrap_or(-1),
+            line_no: node.line_no.map(|l| l as i32).unwrap_or(0),
+        });
+    }
+    ModelRc::from(
+        std::rc::Rc::new(model) as std::rc::Rc<dyn slint::Model<Data = ArchitectureNodeView>>,
+    )
+}
+
+fn architecture_kind_labels(kind: ArchitectureNodeKind) -> (String, &'static str) {
+    let (key, raw) = match kind {
+        ArchitectureNodeKind::Center => ("Center", "center"),
+        ArchitectureNodeKind::Upstream => ("Upstream", "upstream"),
+        ArchitectureNodeKind::Downstream => ("Downstream", "downstream"),
+    };
+    (crate::i18n::tr(key), raw)
 }
 
 /// PR snapshot 全ファイルを semantic adapter に通し、UI 用の linear list を作る。

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -112,6 +112,12 @@ fn translate_ja(key: &str) -> Option<&'static str> {
         // semantic panel (#207 spike)
         "Semantic" => "セマンティック",
         "(no semantic changes)" => "(意味的変更なし)",
+        // architecture mini-map (#208)
+        "Architecture" => "アーキテクチャ",
+        "(no architecture data)" => "(アーキテクチャ情報なし)",
+        "Center" => "中心",
+        "Upstream" => "上流",
+        "Downstream" => "下流",
         "function" => "関数",
         "method" => "メソッド",
         "class" => "クラス",

--- a/src/semantic/adapter.rs
+++ b/src/semantic/adapter.rs
@@ -54,6 +54,12 @@ pub struct ParserDiffItem {
     pub change_type: super::ir::ChangeType,
     pub signature_summary: Option<String>,
     pub body_summary: Option<String>,
+    /// after 側 (Removed の場合は before 側) における symbol の開始行 (1-indexed)。
+    /// パーサが位置情報を持たない場合や file-level item の場合は None。
+    /// architecture mini-map で symbol jump 用に使う。
+    pub start_line: Option<u32>,
+    /// 同上の終了行 (1-indexed)。
+    pub end_line: Option<u32>,
 }
 
 /// 1 ファイル分の adapter 出力。

--- a/src/semantic/architecture.rs
+++ b/src/semantic/architecture.rs
@@ -1,0 +1,576 @@
+//! Architecture mini-map (#208)。
+//!
+//! Go の import グラフを使って、変更された関数・メソッドの 1 hop 上流 / 下流を
+//! 列挙する小さなビューを作る。precise な caller/callee 解析はせず、package
+//! 単位の import 関係に留める。
+//!
+//! 入力は PR の `PullRequestFile` 配列。Go かつ supported なファイルだけを対象に、
+//! file-level の変更シンボル / file が import している外部 path / PR 内の他
+//! ファイルが import している package を 1 つのフラットな `ArchitectureNode`
+//! 配列にまとめる。
+//!
+//! UI 側はこの配列をそのまま縦並びの mini-map として表示し、ノードクリックで
+//! `file_index` の指す PR ファイルにジャンプする。`line_no` が乗っている
+//! ノード（changed symbol）は該当行までスクロールする。
+
+use crate::github::pull_request::PullRequestFile;
+use crate::semantic::analyze::analyze_pull_request_file;
+use crate::semantic::go::{GoParseTree, GoParserAdapter};
+use crate::semantic::ir::ChangeType;
+
+/// 1 ノードがどの種類かを示す。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArchitectureNodeKind {
+    /// このファイルの変更シンボル本体。クリックでファイル＋シンボル行にジャンプ。
+    Center,
+    /// このファイルが import している package（1 hop 下流）。
+    Downstream,
+    /// PR 内の他ファイルがこのファイルの package を import している（1 hop 上流）。
+    Upstream,
+}
+
+/// mini-map に並ぶ 1 ノード。UI に渡しやすいよう値型のみで構成する。
+#[derive(Debug, Clone)]
+pub struct ArchitectureNode {
+    pub kind: ArchitectureNodeKind,
+    /// 第一行（symbol 名 / import path / 他ファイル path）。
+    pub label: String,
+    /// 第二行（focus ファイル path や 補足）。空文字でも OK。
+    pub detail: String,
+    /// PR 内ファイルに解決できる場合の index。external import 等は None。
+    pub file_index: Option<usize>,
+    /// symbol の開始行 (1-indexed)。Center 以外は None。
+    pub line_no: Option<u32>,
+}
+
+/// 1 focus ファイルあたりの downstream / upstream ノードの上限。表示過多防止。
+const PER_FILE_NEIGHBOR_CAP: usize = 5;
+
+/// 全ファイル合計のノード数の上限。さらに溢れた分は捨てる（mini-map 用途）。
+const TOTAL_NODE_CAP: usize = 24;
+
+/// PR 全体から architecture mini-map のノード列を作る。
+///
+/// 順序:
+///   focus file ごとに [Center..., Downstream..., Upstream...] を並べる。
+///   focus file は PR の `files` 並び順を保つ。
+pub fn build_architecture_nodes(files: &[PullRequestFile]) -> Vec<ArchitectureNode> {
+    let go_files = collect_go_files(files);
+    let mut nodes: Vec<ArchitectureNode> = Vec::new();
+
+    for focus in &go_files {
+        if focus.changed_symbols.is_empty() {
+            continue;
+        }
+
+        // Center: 変更された symbol。複数あれば全部出すが TOTAL_NODE_CAP には従う。
+        for sym in &focus.changed_symbols {
+            push_capped(
+                &mut nodes,
+                ArchitectureNode {
+                    kind: ArchitectureNodeKind::Center,
+                    label: sym.display.clone(),
+                    detail: focus.file_path.clone(),
+                    file_index: Some(focus.file_index),
+                    line_no: Some(sym.start_line),
+                },
+            );
+            if nodes.len() >= TOTAL_NODE_CAP {
+                return nodes;
+            }
+        }
+
+        // Downstream: focus file の import path を出す (PR 内ファイルなら index 解決)。
+        let mut downstream_emitted = 0usize;
+        let mut downstream_seen: Vec<&str> = Vec::new();
+        for import_path in &focus.imports {
+            if downstream_seen.contains(&import_path.as_str()) {
+                continue;
+            }
+            downstream_seen.push(import_path.as_str());
+            if downstream_emitted >= PER_FILE_NEIGHBOR_CAP {
+                push_capped(
+                    &mut nodes,
+                    ArchitectureNode {
+                        kind: ArchitectureNodeKind::Downstream,
+                        label: format!("+{} more", focus.imports.len() - downstream_emitted),
+                        detail: focus.file_path.clone(),
+                        file_index: None,
+                        line_no: None,
+                    },
+                );
+                break;
+            }
+            let resolved = resolve_internal_target(import_path, &go_files);
+            push_capped(
+                &mut nodes,
+                ArchitectureNode {
+                    kind: ArchitectureNodeKind::Downstream,
+                    label: import_path.clone(),
+                    detail: focus.file_path.clone(),
+                    file_index: resolved,
+                    line_no: None,
+                },
+            );
+            downstream_emitted += 1;
+            if nodes.len() >= TOTAL_NODE_CAP {
+                return nodes;
+            }
+        }
+
+        // Upstream: PR 内の他 Go ファイルで focus.package_dir を import suffix
+        // として持つものを列挙する。package name だけの一致は stdlib/external
+        // import と誤結合しやすいため使わない。
+        let upstream_targets = upstream_caller_indices(focus, &go_files);
+        for (upstream_emitted, &caller_idx) in upstream_targets.iter().enumerate() {
+            if upstream_emitted >= PER_FILE_NEIGHBOR_CAP {
+                push_capped(
+                    &mut nodes,
+                    ArchitectureNode {
+                        kind: ArchitectureNodeKind::Upstream,
+                        label: format!("+{} more", upstream_targets.len() - upstream_emitted),
+                        detail: focus.file_path.clone(),
+                        file_index: None,
+                        line_no: None,
+                    },
+                );
+                break;
+            }
+            let caller = &go_files[caller_idx];
+            push_capped(
+                &mut nodes,
+                ArchitectureNode {
+                    kind: ArchitectureNodeKind::Upstream,
+                    label: caller.file_path.clone(),
+                    detail: focus.file_path.clone(),
+                    file_index: Some(caller.file_index),
+                    line_no: None,
+                },
+            );
+            if nodes.len() >= TOTAL_NODE_CAP {
+                return nodes;
+            }
+        }
+    }
+
+    nodes
+}
+
+/// 1 changed Go file に集約した内部表現。
+#[derive(Debug, Clone)]
+struct GoFileSummary {
+    /// PR の `files[]` における index。UI からのクリック解決に使う。
+    file_index: usize,
+    file_path: String,
+    /// `file_path` から取り出したパッケージのディレクトリパス。
+    /// 例: `internal/foo/bar.go` -> `internal/foo`。
+    package_dir: String,
+    imports: Vec<String>,
+    changed_symbols: Vec<ChangedSymbol>,
+}
+
+#[derive(Debug, Clone)]
+struct ChangedSymbol {
+    display: String,
+    start_line: u32,
+}
+
+fn collect_go_files(files: &[PullRequestFile]) -> Vec<GoFileSummary> {
+    let mut out = Vec::new();
+    for (idx, file) in files.iter().enumerate() {
+        if file.is_binary || file.unsupported.is_some() {
+            continue;
+        }
+        if !is_go_file(&file.file_path) {
+            continue;
+        }
+
+        let result = analyze_pull_request_file(file);
+        if result.adapter_name != GoParserAdapter::NAME {
+            // 言語検出は通ったが adapter routing が Go でないケース。
+            // たとえば before/after 両方欠落で空結果が返ったような場合にここで弾く。
+            continue;
+        }
+
+        // 解析木が無いと imports が取れないので after を再パース。
+        // run_go_parser は ParserDiffResult しか返さないので、改めて raw 取得用に
+        // GoParserAdapter で parse し直す。
+        let after_tree = parse_go_tree_for_after(file);
+
+        let imports = after_tree
+            .as_ref()
+            .map(|t| t.imports.clone())
+            .unwrap_or_default();
+        let package_dir = parent_dir(&file.file_path).to_string();
+
+        let mut changed_symbols = Vec::new();
+        for item in result.items {
+            // file-level rename (Module) は Center に出さない。Function / Method
+            // の Added / Removed / Modified / Renamed のみ対象。
+            use crate::semantic::ir::SymbolKind;
+            if !matches!(item.kind, SymbolKind::Function | SymbolKind::Method) {
+                continue;
+            }
+            if !matches!(
+                item.change_type,
+                ChangeType::Added
+                    | ChangeType::Removed
+                    | ChangeType::Modified
+                    | ChangeType::Renamed
+            ) {
+                continue;
+            }
+            // start_line が無い (parser が位置を持たない) アイテムは line jump を
+            // None で乗せ、ファイルだけにジャンプさせる。
+            changed_symbols.push(ChangedSymbol {
+                display: item.display_name,
+                start_line: item.start_line.unwrap_or(1),
+            });
+        }
+
+        out.push(GoFileSummary {
+            file_index: idx,
+            file_path: file.file_path.clone(),
+            package_dir,
+            imports,
+            changed_symbols,
+        });
+    }
+    out
+}
+
+fn parse_go_tree_for_after(file: &PullRequestFile) -> Option<GoParseTree> {
+    use crate::review::snapshot::{Revision, SourceSnapshot};
+    use crate::semantic::adapter::ParserAdapter;
+    let content = file.after_content.as_ref().or(file.before_content.as_ref())?;
+    let snap = SourceSnapshot {
+        file_id: file.file_id.clone(),
+        file_path: file.file_path.clone(),
+        language: Some("go".into()),
+        revision: Revision::After,
+        content: content.clone(),
+    };
+    let parsed = GoParserAdapter::new().parse(&snap);
+    let raw = parsed.raw?;
+    raw.downcast_ref::<GoParseTree>().cloned()
+}
+
+fn parent_dir(path: &str) -> &str {
+    match path.rfind('/') {
+        Some(i) => &path[..i],
+        None => "",
+    }
+}
+
+fn is_go_file(path: &str) -> bool {
+    path.rsplit('.')
+        .next()
+        .map(|ext| ext.eq_ignore_ascii_case("go") && ext != path)
+        .unwrap_or(false)
+}
+
+/// import path が PR 内のどの Go ファイルに対応するかを suffix heuristic で解決する。
+///
+/// 例: import path `github.com/foo/bar/internal/util` と PR 内の `internal/util/x.go`
+/// は package_dir `internal/util` でマッチする。複数候補がある場合は
+/// `util` より `internal/util` を優先するため、最長 package_dir 一致を採用する。
+fn resolve_internal_target(import_path: &str, go_files: &[GoFileSummary]) -> Option<usize> {
+    if import_path.is_empty() {
+        return None;
+    }
+    let mut best: Option<(usize, usize)> = None; // (file_index, matched_dir_len)
+    for f in go_files {
+        if f.package_dir.is_empty() {
+            continue;
+        }
+        if import_path == f.package_dir
+            || import_path.ends_with(&format!("/{}", f.package_dir))
+        {
+            let len = f.package_dir.len();
+            if best.is_none_or(|(_, best_len)| len > best_len) {
+                best = Some((f.file_index, len));
+            }
+        }
+    }
+    best.map(|(idx, _)| idx)
+}
+
+/// focus を import している PR 内 Go ファイル の `go_files` index を返す。
+///
+/// マッチ条件 (suffix heuristic):
+/// - caller の import 先 path が `focus.package_dir` と等しい
+/// - caller の import 先 path が `<...>/<focus.package_dir>` の形で終わる
+///
+/// 自分自身は除外する。
+fn upstream_caller_indices(focus: &GoFileSummary, go_files: &[GoFileSummary]) -> Vec<usize> {
+    let mut indices = Vec::new();
+    for (i, candidate) in go_files.iter().enumerate() {
+        if candidate.file_index == focus.file_index {
+            continue;
+        }
+        let mut matched = false;
+        for imp in &candidate.imports {
+            if !focus.package_dir.is_empty()
+                && (imp == &focus.package_dir
+                    || imp.ends_with(&format!("/{}", focus.package_dir)))
+            {
+                matched = true;
+                break;
+            }
+        }
+        if matched {
+            indices.push(i);
+        }
+    }
+    indices
+}
+
+fn push_capped(nodes: &mut Vec<ArchitectureNode>, node: ArchitectureNode) {
+    if nodes.len() >= TOTAL_NODE_CAP {
+        return;
+    }
+    nodes.push(node);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::github::pull_request::FileStatus;
+    use crate::review::snapshot::{FileId, UnsupportedFile};
+
+    fn pr_file(path: &str, before: Option<&str>, after: Option<&str>) -> PullRequestFile {
+        let status = match (before, after) {
+            (None, Some(_)) => FileStatus::Added,
+            (Some(_), None) => FileStatus::Removed,
+            _ => FileStatus::Modified,
+        };
+        PullRequestFile {
+            file_id: FileId::new(path),
+            file_path: path.into(),
+            previous_file_path: None,
+            status,
+            before_content: before.map(str::to_string),
+            after_content: after.map(str::to_string),
+            patch: None,
+            is_binary: false,
+            unsupported: None,
+        }
+    }
+
+    #[test]
+    fn parent_dir_helper() {
+        assert_eq!(parent_dir("a/b/c.go"), "a/b");
+        assert_eq!(parent_dir("foo.go"), "");
+        assert_eq!(parent_dir("/abs/foo.go"), "/abs");
+    }
+
+    #[test]
+    fn non_go_files_do_not_appear_in_minimap() {
+        let files = vec![
+            pr_file("README.md", Some("a"), Some("b")),
+            pr_file("script.ts", Some("a"), Some("b")),
+        ];
+        let nodes = build_architecture_nodes(&files);
+        assert!(nodes.is_empty(), "nodes: {nodes:?}");
+    }
+
+    #[test]
+    fn binary_or_unsupported_go_file_skipped() {
+        let mut bin = pr_file("blob.go", None, None);
+        bin.is_binary = true;
+        let mut unsup = pr_file(
+            "src/x.go",
+            Some("package main\nfunc A(){}\n"),
+            Some("package main\nfunc A(){}\nfunc B(){}\n"),
+        );
+        unsup.unsupported = Some(UnsupportedFile::PatchMissing {
+            file_id: unsup.file_id.clone(),
+            file_path: unsup.file_path.clone(),
+            reason: "x".into(),
+        });
+        let nodes = build_architecture_nodes(&[bin, unsup]);
+        assert!(nodes.is_empty());
+    }
+
+    #[test]
+    fn go_file_with_no_changes_emits_no_nodes() {
+        // before == after かつ symbol body 同一なら ParserDiffResult.items は空。
+        let same = "package main\nfunc A(){}\n";
+        let files = vec![pr_file("a.go", Some(same), Some(same))];
+        let nodes = build_architecture_nodes(&files);
+        assert!(nodes.is_empty(), "nodes: {nodes:?}");
+    }
+
+    #[test]
+    fn changed_symbol_emits_center_node_with_line_info() {
+        let after = "package main\nimport \"fmt\"\nfunc Hello() string {\n  fmt.Println(\"x\")\n  return \"y\"\n}\n";
+        let files = vec![pr_file("hello.go", None, Some(after))];
+        let nodes = build_architecture_nodes(&files);
+        let center = nodes
+            .iter()
+            .find(|n| n.kind == ArchitectureNodeKind::Center)
+            .expect("center node");
+        assert_eq!(center.label, "Hello");
+        assert_eq!(center.file_index, Some(0));
+        assert!(center.line_no.unwrap_or(0) >= 1);
+        assert_eq!(center.detail, "hello.go");
+    }
+
+    #[test]
+    fn downstream_node_emitted_for_each_unique_import() {
+        let after = "package main\n\
+             import (\n\
+                 \"fmt\"\n\
+                 \"os\"\n\
+                 \"fmt\"\n\
+             )\n\
+             func Hello() {}\n";
+        let files = vec![pr_file("hello.go", None, Some(after))];
+        let nodes = build_architecture_nodes(&files);
+        let downstream: Vec<&ArchitectureNode> = nodes
+            .iter()
+            .filter(|n| n.kind == ArchitectureNodeKind::Downstream)
+            .collect();
+        // dedupe で fmt が 2 回出ない
+        let labels: Vec<&str> = downstream.iter().map(|n| n.label.as_str()).collect();
+        assert!(labels.contains(&"fmt"));
+        assert!(labels.contains(&"os"));
+        assert_eq!(
+            downstream.iter().filter(|n| n.label == "fmt").count(),
+            1
+        );
+    }
+
+    #[test]
+    fn upstream_node_resolves_other_pr_file_by_directory_suffix() {
+        // util/util.go を変更し、main.go が github.com/x/util を import している
+        // ケース。util.go の package_dir は "util" なので suffix 一致で main.go が
+        // upstream として出る。
+        let util_after =
+            "package util\nfunc Helper() string { return \"a\" }\n";
+        let util_before = "package util\nfunc Helper() string { return \"b\" }\n";
+        let main_after =
+            "package main\nimport \"github.com/x/util\"\nfunc main(){ util.Helper() }\n";
+        let files = vec![
+            pr_file("util/util.go", Some(util_before), Some(util_after)),
+            pr_file("main.go", Some(main_after), Some(main_after)),
+        ];
+        let nodes = build_architecture_nodes(&files);
+
+        let upstream: Vec<&ArchitectureNode> = nodes
+            .iter()
+            .filter(|n| n.kind == ArchitectureNodeKind::Upstream)
+            .collect();
+        assert_eq!(upstream.len(), 1, "nodes: {nodes:?}");
+        assert_eq!(upstream[0].label, "main.go");
+        assert_eq!(upstream[0].file_index, Some(1));
+    }
+
+    #[test]
+    fn upstream_does_not_match_by_package_name_only() {
+        // internal/log/log.go は package log だが、main.go の `import "log"` は
+        // Go stdlib の log であって internal/log ではない。package name だけで
+        // 結びつけると false upstream になるため、directory suffix 一致だけを
+        // 採用する。
+        let focus_before = "package log\nfunc Helper() string { return \"old\" }\n";
+        let focus_after = "package log\nfunc Helper() string { return \"new\" }\n";
+        let main_after = "package main\nimport \"log\"\nfunc main(){ log.Println(\"x\") }\n";
+        let files = vec![
+            pr_file("internal/log/log.go", Some(focus_before), Some(focus_after)),
+            pr_file("cmd/main.go", Some(main_after), Some(main_after)),
+        ];
+        let nodes = build_architecture_nodes(&files);
+        let upstream: Vec<&ArchitectureNode> = nodes
+            .iter()
+            .filter(|n| n.kind == ArchitectureNodeKind::Upstream)
+            .collect();
+        assert!(upstream.is_empty(), "nodes: {nodes:?}");
+    }
+
+    #[test]
+    fn downstream_resolves_internal_pr_file_index() {
+        // a/foo.go is changed; it imports github.com/x/util; util/util.go is in PR.
+        // Downstream node for "github.com/x/util" should resolve to util/util.go.
+        let foo_after = "package a\nimport \"github.com/x/util\"\nfunc Use(){ util.Helper() }\n";
+        let util_src = "package util\nfunc Helper() {}\n";
+        let files = vec![
+            pr_file("a/foo.go", None, Some(foo_after)),
+            pr_file("util/util.go", Some(util_src), Some(util_src)),
+        ];
+        let nodes = build_architecture_nodes(&files);
+        let downstream: Vec<&ArchitectureNode> = nodes
+            .iter()
+            .filter(|n| n.kind == ArchitectureNodeKind::Downstream)
+            .collect();
+        let resolved = downstream
+            .iter()
+            .find(|n| n.label == "github.com/x/util")
+            .expect("util downstream node");
+        assert_eq!(resolved.file_index, Some(1));
+    }
+
+    #[test]
+    fn downstream_resolution_prefers_longest_directory_suffix() {
+        let foo_after =
+            "package a\nimport \"github.com/x/internal/util\"\nfunc Use(){ util.Helper() }\n";
+        let util_src = "package util\nfunc Helper() {}\n";
+        let files = vec![
+            pr_file("a/foo.go", None, Some(foo_after)),
+            pr_file("util/util.go", Some(util_src), Some(util_src)),
+            pr_file("internal/util/util.go", Some(util_src), Some(util_src)),
+        ];
+        let nodes = build_architecture_nodes(&files);
+        let resolved = nodes
+            .iter()
+            .find(|n| n.kind == ArchitectureNodeKind::Downstream
+                && n.label == "github.com/x/internal/util")
+            .expect("internal util downstream node");
+        assert_eq!(resolved.file_index, Some(2));
+    }
+
+    #[test]
+    fn focus_file_does_not_appear_as_its_own_upstream() {
+        // 同じファイル内で自分自身に相当する import path があってもセルフループは
+        // 出さない。collect_go_files で focus.file_index と一致する candidate を弾く。
+        let after =
+            "package util\nimport \"x/util\"\nfunc Hello() {}\n";
+        let files = vec![pr_file("util/util.go", None, Some(after))];
+        let nodes = build_architecture_nodes(&files);
+        let upstream: Vec<&ArchitectureNode> = nodes
+            .iter()
+            .filter(|n| n.kind == ArchitectureNodeKind::Upstream)
+            .collect();
+        assert!(upstream.is_empty(), "nodes: {nodes:?}");
+    }
+
+    #[test]
+    fn neighbor_cap_emits_overflow_summary() {
+        // 6 件 import すると PER_FILE_NEIGHBOR_CAP=5 を超えるので
+        // "+N more" ノードが 1 つ末尾に出る。
+        let after = "package main\n\
+             import (\n\
+                 \"a/a\"\n\
+                 \"a/b\"\n\
+                 \"a/c\"\n\
+                 \"a/d\"\n\
+                 \"a/e\"\n\
+                 \"a/f\"\n\
+             )\n\
+             func F() {}\n";
+        let files = vec![pr_file("hello.go", None, Some(after))];
+        let nodes = build_architecture_nodes(&files);
+        let downstream: Vec<&ArchitectureNode> = nodes
+            .iter()
+            .filter(|n| n.kind == ArchitectureNodeKind::Downstream)
+            .collect();
+        assert_eq!(downstream.len(), PER_FILE_NEIGHBOR_CAP + 1);
+        assert!(
+            downstream
+                .last()
+                .unwrap()
+                .label
+                .starts_with("+"),
+            "nodes: {downstream:?}"
+        );
+    }
+}

--- a/src/semantic/fallback.rs
+++ b/src/semantic/fallback.rs
@@ -85,6 +85,8 @@ impl ParserAdapter for FallbackLineParserAdapter {
             change_type,
             signature_summary: None,
             body_summary: None,
+            start_line: None,
+            end_line: None,
         };
         ParserDiffResult {
             adapter_name: Self::NAME.into(),

--- a/src/semantic/go.rs
+++ b/src/semantic/go.rs
@@ -40,11 +40,21 @@ pub struct GoSymbol {
     pub container: Option<String>,
     pub signature: String,
     pub body_normalized: String,
+    /// 1-indexed 開始行。tree-sitter の `start_position().row` を +1 したもの。
+    pub start_line: u32,
+    /// 1-indexed 終了行。
+    pub end_line: u32,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct GoParseTree {
     pub symbols: Vec<GoSymbol>,
+    /// `package` 宣言。architecture mini-map で「自パッケージを import している
+    /// 他 PR ファイル」を解決するのに使う。`package main` のような単一識別子。
+    pub package_name: Option<String>,
+    /// import declarations の path (引用符を除去したもの)。
+    /// `_` blank import や `.` dot import の場合も path はそのまま入れる。
+    pub imports: Vec<String>,
 }
 
 fn go_language() -> Language {
@@ -62,9 +72,19 @@ fn extract_symbols(source: &str) -> GoParseTree {
     let root = tree.root_node();
     let bytes = source.as_bytes();
     let mut symbols = Vec::new();
+    let mut package_name: Option<String> = None;
+    let mut imports: Vec<String> = Vec::new();
     for i in 0..(root.child_count() as u32) {
         let Some(child) = root.child(i) else { continue };
         match child.kind() {
+            "package_clause" => {
+                if let Some(name) = extract_package_name(child, bytes) {
+                    package_name = Some(name);
+                }
+            }
+            "import_declaration" => {
+                collect_import_paths(child, bytes, &mut imports);
+            }
             "function_declaration" => {
                 if let Some(sym) = build_function_symbol(child, bytes) {
                     symbols.push(sym);
@@ -78,7 +98,69 @@ fn extract_symbols(source: &str) -> GoParseTree {
             _ => {}
         }
     }
-    GoParseTree { symbols }
+    GoParseTree {
+        symbols,
+        package_name,
+        imports,
+    }
+}
+
+fn extract_package_name(node: Node, src: &[u8]) -> Option<String> {
+    let count = node.child_count() as u32;
+    for i in 0..count {
+        let Some(child) = node.child(i) else { continue };
+        if child.kind() == "package_identifier" {
+            return child.utf8_text(src).ok().map(str::to_string);
+        }
+    }
+    None
+}
+
+fn collect_import_paths(node: Node, src: &[u8], out: &mut Vec<String>) {
+    let count = node.child_count() as u32;
+    for i in 0..count {
+        let Some(child) = node.child(i) else { continue };
+        match child.kind() {
+            "import_spec" => {
+                if let Some(p) = import_path_from_spec(child, src) {
+                    out.push(p);
+                }
+            }
+            "import_spec_list" => {
+                let inner_count = child.child_count() as u32;
+                for j in 0..inner_count {
+                    let Some(grand) = child.child(j) else {
+                        continue;
+                    };
+                    if grand.kind() == "import_spec"
+                        && let Some(p) = import_path_from_spec(grand, src)
+                    {
+                        out.push(p);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn import_path_from_spec(node: Node, src: &[u8]) -> Option<String> {
+    // `import_spec` は「(name)? interpreted_string_literal」。path は
+    // field name "path" で取れる。
+    let path_node = node.child_by_field_name("path")?;
+    let raw = path_node.utf8_text(src).ok()?;
+    Some(strip_string_quotes(raw))
+}
+
+fn strip_string_quotes(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if (trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2)
+        || (trimmed.starts_with('`') && trimmed.ends_with('`') && trimmed.len() >= 2)
+    {
+        trimmed[1..trimmed.len() - 1].to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 fn build_function_symbol(node: Node, src: &[u8]) -> Option<GoSymbol> {
@@ -86,6 +168,7 @@ fn build_function_symbol(node: Node, src: &[u8]) -> Option<GoSymbol> {
     let name = name_node.utf8_text(src).ok()?.to_string();
     let signature = signature_text(node, src);
     let body_normalized = body_normalized(node, src);
+    let (start_line, end_line) = node_line_range(node);
     Some(GoSymbol {
         stable_key: format!("function::{name}"),
         display_name: name,
@@ -93,6 +176,8 @@ fn build_function_symbol(node: Node, src: &[u8]) -> Option<GoSymbol> {
         container: None,
         signature,
         body_normalized,
+        start_line,
+        end_line,
     })
 }
 
@@ -125,6 +210,7 @@ fn build_method_symbol(node: Node, src: &[u8]) -> Option<GoSymbol> {
         container.clone().unwrap_or_else(|| "_".into()),
         name
     );
+    let (start_line, end_line) = node_line_range(node);
     Some(GoSymbol {
         stable_key,
         display_name,
@@ -132,7 +218,15 @@ fn build_method_symbol(node: Node, src: &[u8]) -> Option<GoSymbol> {
         container,
         signature,
         body_normalized,
+        start_line,
+        end_line,
     })
+}
+
+fn node_line_range(node: Node) -> (u32, u32) {
+    let start = (node.start_position().row as u32).saturating_add(1);
+    let end = (node.end_position().row as u32).saturating_add(1);
+    (start, end)
 }
 
 fn extract_receiver_summary(node: Node, src: &[u8]) -> (String, Option<String>) {
@@ -257,6 +351,8 @@ fn symbol_to_item(sym: &GoSymbol, change_type: ChangeType) -> ParserDiffItem {
         change_type,
         signature_summary: Some(sym.signature.clone()),
         body_summary: None,
+        start_line: Some(sym.start_line),
+        end_line: Some(sym.end_line),
     }
 }
 
@@ -505,6 +601,72 @@ mod tests {
         let r = adapter.diff(None, None);
         assert!(r.items.is_empty());
         assert!(r.adapter_name.is_empty());
+    }
+
+    #[test]
+    fn extracts_package_name() {
+        let p = parse("package fooutil\nfunc A() {}\n");
+        let tree = p.raw.as_ref().unwrap().downcast_ref::<GoParseTree>().unwrap();
+        assert_eq!(tree.package_name.as_deref(), Some("fooutil"));
+    }
+
+    #[test]
+    fn extracts_single_import() {
+        let p = parse(
+            "package main\n\
+             import \"fmt\"\n\
+             func F() {}\n",
+        );
+        let tree = p.raw.as_ref().unwrap().downcast_ref::<GoParseTree>().unwrap();
+        assert_eq!(tree.imports, vec!["fmt".to_string()]);
+    }
+
+    #[test]
+    fn extracts_grouped_imports_with_aliases_and_blank() {
+        let src = "package main\n\
+             import (\n\
+                 \"fmt\"\n\
+                 alias \"github.com/foo/bar\"\n\
+                 _ \"github.com/baz/qux\"\n\
+             )\n";
+        let p = parse(src);
+        let tree = p.raw.as_ref().unwrap().downcast_ref::<GoParseTree>().unwrap();
+        assert_eq!(
+            tree.imports,
+            vec![
+                "fmt".to_string(),
+                "github.com/foo/bar".to_string(),
+                "github.com/baz/qux".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn function_symbol_has_one_indexed_line_range() {
+        let src = "package main\n\
+             \n\
+             func Hello() {\n\
+                 // body\n\
+             }\n";
+        let p = parse(src);
+        let tree = p.raw.as_ref().unwrap().downcast_ref::<GoParseTree>().unwrap();
+        let sym = tree.symbols.first().expect("function symbol");
+        // `func Hello()` は 3 行目から始まる (1-indexed)。
+        assert_eq!(sym.start_line, 3);
+        assert!(sym.end_line >= sym.start_line);
+    }
+
+    #[test]
+    fn diff_item_carries_line_info() {
+        let adapter = GoParserAdapter::new();
+        let after = adapter.parse(&make_snapshot(
+            "a.go",
+            "package main\n\nfunc New() {}\n",
+        ));
+        let r = adapter.diff(None, Some(&after));
+        let item = r.items.first().expect("added item");
+        assert!(item.start_line.is_some());
+        assert!(item.end_line.is_some());
     }
 
     #[test]

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -6,12 +6,14 @@
 
 pub mod adapter;
 pub mod analyze;
+pub mod architecture;
 pub mod fallback;
 pub mod go;
 pub mod ir;
 
 pub use adapter::{ParsedSnapshot, ParserAdapter, ParserDiffItem, ParserDiffResult};
 pub use analyze::analyze_pull_request_file;
+pub use architecture::{ArchitectureNode, ArchitectureNodeKind, build_architecture_nodes};
 pub use fallback::FallbackLineParserAdapter;
 pub use go::GoParserAdapter;
 pub use ir::{ChangeType, SemanticChange, SemanticChangeGroup, SymbolKind, UnsupportedFileAnalysis};

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -226,6 +226,23 @@ export struct SemanticItemView {
     change-kind: string, // "added" / "removed" / "modified" / "renamed"
 }
 
+// architecture mini-map (#208) の 1 ノード。Go の import グラフ 1 hop 上下流を
+// 縦並びに表示する小さな panel 用。
+//   kind-label: "Center" / "Upstream" / "Downstream" の i18n 済みラベル
+//   kind-key:   classification 用の安定キー ("center" / "upstream" / "downstream")
+//   label:      symbol 名 / 他ファイル path / import path
+//   detail:     focus ファイル path（補助情報）
+//   file-index: クリック時にジャンプする PR ファイル index。-1 で no-op。
+//   line-no:    symbol 開始行 (1-indexed)。0 で行ジャンプしない。
+export struct ArchitectureNodeView {
+    kind-label: string,
+    kind-key: string,
+    label: string,
+    detail: string,
+    file-index: int,
+    line-no: int,
+}
+
 export component DiffViewerWindow inherits Window {
     in property <string> pr-title;
     in property <string> head-sha;
@@ -243,6 +260,7 @@ export component DiffViewerWindow inherits Window {
     }
 
     in property <[SemanticItemView]> semantic-items;
+    in property <[ArchitectureNodeView]> architecture-nodes;
 
     in property <string> current-anchor-label: @tr("(no selection)");
     in property <bool> has-selection: false;
@@ -323,6 +341,12 @@ export component DiffViewerWindow inherits Window {
 
     callback pr-clicked(int);
     callback pr-filter-changed(int);
+
+    // architecture mini-map (#208) のノードクリック。Rust 側で
+    //   file-index < 0 → no-op
+    //   line-no > 0   → 該当行までスクロール（symbol jump）
+    // と扱う。
+    callback architecture-node-clicked(int /* file-index */, int /* line-no */);
 
     // 隠し Text。Slint の text shaping で実 advance 幅 / 行高を測定する。
     // 単一 "M" だと丸め誤差が出やすいので 10 文字並べて 10 で割る。
@@ -1214,6 +1238,95 @@ export component DiffViewerWindow inherits Window {
                 VerticalBox {
                     spacing: 0px;
                     padding: 0px;
+
+                    // Architecture mini-map section (#208)
+                    Rectangle {
+                        height: 32px;
+                        background: #1a1a22;
+                        HorizontalBox {
+                            padding-left: 10px;
+                            padding-right: 10px;
+                            alignment: start;
+                            Text {
+                                text: @tr("Architecture") + " (" + root.architecture-nodes.length + ")";
+                                color: #ffffff;
+                                font-size: 12px;
+                                font-weight: 600;
+                                vertical-alignment: center;
+                            }
+                        }
+                    }
+
+                    Rectangle {
+                        height: 130px;
+                        background: #14141a;
+
+                        if root.architecture-nodes.length == 0: VerticalBox {
+                            alignment: center;
+                            Text {
+                                text: @tr("(no architecture data)");
+                                color: #5a5a6a;
+                                font-size: 11px;
+                                horizontal-alignment: center;
+                            }
+                        }
+
+                        if root.architecture-nodes.length > 0: ListView {
+                            for node in root.architecture-nodes: Rectangle {
+                                height: 30px;
+                                background: arch-touch.has-hover && node.file-index >= 0
+                                    ? #1e1e28
+                                    : #14141a;
+                                border-width: 1px;
+                                border-color: #1c1c24;
+
+                                arch-touch := TouchArea {
+                                    clicked => {
+                                        // file-index < 0 は外部 import / overflow
+                                        // ノードなので Rust 側で no-op として扱う。
+                                        root.architecture-node-clicked(node.file-index, node.line-no);
+                                    }
+                                    changed has-hover => {
+                                        if (self.has-hover && node.file-index >= 0) {
+                                            root.hovered-tooltip-text = node.label + "  ←  " + node.detail;
+                                        } else if (root.hovered-tooltip-text == node.label + "  ←  " + node.detail) {
+                                            root.hovered-tooltip-text = "";
+                                        }
+                                    }
+                                }
+
+                                HorizontalBox {
+                                    padding-left: 8px;
+                                    padding-right: 8px;
+                                    padding-top: 2px;
+                                    padding-bottom: 2px;
+                                    spacing: 6px;
+                                    alignment: start;
+                                    Text {
+                                        text: node.kind-label;
+                                        color: node.kind-key == "center"
+                                            ? #c0a07a
+                                            : (node.kind-key == "upstream"
+                                                ? #7a9ec0
+                                                : #7ac0a0);
+                                        font-size: 10px;
+                                        font-weight: 600;
+                                        vertical-alignment: center;
+                                        width: 60px;
+                                    }
+                                    Text {
+                                        text: node.label;
+                                        color: node.file-index >= 0 ? #d0d0d5 : #8a8a95;
+                                        font-size: 11px;
+                                        font-family: root.font-family;
+                                        overflow: elide;
+                                        horizontal-stretch: 1;
+                                        vertical-alignment: center;
+                                    }
+                                }
+                            }
+                        }
+                    }
 
                     // Semantic section (#207 spike)
                     Rectangle {


### PR DESCRIPTION
## Motivation

Closes #208.

#207 で Go の関数・メソッド単位 semantic diff が入ったため、その変更 symbol を起点に Go import graph の 1-hop 上流 / 下流を diff viewer 上で確認できる mini-map を追加します。caller/callee 解析や多言語対応は後続に残し、v0.2 spike として package-level import に限定します。

## Changes

- Go parser 出力に package 名 / import path / symbol start-end line を追加
- `ParserDiffItem` に `start_line` / `end_line` を追加し、symbol jump の最低限の位置情報を保持
- `src/semantic/architecture.rs` を追加し、PR 内 Go files から architecture mini-map nodes を生成
  - Center: 変更された Function / Method
  - Downstream: focus file の import path
  - Upstream: PR 内の他 Go file が focus package を import する 1-hop
  - non-Go / binary / unsupported は除外
  - neighbor / total node cap で表示過多を抑制
- Slint 右ペインに `Architecture` セクションを追加
- node click で該当 file へ切替、line 情報がある Center node は概算で symbol 行へ scroll
- i18n を追加

## Validation

- `rtk cargo build`
- `rtk cargo test`（207 passed）
- `rtk cargo clippy --all-targets -- -D warnings`
- `rtk git diff --check`
- 実機ログ: `rtk scripts/diagnose_ui.sh github duck8823/locus#324 --duration 8 --window-size 1280x720 --out-dir target/locus-diagnostics/issue208-architecture-ui-smoke --no-debug-grid`
  - `initial hydrate completed pr=324 file_count=12`
  - warn/error linesなし
  - screenshot は desktop fallback で黒画面のため目視証跡としては不十分（ログは取得済み）

## Notes

- 上流 / 下流の解決は Go module path を読まず、PR 内 file path の directory suffix / package name による heuristic です。
- line jump は diff row の固定高さから概算 scroll します。正確な hunk line mapping は後続で改善可能です。
