### PR TITLE
fix(ui): terminal CJK glyph に専用 font を適用

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -65,7 +65,8 @@ GitHub アクセス用 token は次の優先順位で解決されます:
 | `LOCUS_TERMINAL_FONT_FAMILY` | OS 別 (macOS: `SF Mono, Menlo, Monaco, Osaka-Mono, Hiragino Sans, Apple Symbols, Apple Color Emoji, monospace`) | terminal grid 専用のフォント fallback。等幅候補を優先し、terminal glyph や cell metrics が崩れる場合の切り分けに使う。 |
 | `LOCUS_TERMINAL_EMOJI_FONT_FAMILY` | OS 別 (macOS: `Apple Color Emoji`) | terminal 出力に emoji / ZWJ / VS16 glyph が含まれる cell だけに使う emoji 専用フォント。 |
 | `LOCUS_TERMINAL_SYMBOL_FONT_FAMILY` | OS 別 (macOS: `Apple Symbols`) | `↯` などの装飾 symbol / arrow を含む cell だけに使う symbol 専用フォント。通常の等幅 cell は変えない。 |
-| `LOCUS_TERMINAL_CJK_FONT_FAMILY` | OS 別 (macOS: `Hiragino Sans`) | 日本語・中国語・韓国語などの CJK / Kana / Hangul glyph を含む cell だけに使う CJK 専用フォント。 |
+| `LOCUS_TERMINAL_CJK_FONT_FAMILY` | OS 別 (macOS: `Hiragino Sans`) | 日本語・中国語などの CJK / Kana glyph を含む cell だけに使う CJK 専用フォント。 |
+| `LOCUS_TERMINAL_HANGUL_FONT_FAMILY` | OS 別 (macOS: `Apple SD Gothic Neo`, Windows: `Malgun Gothic`) | 韓国語 Hangul glyph を含む cell だけに使う Hangul 専用フォント。 |
 | `LOCUS_FONT_SIZE` | (未設定) | terminal/diff 両方のフォントサイズを一括指定。 |
 | `LOCUS_TERMINAL_FONT_SIZE` | `13.0` | terminal pane のフォントサイズ (logical px)。 |
 | `LOCUS_TERMINAL_CELL_W` / `LOCUS_TERMINAL_CELL_H` | 比率 fallback (`font_size * 0.6` / `font_size * 1.45`) | terminal cell の幅/高さを logical px で手動上書きする。probe / fallback のいずれよりも優先。glyph と cell metric のズレを診断・強制同期する場合に使う。 |

--- a/README.ja.md
+++ b/README.ja.md
@@ -64,7 +64,8 @@ GitHub アクセス用 token は次の優先順位で解決されます:
 | `LOCUS_FONT_FAMILY` | OS 別 (macOS: `Menlo, Hiragino Sans, Apple Symbols, Apple Color Emoji, Consolas, monospace`) | diff / chrome 側のフォントファミリ。`LOCUS_TERMINAL_FONT_FAMILY` が未設定の場合は terminal にも適用される。 |
 | `LOCUS_TERMINAL_FONT_FAMILY` | OS 別 (macOS: `SF Mono, Menlo, Monaco, Osaka-Mono, Hiragino Sans, Apple Symbols, Apple Color Emoji, monospace`) | terminal grid 専用のフォント fallback。等幅候補を優先し、terminal glyph や cell metrics が崩れる場合の切り分けに使う。 |
 | `LOCUS_TERMINAL_EMOJI_FONT_FAMILY` | OS 別 (macOS: `Apple Color Emoji`) | terminal 出力に emoji / ZWJ / VS16 glyph が含まれる cell だけに使う emoji 専用フォント。 |
-| `LOCUS_TERMINAL_SYMBOL_FONT_FAMILY` | OS 別 (macOS: `Apple Symbols`) | `↯` などの装飾 symbol / arrow を含む cell だけに使う symbol 専用フォント。通常の等幅 / CJK cell は変えない。 |
+| `LOCUS_TERMINAL_SYMBOL_FONT_FAMILY` | OS 別 (macOS: `Apple Symbols`) | `↯` などの装飾 symbol / arrow を含む cell だけに使う symbol 専用フォント。通常の等幅 cell は変えない。 |
+| `LOCUS_TERMINAL_CJK_FONT_FAMILY` | OS 別 (macOS: `Hiragino Sans`) | 日本語・中国語・韓国語などの CJK / Kana / Hangul glyph を含む cell だけに使う CJK 専用フォント。 |
 | `LOCUS_FONT_SIZE` | (未設定) | terminal/diff 両方のフォントサイズを一括指定。 |
 | `LOCUS_TERMINAL_FONT_SIZE` | `13.0` | terminal pane のフォントサイズ (logical px)。 |
 | `LOCUS_TERMINAL_CELL_W` / `LOCUS_TERMINAL_CELL_H` | 比率 fallback (`font_size * 0.6` / `font_size * 1.45`) | terminal cell の幅/高さを logical px で手動上書きする。probe / fallback のいずれよりも優先。glyph と cell metric のズレを診断・強制同期する場合に使う。 |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ For GitHub access, locus reads tokens in this order:
 | `LOCUS_FONT_FAMILY` | OS-specific (macOS: `Menlo, Hiragino Sans, Apple Symbols, Apple Color Emoji, Consolas, monospace`) | Font family for diff / chrome. If `LOCUS_TERMINAL_FONT_FAMILY` is unset, this also overrides terminal fonts. |
 | `LOCUS_TERMINAL_FONT_FAMILY` | OS-specific (macOS: `SF Mono, Menlo, Monaco, Osaka-Mono, Hiragino Sans, Apple Symbols, Apple Color Emoji, monospace`) | Terminal-grid-only font fallback chain. Prefer monospace candidates first; useful when terminal glyphs or cell metrics look broken. |
 | `LOCUS_TERMINAL_EMOJI_FONT_FAMILY` | OS-specific (macOS: `Apple Color Emoji`) | Per-cell emoji font used when terminal output contains emoji / ZWJ / VS16 glyphs. |
-| `LOCUS_TERMINAL_SYMBOL_FONT_FAMILY` | OS-specific (macOS: `Apple Symbols`) | Per-cell decorative symbol font used for arrows such as `↯` without changing normal monospace / CJK cells. |
+| `LOCUS_TERMINAL_SYMBOL_FONT_FAMILY` | OS-specific (macOS: `Apple Symbols`) | Per-cell decorative symbol font used for arrows such as `↯` without changing normal monospace cells. |
+| `LOCUS_TERMINAL_CJK_FONT_FAMILY` | OS-specific (macOS: `Hiragino Sans`) | Per-cell CJK / Kana / Hangul font used when terminal output contains Japanese, Chinese, or Korean glyphs. |
 | `LOCUS_FONT_SIZE` | (unset) | Single override for both terminal and diff font sizes. |
 | `LOCUS_TERMINAL_FONT_SIZE` | `13.0` | Terminal pane font size in logical pixels. |
 | `LOCUS_TERMINAL_CELL_W` / `LOCUS_TERMINAL_CELL_H` | fallback ratio (`font_size * 0.6` / `font_size * 1.45`) | Manual terminal cell width/height override in logical pixels. Always wins over both probe and fallback. Use for diagnosing glyph/cell metric mismatch. |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ For GitHub access, locus reads tokens in this order:
 | `LOCUS_TERMINAL_FONT_FAMILY` | OS-specific (macOS: `SF Mono, Menlo, Monaco, Osaka-Mono, Hiragino Sans, Apple Symbols, Apple Color Emoji, monospace`) | Terminal-grid-only font fallback chain. Prefer monospace candidates first; useful when terminal glyphs or cell metrics look broken. |
 | `LOCUS_TERMINAL_EMOJI_FONT_FAMILY` | OS-specific (macOS: `Apple Color Emoji`) | Per-cell emoji font used when terminal output contains emoji / ZWJ / VS16 glyphs. |
 | `LOCUS_TERMINAL_SYMBOL_FONT_FAMILY` | OS-specific (macOS: `Apple Symbols`) | Per-cell decorative symbol font used for arrows such as `↯` without changing normal monospace cells. |
-| `LOCUS_TERMINAL_CJK_FONT_FAMILY` | OS-specific (macOS: `Hiragino Sans`) | Per-cell CJK / Kana / Hangul font used when terminal output contains Japanese, Chinese, or Korean glyphs. |
+| `LOCUS_TERMINAL_CJK_FONT_FAMILY` | OS-specific (macOS: `Hiragino Sans`) | Per-cell CJK / Kana font used when terminal output contains Japanese or Chinese glyphs. |
+| `LOCUS_TERMINAL_HANGUL_FONT_FAMILY` | OS-specific (macOS: `Apple SD Gothic Neo`, Windows: `Malgun Gothic`) | Per-cell Hangul font used when terminal output contains Korean glyphs. |
 | `LOCUS_FONT_SIZE` | (unset) | Single override for both terminal and diff font sizes. |
 | `LOCUS_TERMINAL_FONT_SIZE` | `13.0` | Terminal pane font size in logical pixels. |
 | `LOCUS_TERMINAL_CELL_W` / `LOCUS_TERMINAL_CELL_H` | fallback ratio (`font_size * 0.6` / `font_size * 1.45`) | Manual terminal cell width/height override in logical pixels. Always wins over both probe and fallback. Use for diagnosing glyph/cell metric mismatch. |

--- a/src/ui_state/mod.rs
+++ b/src/ui_state/mod.rs
@@ -130,7 +130,8 @@ fn cell_to_terminal_cell(cell: &Cell, span: i32, ch: &str) -> TerminalCell {
     }
 }
 
-/// Glyph 文字列の分類結果。emoji / 装飾 symbol / CJK / その他 (ASCII 等) に分け、
+/// Glyph 文字列の分類結果。emoji / 装飾 symbol / CJK / Hangul / その他
+/// (ASCII 等) に分け、
 /// per-cell font-family を選ぶ。Slint Text の font-family は実質単一 family と
 /// して扱われがちで、カンマ区切り fallback の per-glyph 解決が崩れる事象 (#277)
 /// があるため、必要な cell だけ専用 family を渡す。
@@ -138,8 +139,10 @@ fn cell_to_terminal_cell(cell: &Cell, span: i32, ch: &str) -> TerminalCell {
 enum GlyphCategory {
     /// 既定 font-family にフォールバックする (ASCII / spacer)。
     Default,
-    /// CJK / Kana / Hangul などの East Asian glyph。
+    /// CJK / Kana などの East Asian glyph。
     Cjk,
+    /// Hangul。Windows/macOS では日本語向け CJK font と別 family が必要。
+    Hangul,
     /// emoji (絵文字 / ZWJ chain / Variation Selector-16 / Regional Indicator)。
     Emoji,
     /// 装飾的な記号・矢印 (例: ↯ U+21AF)。
@@ -152,6 +155,7 @@ fn classify_glyph(s: &str) -> GlyphCategory {
     }
     let mut emoji = false;
     let mut symbol = false;
+    let mut hangul = false;
     let mut cjk = false;
     for ch in s.chars() {
         let c = ch as u32;
@@ -163,6 +167,8 @@ fn classify_glyph(s: &str) -> GlyphCategory {
             emoji = true;
         } else if is_decorative_symbol_codepoint(c) {
             symbol = true;
+        } else if is_hangul_codepoint(c) {
+            hangul = true;
         } else if is_cjk_codepoint(c) {
             cjk = true;
         }
@@ -171,6 +177,8 @@ fn classify_glyph(s: &str) -> GlyphCategory {
         GlyphCategory::Emoji
     } else if symbol {
         GlyphCategory::Symbol
+    } else if hangul {
+        GlyphCategory::Hangul
     } else if cjk {
         GlyphCategory::Cjk
     } else {
@@ -256,7 +264,7 @@ fn is_decorative_symbol_codepoint(c: u32) -> bool {
     )
 }
 
-/// CJK / Kana / Hangul など East Asian glyph の近似判定。
+/// CJK / Kana など East Asian glyph の近似判定。
 ///
 /// alacritty 側の wide-cell 判定により多くの CJK glyph は span=2 になるため、
 /// Slint 側では cell ごとに CJK font を明示し、font-family fallback が効かず
@@ -265,28 +273,36 @@ fn is_decorative_symbol_codepoint(c: u32) -> bool {
 fn is_cjk_codepoint(c: u32) -> bool {
     matches!(
         c,
-        0x1100..=0x11FF // Hangul Jamo
-            | 0x2E80..=0x2EFF // CJK Radicals Supplement
+        0x2E80..=0x2EFF // CJK Radicals Supplement
             | 0x2F00..=0x2FDF // Kangxi Radicals
             | 0x3000..=0x303F // CJK Symbols and Punctuation
             | 0x3040..=0x309F // Hiragana
             | 0x30A0..=0x30FF // Katakana
             | 0x3100..=0x312F // Bopomofo
-            | 0x3130..=0x318F // Hangul Compatibility Jamo
             | 0x3190..=0x319F // Kanbun
             | 0x31A0..=0x31BF // Bopomofo Extended
             | 0x31C0..=0x31EF // CJK Strokes
             | 0x31F0..=0x31FF // Katakana Phonetic Extensions
             | 0x3400..=0x4DBF // CJK Unified Ideographs Extension A
             | 0x4E00..=0x9FFF // CJK Unified Ideographs
-            | 0xA960..=0xA97F // Hangul Jamo Extended-A
-            | 0xAC00..=0xD7AF // Hangul Syllables
-            | 0xD7B0..=0xD7FF // Hangul Jamo Extended-B
             | 0xF900..=0xFAFF // CJK Compatibility Ideographs
             | 0xFE10..=0xFE1F // Vertical Forms
             | 0xFE30..=0xFE4F // CJK Compatibility Forms
             | 0xFF00..=0xFFEF // Halfwidth and Fullwidth Forms
             | 0x20000..=0x2FA1F // CJK Unified Ideographs Extensions B..compat
+    )
+}
+
+/// Hangul glyph の近似判定。日本語向け CJK font は Hangul を含まないことがある
+/// ため、CJK と別カテゴリにして per-cell family を分ける。
+fn is_hangul_codepoint(c: u32) -> bool {
+    matches!(
+        c,
+        0x1100..=0x11FF // Hangul Jamo
+            | 0x3130..=0x318F // Hangul Compatibility Jamo
+            | 0xA960..=0xA97F // Hangul Jamo Extended-A
+            | 0xAC00..=0xD7AF // Hangul Syllables
+            | 0xD7B0..=0xD7FF // Hangul Jamo Extended-B
     )
 }
 
@@ -320,7 +336,22 @@ fn symbol_font_family() -> &'static str {
         .as_str()
 }
 
-/// CJK / Kana / Hangul 用 font family。`LOCUS_TERMINAL_CJK_FONT_FAMILY` で
+/// Hangul 用 font family。`LOCUS_TERMINAL_HANGUL_FONT_FAMILY` で OS 既定を
+/// 上書き可能。
+fn hangul_font_family() -> &'static str {
+    static CACHE: OnceLock<String> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            std::env::var("LOCUS_TERMINAL_HANGUL_FONT_FAMILY")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| default_hangul_font_family().to_string())
+        })
+        .as_str()
+}
+
+/// CJK / Kana 用 font family。`LOCUS_TERMINAL_CJK_FONT_FAMILY` で
 /// OS 既定を上書き可能。
 fn cjk_font_family() -> &'static str {
     static CACHE: OnceLock<String> = OnceLock::new();
@@ -365,6 +396,21 @@ const fn default_symbol_font_family() -> &'static str {
     }
 }
 
+const fn default_hangul_font_family() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "Apple SD Gothic Neo"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Malgun Gothic"
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        "Noto Sans CJK KR"
+    }
+}
+
 const fn default_cjk_font_family() -> &'static str {
     #[cfg(target_os = "macos")]
     {
@@ -384,6 +430,7 @@ fn font_family_for_glyph(s: &str) -> &'static str {
     match classify_glyph(s) {
         GlyphCategory::Emoji => emoji_font_family(),
         GlyphCategory::Symbol => symbol_font_family(),
+        GlyphCategory::Hangul => hangul_font_family(),
         GlyphCategory::Cjk => cjk_font_family(),
         GlyphCategory::Default => "",
     }
@@ -465,8 +512,16 @@ mod tests {
         // CJK cell ごとに専用 family を渡す。
         assert_eq!(classify_glyph("あ"), GlyphCategory::Cjk);
         assert_eq!(classify_glyph("漢"), GlyphCategory::Cjk);
-        assert_eq!(classify_glyph("한"), GlyphCategory::Cjk);
         assert_eq!(font_family_for_glyph("あ"), default_cjk_font_family());
+    }
+
+    #[test]
+    fn hangul_classified_as_hangul() {
+        assert_eq!(classify_glyph("한"), GlyphCategory::Hangul);
+        assert_eq!(
+            font_family_for_glyph("한"),
+            default_hangul_font_family()
+        );
     }
 
     #[test]

--- a/src/ui_state/mod.rs
+++ b/src/ui_state/mod.rs
@@ -130,14 +130,16 @@ fn cell_to_terminal_cell(cell: &Cell, span: i32, ch: &str) -> TerminalCell {
     }
 }
 
-/// Glyph 文字列の分類結果。emoji / 装飾 symbol / その他 (CJK・ASCII 等) に分け、
+/// Glyph 文字列の分類結果。emoji / 装飾 symbol / CJK / その他 (ASCII 等) に分け、
 /// per-cell font-family を選ぶ。Slint Text の font-family は実質単一 family と
 /// して扱われがちで、カンマ区切り fallback の per-glyph 解決が崩れる事象 (#277)
 /// があるため、必要な cell だけ専用 family を渡す。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GlyphCategory {
-    /// 既定 font-family にフォールバックする (CJK / ASCII / spacer)。
+    /// 既定 font-family にフォールバックする (ASCII / spacer)。
     Default,
+    /// CJK / Kana / Hangul などの East Asian glyph。
+    Cjk,
     /// emoji (絵文字 / ZWJ chain / Variation Selector-16 / Regional Indicator)。
     Emoji,
     /// 装飾的な記号・矢印 (例: ↯ U+21AF)。
@@ -150,6 +152,7 @@ fn classify_glyph(s: &str) -> GlyphCategory {
     }
     let mut emoji = false;
     let mut symbol = false;
+    let mut cjk = false;
     for ch in s.chars() {
         let c = ch as u32;
         // ZWJ / VS16 / Regional Indicator が含まれていれば確定で emoji。
@@ -160,12 +163,16 @@ fn classify_glyph(s: &str) -> GlyphCategory {
             emoji = true;
         } else if is_decorative_symbol_codepoint(c) {
             symbol = true;
+        } else if is_cjk_codepoint(c) {
+            cjk = true;
         }
     }
     if emoji {
         GlyphCategory::Emoji
     } else if symbol {
         GlyphCategory::Symbol
+    } else if cjk {
+        GlyphCategory::Cjk
     } else {
         GlyphCategory::Default
     }
@@ -249,6 +256,40 @@ fn is_decorative_symbol_codepoint(c: u32) -> bool {
     )
 }
 
+/// CJK / Kana / Hangul など East Asian glyph の近似判定。
+///
+/// alacritty 側の wide-cell 判定により多くの CJK glyph は span=2 になるため、
+/// Slint 側では cell ごとに CJK font を明示し、font-family fallback が効かず
+/// □ になるケース (#327) を避ける。Box Drawing (U+2500..=U+257F) は terminal
+/// grid を保つため含めない。
+fn is_cjk_codepoint(c: u32) -> bool {
+    matches!(
+        c,
+        0x1100..=0x11FF // Hangul Jamo
+            | 0x2E80..=0x2EFF // CJK Radicals Supplement
+            | 0x2F00..=0x2FDF // Kangxi Radicals
+            | 0x3000..=0x303F // CJK Symbols and Punctuation
+            | 0x3040..=0x309F // Hiragana
+            | 0x30A0..=0x30FF // Katakana
+            | 0x3100..=0x312F // Bopomofo
+            | 0x3130..=0x318F // Hangul Compatibility Jamo
+            | 0x3190..=0x319F // Kanbun
+            | 0x31A0..=0x31BF // Bopomofo Extended
+            | 0x31C0..=0x31EF // CJK Strokes
+            | 0x31F0..=0x31FF // Katakana Phonetic Extensions
+            | 0x3400..=0x4DBF // CJK Unified Ideographs Extension A
+            | 0x4E00..=0x9FFF // CJK Unified Ideographs
+            | 0xA960..=0xA97F // Hangul Jamo Extended-A
+            | 0xAC00..=0xD7AF // Hangul Syllables
+            | 0xD7B0..=0xD7FF // Hangul Jamo Extended-B
+            | 0xF900..=0xFAFF // CJK Compatibility Ideographs
+            | 0xFE10..=0xFE1F // Vertical Forms
+            | 0xFE30..=0xFE4F // CJK Compatibility Forms
+            | 0xFF00..=0xFFEF // Halfwidth and Fullwidth Forms
+            | 0x20000..=0x2FA1F // CJK Unified Ideographs Extensions B..compat
+    )
+}
+
 /// emoji 用 font family。`LOCUS_TERMINAL_EMOJI_FONT_FAMILY` で OS 既定を上書き
 /// できる (例: Linux で `Twemoji Mozilla` を強制したい場合など)。
 fn emoji_font_family() -> &'static str {
@@ -275,6 +316,21 @@ fn symbol_font_family() -> &'static str {
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| default_symbol_font_family().to_string())
+        })
+        .as_str()
+}
+
+/// CJK / Kana / Hangul 用 font family。`LOCUS_TERMINAL_CJK_FONT_FAMILY` で
+/// OS 既定を上書き可能。
+fn cjk_font_family() -> &'static str {
+    static CACHE: OnceLock<String> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            std::env::var("LOCUS_TERMINAL_CJK_FONT_FAMILY")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| default_cjk_font_family().to_string())
         })
         .as_str()
 }
@@ -309,10 +365,26 @@ const fn default_symbol_font_family() -> &'static str {
     }
 }
 
+const fn default_cjk_font_family() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "Hiragino Sans"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Yu Gothic UI"
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        "Noto Sans CJK JP"
+    }
+}
+
 fn font_family_for_glyph(s: &str) -> &'static str {
     match classify_glyph(s) {
         GlyphCategory::Emoji => emoji_font_family(),
         GlyphCategory::Symbol => symbol_font_family(),
+        GlyphCategory::Cjk => cjk_font_family(),
         GlyphCategory::Default => "",
     }
 }
@@ -388,12 +460,20 @@ mod tests {
     }
 
     #[test]
-    fn cjk_classified_as_default() {
-        // CJK は既存 monospace + CJK fallback chain (例: Hiragino Sans) で
-        // そのまま描けるので Default に倒し、専用 family を渡さない。
-        assert_eq!(classify_glyph("あ"), GlyphCategory::Default);
-        assert_eq!(classify_glyph("漢"), GlyphCategory::Default);
-        assert_eq!(font_family_for_glyph("あ"), "");
+    fn cjk_classified_as_cjk() {
+        // CJK は既存 fallback chain 任せだと Slint 側で □ になる環境があるため、
+        // CJK cell ごとに専用 family を渡す。
+        assert_eq!(classify_glyph("あ"), GlyphCategory::Cjk);
+        assert_eq!(classify_glyph("漢"), GlyphCategory::Cjk);
+        assert_eq!(classify_glyph("한"), GlyphCategory::Cjk);
+        assert_eq!(font_family_for_glyph("あ"), default_cjk_font_family());
+    }
+
+    #[test]
+    fn cjk_punctuation_uses_cjk_font() {
+        assert_eq!(classify_glyph("。"), GlyphCategory::Cjk);
+        assert_eq!(classify_glyph("："), GlyphCategory::Cjk);
+        assert_eq!(font_family_for_glyph("。"), default_cjk_font_family());
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概要

- terminal cell の glyph 分類に CJK / Hangul カテゴリを追加
- CJK cell に `LOCUS_TERMINAL_CJK_FONT_FAMILY`（macOS 既定: `Hiragino Sans`）を per-cell 指定
- Hangul cell に `LOCUS_TERMINAL_HANGUL_FONT_FAMILY`（macOS 既定: `Apple SD Gothic Neo`, Windows 既定: `Malgun Gothic`）を per-cell 指定
- emoji / `↯` symbol / box drawing の既存分類は維持
- README / README.ja.md に CJK / Hangul font override を追記

Closes #327

## Motivation / モチベーション

#277 で emoji / decorative symbol の tofu は解消したが、確認用メッセージ `確認用に起動中です。閉じるまでこの表示を保持します。` の日本語部分は既存 terminal fallback chain 任せのままで、Slint Text の font-family fallback が効かず tofu になるケースが残っていた。

CJK も emoji / symbol と同じく terminal cell ごとに明示 font を渡すことで、fallback 解決に依存せず日本語・中国語 glyph を描画できるようにする。Hangul は日本語向け CJK font ではカバーされない OS があるため、独立した Hangul family に分ける。

## Scope / スコープ

- In scope / 対象:
  - CJK / Kana / Hangul glyph の per-cell font-family 指定
  - OS 別既定 CJK / Hangul font と env override
  - glyph 分類 unit test と README 記載
  - 実機 screenshot による terminal glyph 確認
- Out of scope / 非対象:
  - terminal cell metrics / 操作遅延の追加調整
  - box drawing / ASCII の font 変更

## Validation / 検証

- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (221 passed)
- [x] `git diff --check`
- [x] UI 起動確認: `scripts/diagnose_ui.sh terminal --agent-cmd /tmp/locus-cjk-glyph-check.sh --duration 8 --window-size 900x540 --out-dir target/locus-diagnostics/issue327-terminal-cjk-hangul-glyph-smoke --no-debug-grid`
  - screenshot: `target/locus-diagnostics/issue327-terminal-cjk-hangul-glyph-smoke/screenshot.png`
  - 目視結果: `確認用に起動中です。閉じるまでこの表示を保持します。` は tofu なし。Hangul / emoji / `↯` も tofu なし。

## AI Review Loop / AI レビューループ

- [x] Gemini scout done
- [x] Codex verifier done
- [x] Codex GitHub review pass 1: P2 Hangul default font 指摘 → `Hangul` category と OS 別 Hangul font を追加
- [x] Codex GitHub review pass 2: no major issues
